### PR TITLE
TUI footer + agent-down hook warning + login-shell hook install

### DIFF
--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -29,5 +29,74 @@ func newHookCmd() *cobra.Command {
 			fmt.Fprint(cmd.OutOrStdout(), shell.Zsh)
 		},
 	})
+	c.AddCommand(newHookInstallCmd())
+	c.AddCommand(newHookStatusCmd())
 	return c
+}
+
+func newHookInstallCmd() *cobra.Command {
+	var shellFlag string
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Append the activation line to ~/.bashrc / ~/.zshrc (idempotent)",
+		Long: `Adds an "eval \"$(jitenv hook <shell>)\"" line to the user's shell rc
+file so the hook is loaded on every new shell. Already installed: no-op.
+Reinstall by removing the line manually and running again.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			sh := shellFlag
+			if sh == "" {
+				sh = shell.DetectShell()
+			}
+			if sh == "" {
+				return fmt.Errorf("could not detect shell from $SHELL; pass --shell bash|zsh")
+			}
+			rc := shell.RcPath(sh)
+			if rc == "" {
+				return fmt.Errorf("unsupported shell %q (only bash and zsh)", sh)
+			}
+			line := shell.HookLine(sh)
+			added, err := shell.Install(rc, line)
+			if err != nil {
+				return fmt.Errorf("install hook in %s: %w", rc, err)
+			}
+			out := cmd.OutOrStdout()
+			if added {
+				fmt.Fprintf(out, "added hook line to %s — open a new shell to activate\n", rc)
+			} else {
+				fmt.Fprintf(out, "hook already installed in %s\n", rc)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&shellFlag, "shell", "", "shell to install for (bash|zsh); auto-detect by default")
+	return cmd
+}
+
+func newHookStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Print whether the shell hook is installed in the current shell's rc file",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			st, err := shell.CurrentStatus()
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if st.Shell == "" {
+				fmt.Fprintln(out, "shell: unsupported (only bash and zsh)")
+				return nil
+			}
+			fmt.Fprintf(out, "shell:     %s\n", st.Shell)
+			fmt.Fprintf(out, "rc file:   %s\n", st.RcPath)
+			if st.Installed {
+				fmt.Fprintln(out, "installed: yes")
+			} else {
+				fmt.Fprintln(out, "installed: no")
+				fmt.Fprintf(out, "to install: jitenv hook install\n")
+			}
+			return nil
+		},
+	}
 }

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -38,10 +38,13 @@ func newHookInstallCmd() *cobra.Command {
 	var shellFlag string
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Append the activation line to ~/.bashrc / ~/.zshrc (idempotent)",
-		Long: `Adds an "eval \"$(jitenv hook <shell>)\"" line to the user's shell rc
-file so the hook is loaded on every new shell. Already installed: no-op.
-Reinstall by removing the line manually and running again.`,
+		Short: "Append the activation line to the user's shell startup files (idempotent)",
+		Long: `For bash, the eval line is appended to ~/.bashrc; if the user's bash
+login chain (.bash_profile / .bash_login / .profile) doesn't already
+end up sourcing ~/.bashrc, a guarded source line is added so that
+login shells pick up the hook too. For zsh, the eval line is
+appended to ~/.zshrc (sourced for both interactive and login).
+Re-running this command is a safe no-op when nothing needs to change.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			sh := shellFlag
@@ -51,21 +54,25 @@ Reinstall by removing the line manually and running again.`,
 			if sh == "" {
 				return fmt.Errorf("could not detect shell from $SHELL; pass --shell bash|zsh")
 			}
-			rc := shell.RcPath(sh)
-			if rc == "" {
-				return fmt.Errorf("unsupported shell %q (only bash and zsh)", sh)
-			}
-			line := shell.HookLine(sh)
-			added, err := shell.Install(rc, line)
+			rep, err := shell.InstallShell(sh)
 			if err != nil {
-				return fmt.Errorf("install hook in %s: %w", rc, err)
+				return err
 			}
 			out := cmd.OutOrStdout()
-			if added {
-				fmt.Fprintf(out, "added hook line to %s — open a new shell to activate\n", rc)
+			if rep.RcAdded {
+				fmt.Fprintf(out, "added hook line to %s\n", rep.RcPath)
 			} else {
-				fmt.Fprintf(out, "hook already installed in %s\n", rc)
+				fmt.Fprintf(out, "hook line already present in %s\n", rep.RcPath)
 			}
+			if sh == "bash" {
+				switch {
+				case rep.LoginAdded && rep.LoginPath != "":
+					fmt.Fprintf(out, "added '. ~/.bashrc' to %s so login shells load the hook\n", rep.LoginPath)
+				case rep.LoginAlreadyOK && rep.LoginPath != "":
+					fmt.Fprintf(out, "%s already sources ~/.bashrc — login shells covered\n", rep.LoginPath)
+				}
+			}
+			fmt.Fprintln(out, "open a new shell to activate")
 			return nil
 		},
 	}
@@ -94,7 +101,18 @@ func newHookStatusCmd() *cobra.Command {
 				fmt.Fprintln(out, "installed: yes")
 			} else {
 				fmt.Fprintln(out, "installed: no")
-				fmt.Fprintf(out, "to install: jitenv hook install\n")
+			}
+			if st.Shell == "bash" {
+				if st.LoginPath == "" {
+					fmt.Fprintln(out, "login chain: no .bash_profile / .bash_login / .profile")
+				} else if st.LoginSources {
+					fmt.Fprintf(out, "login chain: %s sources ~/.bashrc — login shells covered\n", st.LoginPath)
+				} else {
+					fmt.Fprintf(out, "login chain: %s does NOT source ~/.bashrc — login shells will skip the hook\n", st.LoginPath)
+				}
+			}
+			if !st.Installed || (st.Shell == "bash" && st.LoginPath != "" && !st.LoginSources) {
+				fmt.Fprintln(out, "to install: jitenv hook install")
 			}
 			return nil
 		},

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gv/jitenv/internal/agent"
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
+	"github.com/gv/jitenv/internal/shell"
 )
 
 var unlockForeground bool
@@ -61,11 +62,30 @@ func newUnlockCmd() *cobra.Command {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "agent started (socket: %s)\n", paths.Socket)
+			warnIfHookMissing(cmd.ErrOrStderr())
 			return nil
 		},
 	}
 	c.Flags().BoolVar(&unlockForeground, "foreground", false, "run agent in foreground (for development)")
 	return c
+}
+
+// warnIfHookMissing prints a one-line yellow notice to w when the
+// shell hook isn't installed yet, so users who unlock the agent know
+// they still need to wire up the shell.
+func warnIfHookMissing(w interface {
+	Write(p []byte) (n int, err error)
+}) {
+	st, err := shell.CurrentStatus()
+	if err != nil || st.Shell == "" || st.Installed {
+		return
+	}
+	const yellow = "\033[33m"
+	const reset = "\033[0m"
+	fmt.Fprintf(w,
+		"%snote:%s shell hook not installed in %s — run `jitenv hook install` "+
+			"or open `jitenv config` → Settings to add it.\n",
+		yellow, reset, st.RcPath)
 }
 
 func parseIdle(s string) time.Duration {

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -70,22 +70,35 @@ func newUnlockCmd() *cobra.Command {
 	return c
 }
 
-// warnIfHookMissing prints a one-line yellow notice to w when the
-// shell hook isn't installed yet, so users who unlock the agent know
-// they still need to wire up the shell.
+// warnIfHookMissing prints a yellow notice to w when the shell hook
+// isn't fully wired up. Two failure modes are flagged:
+//   - the eval line is not in the user's interactive rc file at all;
+//   - the eval line is in ~/.bashrc but bash login shells don't end up
+//     sourcing ~/.bashrc, so the hook only fires in interactive shells
+//     (this is the situation that hides the agent-down warning when
+//     the user opens a new terminal as a login shell).
 func warnIfHookMissing(w interface {
 	Write(p []byte) (n int, err error)
 }) {
 	st, err := shell.CurrentStatus()
-	if err != nil || st.Shell == "" || st.Installed {
+	if err != nil || st.Shell == "" {
 		return
 	}
 	const yellow = "\033[33m"
 	const reset = "\033[0m"
-	fmt.Fprintf(w,
-		"%snote:%s shell hook not installed in %s — run `jitenv hook install` "+
-			"or open `jitenv config` → Settings to add it.\n",
-		yellow, reset, st.RcPath)
+	if !st.Installed {
+		fmt.Fprintf(w,
+			"%snote:%s shell hook not installed in %s — run `jitenv hook install` "+
+				"or open `jitenv config` → Settings to add it.\n",
+			yellow, reset, st.RcPath)
+		return
+	}
+	if st.Shell == "bash" && st.LoginPath != "" && !st.LoginSources {
+		fmt.Fprintf(w,
+			"%snote:%s ~/.bashrc has the hook line, but %s does not source ~/.bashrc — "+
+				"login shells will skip it. Run `jitenv hook install` to fix.\n",
+			yellow, reset, st.LoginPath)
+	}
 }
 
 func parseIdle(s string) time.Duration {

--- a/internal/shell/hook_e2e_test.go
+++ b/internal/shell/hook_e2e_test.go
@@ -107,3 +107,53 @@ echo "IS_MAPPED_RC=$(jitenv is-mapped %q >/dev/null 2>&1; echo $?)"
 		t.Fatalf("expected hook to inject FOO; output:\n%s", got)
 	}
 }
+
+// TestBashHookAgentDownWarnsThenRuns verifies that when the agent is
+// not running, the bash hook prints the red warning, waits for the
+// (env-shortened) delay, and then runs the command anyway. The script
+// produces "RAN" so we can confirm execution went through.
+func TestBashHookAgentDownWarnsThenRuns(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho RAN\n"), 0755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Point XDG_RUNTIME_DIR at an empty dir so no agent socket exists
+	// — that's what triggers the agent-unreachable path in is-mapped.
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0700)
+
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+eval "$(%s/jitenv hook bash)"
+%q
+`, binDir, binDir, scriptPath,
+	))
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_HOOK_DELAY=1", // shrink the 10s wait for the test
+	)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "agent is not loaded") {
+		t.Errorf("expected red 'agent is not loaded' warning; got:\n%s", got)
+	}
+	if !strings.Contains(got, "RAN") {
+		t.Errorf("expected the script to still run after the delay; got:\n%s", got)
+	}
+	if elapsed < 800*time.Millisecond {
+		t.Errorf("expected the hook to wait ~1s; only %s elapsed", elapsed)
+	}
+}

--- a/internal/shell/hook_unlock_lock_test.go
+++ b/internal/shell/hook_unlock_lock_test.go
@@ -1,0 +1,145 @@
+package shell_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+)
+
+// TestBashHookUnlockRunLockRun mirrors the user's repro:
+//
+//	1. unlock the agent
+//	2. run a mapped script (env vars present, no warning)
+//	3. lock the agent
+//	4. run the mapped script again (red warning printed, script still runs)
+//
+// All four steps execute inside the same bash subprocess so the hook
+// state is preserved across them.
+func TestBashHookUnlockRunLockRun(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "testjitenv.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"${FOO:-MISSING}\"\n"), 0755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-flow")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	key, _ := config.DeriveKeyFromMeta(cfg, pw)
+
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "value-from-noop"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: scriptPath, Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}}},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	os.Rename(tmp.Name(), cfgPath)
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	// Spawn the agent (step 1 surrogate — we don't go through `unlock`
+	// because that prompts for a passphrase on /dev/tty).
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon: %v", err)
+	}
+	pr.Close()
+	pw2.Write(key)
+	pw2.Close()
+	defer daemon.Process.Kill()
+
+	cli := agent.NewClient(paths.Socket)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Step 2: agent up + script. Step 3: lock. Step 4: script again.
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+eval "$(%s/jitenv hook bash)"
+echo '--- step 2 (agent up) ---'
+%q
+echo '--- step 3 (lock) ---'
+jitenv lock
+sleep 0.5
+echo '--- step 4 (agent down) ---'
+%q
+`, binDir, binDir, scriptPath, scriptPath,
+	))
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_HOOK_DELAY=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	t.Logf("bash output:\n%s", got)
+
+	step2 := sectionBetween(got, "--- step 2 (agent up) ---", "--- step 3 (lock) ---")
+	step4 := sectionBetween(got, "--- step 4 (agent down) ---", "")
+
+	if !strings.Contains(step2, "FOO=value-from-noop") {
+		t.Errorf("step 2: expected env to be injected; got:\n%s", step2)
+	}
+	if strings.Contains(step2, "agent is not loaded") {
+		t.Errorf("step 2: did not expect the warning while agent is up; got:\n%s", step2)
+	}
+	if !strings.Contains(step4, "agent is not loaded") {
+		t.Errorf("step 4: expected the agent-down warning; got:\n%s", step4)
+	}
+	if !strings.Contains(step4, "FOO=MISSING") {
+		t.Errorf("step 4: expected the script to still run (with FOO=MISSING); got:\n%s", step4)
+	}
+}
+
+func sectionBetween(haystack, start, end string) string {
+	i := strings.Index(haystack, start)
+	if i < 0 {
+		return ""
+	}
+	rest := haystack[i+len(start):]
+	if end == "" {
+		return rest
+	}
+	j := strings.Index(rest, end)
+	if j < 0 {
+		return rest
+	}
+	return rest[:j]
+}

--- a/internal/shell/install.go
+++ b/internal/shell/install.go
@@ -1,0 +1,122 @@
+package shell
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DetectShell returns "bash" / "zsh" based on $SHELL, or "" if the
+// current shell isn't supported.
+func DetectShell() string {
+	sh := os.Getenv("SHELL")
+	if sh == "" {
+		return ""
+	}
+	switch filepath.Base(sh) {
+	case "bash":
+		return "bash"
+	case "zsh":
+		return "zsh"
+	}
+	return ""
+}
+
+// RcPath returns the conventional rc file path for shell, or "" if we
+// don't know one.
+func RcPath(shell string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	switch shell {
+	case "bash":
+		return filepath.Join(home, ".bashrc")
+	case "zsh":
+		return filepath.Join(home, ".zshrc")
+	}
+	return ""
+}
+
+// HookLine returns the literal line that activates the jitenv hook in
+// the user's rc file. Because every shell session runs `jitenv hook
+// <shell>` at startup, the hook content itself is always whatever the
+// installed binary prints — there is no separate version to upgrade.
+func HookLine(shell string) string {
+	return fmt.Sprintf(`eval "$(jitenv hook %s)"`, shell)
+}
+
+// IsInstalled reports whether `line` already appears in `rcPath`. A
+// non-existent file is treated as "not installed" without error.
+func IsInstalled(rcPath, line string) (bool, error) {
+	b, err := os.ReadFile(rcPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	target := strings.TrimSpace(line)
+	for _, ln := range strings.Split(string(b), "\n") {
+		if strings.TrimSpace(ln) == target {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Install appends a small block (a comment + the eval line) to rcPath
+// if `line` is not already present. The file is created with mode
+// 0644 if it didn't exist. Returns (added bool, err error): added is
+// true when the file was actually modified.
+func Install(rcPath, line string) (bool, error) {
+	already, err := IsInstalled(rcPath, line)
+	if err != nil {
+		return false, err
+	}
+	if already {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(rcPath), 0o755); err != nil {
+		return false, err
+	}
+	f, err := os.OpenFile(rcPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	block := fmt.Sprintf("\n# jitenv: route execution of mapped files through the agent\n%s\n", line)
+	if _, err := f.WriteString(block); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Status reports the install state of the hook for the current user.
+// shell is the detected shell; "" means unsupported. rcPath is the rc
+// file we'd touch (or "" when shell is unsupported). installed is true
+// when the eval line is already present.
+type Status struct {
+	Shell     string
+	RcPath    string
+	Line      string
+	Installed bool
+}
+
+// CurrentStatus returns the status for the user's current shell.
+func CurrentStatus() (Status, error) {
+	sh := DetectShell()
+	if sh == "" {
+		return Status{}, nil
+	}
+	rc := RcPath(sh)
+	line := HookLine(sh)
+	installed, err := IsInstalled(rc, line)
+	if err != nil {
+		return Status{}, err
+	}
+	return Status{Shell: sh, RcPath: rc, Line: line, Installed: installed}, nil
+}

--- a/internal/shell/install.go
+++ b/internal/shell/install.go
@@ -96,14 +96,13 @@ func Install(rcPath, line string) (bool, error) {
 }
 
 // Status reports the install state of the hook for the current user.
-// shell is the detected shell; "" means unsupported. rcPath is the rc
-// file we'd touch (or "" when shell is unsupported). installed is true
-// when the eval line is already present.
 type Status struct {
-	Shell     string
-	RcPath    string
-	Line      string
-	Installed bool
+	Shell        string
+	RcPath       string
+	Line         string
+	Installed    bool
+	LoginPath    string // login-shell startup file we'd touch (bash only)
+	LoginSources bool   // whether the login file already sources RcPath
 }
 
 // CurrentStatus returns the status for the user's current shell.
@@ -118,5 +117,170 @@ func CurrentStatus() (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	return Status{Shell: sh, RcPath: rc, Line: line, Installed: installed}, nil
+	st := Status{Shell: sh, RcPath: rc, Line: line, Installed: installed}
+	if sh == "bash" {
+		st.LoginPath, st.LoginSources = inspectBashLogin()
+	} else {
+		// zsh sources ~/.zshrc for both interactive and login shells,
+		// so there is no separate login file to track.
+		st.LoginSources = true
+	}
+	return st, nil
+}
+
+// InstallReport summarises what InstallShell did.
+type InstallReport struct {
+	RcPath          string
+	RcAdded         bool
+	LoginPath       string
+	LoginAdded      bool
+	LoginAlreadyOK  bool
+}
+
+// InstallShell does a full install for shellName:
+//   - bash: append eval line to ~/.bashrc, then ensure bash login
+//     shells will end up sourcing ~/.bashrc (existing login file gets
+//     a guarded source line; if none exists, ~/.bash_profile is
+//     created with one).
+//   - zsh: append eval line to ~/.zshrc only.
+func InstallShell(shellName string) (InstallReport, error) {
+	rc := RcPath(shellName)
+	if rc == "" {
+		return InstallReport{}, fmt.Errorf("unsupported shell %q", shellName)
+	}
+	line := HookLine(shellName)
+	added, err := Install(rc, line)
+	if err != nil {
+		return InstallReport{}, err
+	}
+	rep := InstallReport{RcPath: rc, RcAdded: added}
+	if shellName == "bash" {
+		loginAdded, loginPath, loginOK, err := ensureBashLoginSourcesBashrc()
+		if err != nil {
+			return rep, err
+		}
+		rep.LoginPath = loginPath
+		rep.LoginAdded = loginAdded
+		rep.LoginAlreadyOK = loginOK
+	}
+	return rep, nil
+}
+
+// inspectBashLogin returns the path of the first existing bash login
+// startup file and whether it already sources ~/.bashrc. If no login
+// file exists, the path is empty and sources is false.
+func inspectBashLogin() (string, bool) {
+	for _, p := range bashLoginCandidates() {
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return p, false
+		}
+		return p, loginFileSourcesBashrc(string(b))
+	}
+	return "", false
+}
+
+// ensureBashLoginSourcesBashrc makes sure bash login shells will end
+// up sourcing ~/.bashrc.
+//
+//	If a login file (.bash_profile / .bash_login / .profile) exists and
+//	already sources ~/.bashrc, no-op.
+//	If a login file exists but doesn't, append a guarded source line.
+//	If no login file exists, create ~/.bash_profile with the source line.
+//
+// Returns (added bool, modifiedPath string, alreadyOK bool, err).
+func ensureBashLoginSourcesBashrc() (bool, string, bool, error) {
+	for _, p := range bashLoginCandidates() {
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return false, p, false, err
+		}
+		if loginFileSourcesBashrc(string(b)) {
+			return false, p, true, nil
+		}
+		f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return false, p, false, err
+		}
+		defer f.Close()
+		if _, err := f.WriteString(loginSourcingBlock(p)); err != nil {
+			return false, p, false, err
+		}
+		return true, p, false, nil
+	}
+	// No login file at all. Create ~/.bash_profile.
+	candidates := bashLoginCandidates()
+	if len(candidates) == 0 {
+		return false, "", false, nil
+	}
+	target := candidates[0]
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return false, "", false, err
+	}
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return false, "", false, err
+	}
+	defer f.Close()
+	if _, err := f.WriteString(strings.TrimPrefix(loginSourcingBlock(target), "\n")); err != nil {
+		return false, "", false, err
+	}
+	return true, target, false, nil
+}
+
+func bashLoginCandidates() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, ".bash_profile"),
+		filepath.Join(home, ".bash_login"),
+		filepath.Join(home, ".profile"),
+	}
+}
+
+// loginSourcingBlock returns the comment + source line to append. If
+// the target is .profile (which sh may also source), the source line
+// is wrapped in a $BASH_VERSION guard so non-bash shells skip it.
+func loginSourcingBlock(target string) string {
+	home, _ := os.UserHomeDir()
+	bashrc := filepath.Join(home, ".bashrc")
+	if filepath.Base(target) == ".profile" {
+		return fmt.Sprintf(
+			"\n# jitenv: ensure bash login shells load ~/.bashrc (sh-safe)\n"+
+				"[ -n \"$BASH_VERSION\" ] && [ -f %s ] && . %s\n",
+			bashrc, bashrc)
+	}
+	return fmt.Sprintf(
+		"\n# jitenv: ensure bash login shells load ~/.bashrc\n"+
+			"[ -f %s ] && . %s\n",
+		bashrc, bashrc)
+}
+
+// loginFileSourcesBashrc reports whether `text` contains a line that
+// sources ~/.bashrc, in any of the common forms.
+func loginFileSourcesBashrc(text string) bool {
+	home, _ := os.UserHomeDir()
+	bashrc := filepath.Join(home, ".bashrc")
+	patterns := []string{
+		"source ~/.bashrc",
+		". ~/.bashrc",
+		"source $HOME/.bashrc",
+		". $HOME/.bashrc",
+		"source " + bashrc,
+		". " + bashrc,
+	}
+	for _, p := range patterns {
+		if strings.Contains(text, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/shell/install_test.go
+++ b/internal/shell/install_test.go
@@ -1,4 +1,4 @@
-package tui
+package shell
 
 import (
 	"os"
@@ -7,47 +7,51 @@ import (
 	"testing"
 )
 
-func TestIsHookInstalled_Missing(t *testing.T) {
+func TestIsInstalled_Missing(t *testing.T) {
 	dir := t.TempDir()
 	rc := filepath.Join(dir, ".bashrc")
-	got, err := isHookInstalled(rc, hookLineForShell("bash"))
+	got, err := IsInstalled(rc, HookLine("bash"))
 	if err != nil || got {
 		t.Fatalf("expected (false, nil) for missing file, got (%v, %v)", got, err)
 	}
 }
 
-func TestIsHookInstalled_Present(t *testing.T) {
+func TestIsInstalled_Present(t *testing.T) {
 	dir := t.TempDir()
 	rc := filepath.Join(dir, ".bashrc")
-	line := hookLineForShell("bash")
+	line := HookLine("bash")
 	body := "# stuff\nexport PATH=$PATH:/x\n" + line + "\n# more\n"
 	if err := os.WriteFile(rc, []byte(body), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got, err := isHookInstalled(rc, line)
+	got, err := IsInstalled(rc, line)
 	if err != nil || !got {
 		t.Fatalf("expected (true, nil), got (%v, %v)", got, err)
 	}
 }
 
-func TestIsHookInstalled_Absent(t *testing.T) {
+func TestIsInstalled_Absent(t *testing.T) {
 	dir := t.TempDir()
 	rc := filepath.Join(dir, ".bashrc")
 	if err := os.WriteFile(rc, []byte("export PS1='> '\n"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got, err := isHookInstalled(rc, hookLineForShell("bash"))
+	got, err := IsInstalled(rc, HookLine("bash"))
 	if err != nil || got {
 		t.Fatalf("expected (false, nil), got (%v, %v)", got, err)
 	}
 }
 
-func TestAppendHookLine_CreatesFile(t *testing.T) {
+func TestInstall_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	rc := filepath.Join(dir, ".bashrc")
-	line := hookLineForShell("bash")
-	if err := appendHookLine(rc, line); err != nil {
-		t.Fatalf("append: %v", err)
+	line := HookLine("bash")
+	added, err := Install(rc, line)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !added {
+		t.Errorf("expected added=true on first install")
 	}
 	b, err := os.ReadFile(rc)
 	if err != nil {
@@ -61,16 +65,37 @@ func TestAppendHookLine_CreatesFile(t *testing.T) {
 	}
 }
 
-func TestAppendHookLine_AppendsToExisting(t *testing.T) {
+func TestInstall_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	rc := filepath.Join(dir, ".bashrc")
+	line := HookLine("bash")
+	if _, err := Install(rc, line); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	added, err := Install(rc, line)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if added {
+		t.Errorf("second install should report added=false")
+	}
+	b, _ := os.ReadFile(rc)
+	if strings.Count(string(b), line) != 1 {
+		t.Fatalf("hook line should appear exactly once:\n%s", b)
+	}
+}
+
+func TestInstall_AppendsToExisting(t *testing.T) {
 	dir := t.TempDir()
 	rc := filepath.Join(dir, ".bashrc")
 	pre := "export FOO=bar\n"
 	if err := os.WriteFile(rc, []byte(pre), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	line := hookLineForShell("bash")
-	if err := appendHookLine(rc, line); err != nil {
-		t.Fatalf("append: %v", err)
+	line := HookLine("bash")
+	added, err := Install(rc, line)
+	if err != nil || !added {
+		t.Fatalf("install: added=%v err=%v", added, err)
 	}
 	b, _ := os.ReadFile(rc)
 	if !strings.HasPrefix(string(b), pre) {
@@ -81,37 +106,37 @@ func TestAppendHookLine_AppendsToExisting(t *testing.T) {
 	}
 }
 
-func TestRcPathForShell(t *testing.T) {
+func TestRcPath(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatalf("home: %v", err)
 	}
-	if got := rcPathForShell("bash"); got != filepath.Join(home, ".bashrc") {
+	if got := RcPath("bash"); got != filepath.Join(home, ".bashrc") {
 		t.Fatalf("bash rc: %q", got)
 	}
-	if got := rcPathForShell("zsh"); got != filepath.Join(home, ".zshrc") {
+	if got := RcPath("zsh"); got != filepath.Join(home, ".zshrc") {
 		t.Fatalf("zsh rc: %q", got)
 	}
-	if got := rcPathForShell("fish"); got != "" {
+	if got := RcPath("fish"); got != "" {
 		t.Fatalf("fish should be unsupported, got %q", got)
 	}
 }
 
 func TestDetectShell(t *testing.T) {
 	t.Setenv("SHELL", "/usr/bin/bash")
-	if got := detectShell(); got != "bash" {
+	if got := DetectShell(); got != "bash" {
 		t.Fatalf("bash detection: %q", got)
 	}
 	t.Setenv("SHELL", "/usr/local/bin/zsh")
-	if got := detectShell(); got != "zsh" {
+	if got := DetectShell(); got != "zsh" {
 		t.Fatalf("zsh detection: %q", got)
 	}
 	t.Setenv("SHELL", "/bin/dash")
-	if got := detectShell(); got != "" {
+	if got := DetectShell(); got != "" {
 		t.Fatalf("unsupported shell should return empty, got %q", got)
 	}
 	t.Setenv("SHELL", "")
-	if got := detectShell(); got != "" {
+	if got := DetectShell(); got != "" {
 		t.Fatalf("empty SHELL should return empty, got %q", got)
 	}
 }

--- a/internal/shell/install_test.go
+++ b/internal/shell/install_test.go
@@ -122,6 +122,126 @@ func TestRcPath(t *testing.T) {
 	}
 }
 
+// withFakeHome replaces $HOME for the duration of a test so the
+// installer touches a sandbox instead of the user's real dotfiles.
+func withFakeHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	return dir
+}
+
+func TestInstallShell_BashCreatesLoginChain(t *testing.T) {
+	home := withFakeHome(t)
+	rep, err := InstallShell("bash")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !rep.RcAdded {
+		t.Errorf("expected RcAdded=true on first install")
+	}
+	if rep.LoginPath != filepath.Join(home, ".bash_profile") {
+		t.Errorf("expected new .bash_profile, got %q", rep.LoginPath)
+	}
+	if !rep.LoginAdded {
+		t.Errorf("expected LoginAdded=true when no login file existed")
+	}
+	body, _ := os.ReadFile(rep.LoginPath)
+	if !strings.Contains(string(body), "/.bashrc") {
+		t.Errorf("created .bash_profile should source ~/.bashrc; got:\n%s", body)
+	}
+}
+
+func TestInstallShell_BashAppendsToExistingProfile(t *testing.T) {
+	home := withFakeHome(t)
+	profile := filepath.Join(home, ".profile")
+	if err := os.WriteFile(profile, []byte("export PS1='> '\n"), 0644); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+
+	rep, err := InstallShell("bash")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if rep.LoginPath != profile {
+		t.Errorf("expected modification of existing .profile, got %q", rep.LoginPath)
+	}
+	if !rep.LoginAdded {
+		t.Errorf("expected LoginAdded=true on .profile that didn't source bashrc")
+	}
+	body, _ := os.ReadFile(profile)
+	if !strings.Contains(string(body), "BASH_VERSION") {
+		t.Errorf(".profile additions should be bash-guarded; got:\n%s", body)
+	}
+	if !strings.HasPrefix(string(body), "export PS1") {
+		t.Errorf("existing .profile content was not preserved: %q", body)
+	}
+}
+
+func TestInstallShell_BashSkipsWhenAlreadySources(t *testing.T) {
+	home := withFakeHome(t)
+	bashProfile := filepath.Join(home, ".bash_profile")
+	if err := os.WriteFile(bashProfile,
+		[]byte("[[ -f ~/.bashrc ]] && source ~/.bashrc\n"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	rep, err := InstallShell("bash")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if rep.LoginAdded {
+		t.Errorf("expected no login-file change when it already sources ~/.bashrc")
+	}
+	if !rep.LoginAlreadyOK {
+		t.Errorf("expected LoginAlreadyOK=true")
+	}
+	body, _ := os.ReadFile(bashProfile)
+	if strings.Count(string(body), "source ~/.bashrc") != 1 {
+		t.Errorf("source line should appear exactly once: %q", body)
+	}
+}
+
+func TestInstallShell_ZshOnlyTouchesZshrc(t *testing.T) {
+	home := withFakeHome(t)
+	rep, err := InstallShell("zsh")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if rep.RcPath != filepath.Join(home, ".zshrc") {
+		t.Errorf("zsh rc path: %q", rep.RcPath)
+	}
+	if rep.LoginPath != "" || rep.LoginAdded {
+		t.Errorf("zsh install should not touch a login file (got %+v)", rep)
+	}
+}
+
+func TestCurrentStatus_BashReportsLoginGap(t *testing.T) {
+	home := withFakeHome(t)
+	t.Setenv("SHELL", "/bin/bash")
+
+	if err := os.WriteFile(filepath.Join(home, ".bashrc"),
+		[]byte(HookLine("bash")+"\n"), 0644); err != nil {
+		t.Fatalf("seed bashrc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".bash_profile"),
+		[]byte("# unrelated\n"), 0644); err != nil {
+		t.Fatalf("seed bash_profile: %v", err)
+	}
+	st, err := CurrentStatus()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !st.Installed {
+		t.Errorf("expected Installed=true")
+	}
+	if st.LoginPath != filepath.Join(home, ".bash_profile") {
+		t.Errorf("LoginPath: %q", st.LoginPath)
+	}
+	if st.LoginSources {
+		t.Errorf("expected LoginSources=false when .bash_profile lacks a source line")
+	}
+}
+
 func TestDetectShell(t *testing.T) {
 	t.Setenv("SHELL", "/usr/bin/bash")
 	if got := DetectShell(); got != "bash" {

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -9,6 +9,40 @@ __JITENV_LOADED=1
 
 shopt -s extdebug
 
+# Print the "agent not loaded" warning in red and count down 10 seconds
+# before returning. Ctrl+C during the countdown is caught and converted
+# into a non-zero return so the caller can cancel the original command.
+__jitenv_warn_no_agent() {
+    local target="$1"
+    local aborted=0
+    trap 'aborted=1' INT
+
+    local red=$'\033[1;31m'
+    local reset=$'\033[0m'
+
+    printf '%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n' \
+        "$red" "$target" "$reset" >&2
+    printf '%sWill run the command anyway in 10s. Press Ctrl+C now to abort.%s\n' \
+        "$red" "$reset" >&2
+
+    local total=${JITENV_HOOK_DELAY:-10}
+    local i
+    for ((i=total; i>0; i--)); do
+        (( aborted )) && break
+        printf '\r%s  %2ds remaining %s' "$red" "$i" "$reset" >&2
+        sleep 1 2>/dev/null
+        (( aborted )) && break
+    done
+
+    trap - INT
+    if (( aborted )); then
+        printf '\n%saborted — command not executed.%s\n' "$red" "$reset" >&2
+        return 1
+    fi
+    printf '\n' >&2
+    return 0
+}
+
 __jitenv_debug_trap() {
     [[ -n "${__JITENV_REENTRY:-}" ]] && return 0
 
@@ -31,14 +65,29 @@ __jitenv_debug_trap() {
     fi
     [[ ! -f "$resolved" ]] && return 0
 
-    if jitenv is-mapped "$resolved" >/dev/null 2>&1; then
-        local rest="${cmd#"$first_raw"}"
-        __JITENV_REENTRY=1
-        eval "jitenv run \"$resolved\"$rest"
-        unset __JITENV_REENTRY
-        return 1
-    fi
-    return 0
+    jitenv is-mapped "$resolved" >/dev/null 2>&1
+    local rc=$?
+    case "$rc" in
+        0)
+            local rest="${cmd#"$first_raw"}"
+            __JITENV_REENTRY=1
+            eval "jitenv run \"$resolved\"$rest"
+            unset __JITENV_REENTRY
+            return 1
+            ;;
+        2)
+            # Agent unreachable. We can't tell whether the file is
+            # mapped, but the user clearly intends to use jitenv (the
+            # hook is installed) so warn loudly and offer an abort.
+            if ! __jitenv_warn_no_agent "$resolved"; then
+                return 1
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }
 
 trap '__jitenv_debug_trap' DEBUG

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -43,6 +43,11 @@ __jitenv_warn_no_agent() {
     return 0
 }
 
+# Set JITENV_HOOK_DEBUG=1 to log each branch the trap takes.
+__jitenv_log() {
+    [[ -n "${JITENV_HOOK_DEBUG:-}" ]] && printf 'jitenv-hook: %s\n' "$*" >&2
+}
+
 __jitenv_debug_trap() {
     [[ -n "${__JITENV_REENTRY:-}" ]] && return 0
 
@@ -65,10 +70,13 @@ __jitenv_debug_trap() {
     fi
     [[ ! -f "$resolved" ]] && return 0
 
+    __jitenv_log "candidate cmd=[$cmd] resolved=[$resolved]"
     jitenv is-mapped "$resolved" >/dev/null 2>&1
     local rc=$?
+    __jitenv_log "is-mapped rc=$rc"
     case "$rc" in
         0)
+            __jitenv_log "branch=case0 (mapped → jitenv run)"
             local rest="${cmd#"$first_raw"}"
             __JITENV_REENTRY=1
             eval "jitenv run \"$resolved\"$rest"
@@ -76,6 +84,7 @@ __jitenv_debug_trap() {
             return 1
             ;;
         2)
+            __jitenv_log "branch=case2 (agent unreachable → warn)"
             # Agent unreachable. We can't tell whether the file is
             # mapped, but the user clearly intends to use jitenv (the
             # hook is installed) so warn loudly and offer an abort.
@@ -85,6 +94,7 @@ __jitenv_debug_trap() {
             return 0
             ;;
         *)
+            __jitenv_log "branch=case* (rc=$rc — unmapped, let it run)"
             return 0
             ;;
     esac

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -41,6 +41,11 @@ __jitenv_warn_no_agent() {
     return 0
 }
 
+# Set JITENV_HOOK_DEBUG=1 to log each branch the widget takes.
+__jitenv_log() {
+    [[ -n "${JITENV_HOOK_DEBUG:-}" ]] && printf 'jitenv-hook: %s\n' "$*" >&2
+}
+
 __jitenv_accept_line() {
     emulate -L zsh
     local first_raw first rest resolved
@@ -57,17 +62,24 @@ __jitenv_accept_line() {
             *)         resolved="" ;;
         esac
         if [[ -n "$resolved" && -f "$resolved" ]]; then
+            __jitenv_log "candidate cmd=[$BUFFER] resolved=[$resolved]"
             jitenv is-mapped "$resolved" >/dev/null 2>&1
             local rc=$?
+            __jitenv_log "is-mapped rc=$rc"
             case "$rc" in
                 0)
+                    __jitenv_log "branch=case0 (mapped → jitenv run)"
                     BUFFER="jitenv run \"$resolved\"$rest"
                     ;;
                 2)
+                    __jitenv_log "branch=case2 (agent unreachable → warn)"
                     # Agent unreachable — wrap the user's command so the
                     # warning + 10s grace runs first. && short-circuits
                     # the real command if the user aborts via Ctrl+C.
                     BUFFER="__jitenv_warn_no_agent \"$resolved\" && { $BUFFER ; }"
+                    ;;
+                *)
+                    __jitenv_log "branch=case* (rc=$rc — unmapped, let it run)"
                     ;;
             esac
         fi

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -6,6 +6,41 @@
 if [[ -n "${__JITENV_LOADED:-}" ]]; then return 0; fi
 __JITENV_LOADED=1
 
+# Warn loudly when the agent isn't reachable, count down 10 seconds,
+# and let Ctrl+C abort. Returns non-zero on abort so the caller's `&&`
+# short-circuits the actual command.
+__jitenv_warn_no_agent() {
+    emulate -L zsh
+    local target="$1"
+    local aborted=0
+    trap 'aborted=1' INT
+
+    local red=$'\033[1;31m'
+    local reset=$'\033[0m'
+
+    printf '%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n' \
+        "$red" "$target" "$reset" >&2
+    printf '%sWill run the command anyway in 10s. Press Ctrl+C now to abort.%s\n' \
+        "$red" "$reset" >&2
+
+    local total=${JITENV_HOOK_DELAY:-10}
+    local i
+    for ((i=total; i>0; i--)); do
+        (( aborted )) && break
+        printf '\r%s  %2ds remaining %s' "$red" "$i" "$reset" >&2
+        sleep 1
+        (( aborted )) && break
+    done
+
+    trap - INT
+    if (( aborted )); then
+        printf '\n%saborted — command not executed.%s\n' "$red" "$reset" >&2
+        return 1
+    fi
+    printf '\n' >&2
+    return 0
+}
+
 __jitenv_accept_line() {
     emulate -L zsh
     local first_raw first rest resolved
@@ -22,9 +57,19 @@ __jitenv_accept_line() {
             *)         resolved="" ;;
         esac
         if [[ -n "$resolved" && -f "$resolved" ]]; then
-            if jitenv is-mapped "$resolved" >/dev/null 2>&1; then
-                BUFFER="jitenv run \"$resolved\"$rest"
-            fi
+            jitenv is-mapped "$resolved" >/dev/null 2>&1
+            local rc=$?
+            case "$rc" in
+                0)
+                    BUFFER="jitenv run \"$resolved\"$rest"
+                    ;;
+                2)
+                    # Agent unreachable — wrap the user's command so the
+                    # warning + 10s grace runs first. && short-circuits
+                    # the real command if the user aborts via Ctrl+C.
+                    BUFFER="__jitenv_warn_no_agent \"$resolved\" && { $BUFFER ; }"
+                    ;;
+            esac
         fi
     fi
     zle .accept-line

--- a/internal/tui/hookinstall.go
+++ b/internal/tui/hookinstall.go
@@ -1,115 +1,37 @@
 package tui
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/shell"
 )
-
-// detectShell returns "bash" / "zsh" based on $SHELL, or "" if the
-// current shell isn't supported.
-func detectShell() string {
-	sh := os.Getenv("SHELL")
-	if sh == "" {
-		return ""
-	}
-	switch filepath.Base(sh) {
-	case "bash":
-		return "bash"
-	case "zsh":
-		return "zsh"
-	}
-	return ""
-}
-
-// rcPathForShell returns the conventional rc file path for shell, or
-// "" if we don't know one.
-func rcPathForShell(shell string) string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	switch shell {
-	case "bash":
-		return filepath.Join(home, ".bashrc")
-	case "zsh":
-		return filepath.Join(home, ".zshrc")
-	}
-	return ""
-}
-
-// hookLineForShell returns the literal line that activates the jitenv
-// hook in the user's rc file.
-func hookLineForShell(shell string) string {
-	return fmt.Sprintf(`eval "$(jitenv hook %s)"`, shell)
-}
-
-// isHookInstalled reports whether `line` already appears in `rcPath`.
-// A non-existent file is treated as "not installed" without error.
-func isHookInstalled(rcPath, line string) (bool, error) {
-	b, err := os.ReadFile(rcPath)
-	if errors.Is(err, fs.ErrNotExist) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	target := strings.TrimSpace(line)
-	for _, ln := range strings.Split(string(b), "\n") {
-		if strings.TrimSpace(ln) == target {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// appendHookLine appends a small block (a comment + the eval line) to
-// rcPath. The file is created with mode 0644 if it didn't exist.
-func appendHookLine(rcPath, line string) error {
-	f, err := os.OpenFile(rcPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	block := fmt.Sprintf("\n# jitenv: route execution of mapped files through the agent\n%s\n", line)
-	_, err = f.WriteString(block)
-	return err
-}
 
 // maybePromptInstallHook returns a tea.Cmd that pushes a confirm modal
 // asking the user to install the hook in their rc file. Returns nil if
 // the hook is already installed, the shell isn't supported, or the rc
 // file can't be read.
 func maybePromptInstallHook(r *rootModel) tea.Cmd {
-	shell := detectShell()
-	if shell == "" {
-		return nil
-	}
-	rc := rcPathForShell(shell)
-	if rc == "" {
-		return nil
-	}
-	line := hookLineForShell(shell)
-	installed, err := isHookInstalled(rc, line)
-	if err != nil || installed {
+	st, err := shell.CurrentStatus()
+	if err != nil || st.Shell == "" || st.Installed {
 		return nil
 	}
 	prompt := fmt.Sprintf(
 		"Shell hook is not installed.\nAppend the following line to %s?\n\n    %s\n\nWithout it, mapped files won't pick up env vars\nautomatically — you'd have to invoke `jitenv run` by hand.",
-		rc, line,
+		st.RcPath, st.Line,
 	)
 	cb := func(choice string) tea.Cmd {
 		switch choice {
 		case "Install":
-			if err := appendHookLine(rc, line); err != nil {
+			added, err := shell.Install(st.RcPath, st.Line)
+			if err != nil {
 				return tea.Sequence(emit(popMsg{}), emit(errorMsg("install hook: "+err.Error())))
 			}
-			msg := fmt.Sprintf("hook installed in %s — open a new shell to activate", rc)
+			msg := fmt.Sprintf("hook installed in %s — open a new shell to activate", st.RcPath)
+			if !added {
+				msg = "hook already present in " + st.RcPath
+			}
 			return tea.Sequence(emit(popMsg{}), emit(statusMsg(msg)))
 		default:
 			return emit(popMsg{})

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -6,31 +6,32 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// renderApp composes the centered content panel and the bottom status
-// bar into one full-screen string sized to the actual terminal. If the
-// terminal is too small to fit the body, the body is clipped from the
-// bottom (preserving the heading) rather than overflowing — overflow
-// would push the top of the UI off screen in alt-screen mode.
+// renderApp composes the centered content panel, the bottom status
+// bar, and a one-line copyright footer into a full-screen string sized
+// to the actual terminal. If the terminal is too small to fit the
+// body, the body is clipped from the bottom (preserving the heading)
+// rather than overflowing — overflow would push the top of the UI off
+// screen in alt-screen mode.
 func renderApp(w, h int, body, status string) string {
 	if w < 4 {
 		w = 4
 	}
-	if h < 3 {
-		h = 3
+	if h < 4 {
+		h = 4
 	}
 
 	statusLine := statusBarStyle.Width(w).Render(status)
+	footerLine := copyrightStyle.Width(w).Align(lipgloss.Center).Render(copyrightText)
 
-	// Available rows for the panel = total - 1 status row.
-	contentH := h - 1
+	// Reserve 1 row for status + 1 row for the footer.
+	contentH := h - 2
 
-	// Panel decoration: 2 rows of border + 2 rows of padding.
-	const decor = 4
+	const decor = 4 // 2 border rows + 2 padding rows around the body.
 	innerH := contentH - decor
 	if innerH < 1 {
-		// Terminal is too short for any meaningful panel; show the
-		// status bar only and return.
-		return strings.Repeat("\n", contentH) + statusLine
+		// Terminal too short for a meaningful panel; show status +
+		// footer only.
+		return strings.Repeat("\n", contentH) + statusLine + "\n" + footerLine
 	}
 
 	innerW := w - decor
@@ -48,8 +49,14 @@ func renderApp(w, h int, body, status string) string {
 	bodyStr := strings.Join(bodyLines, "\n")
 
 	panel := panelStyle.Width(innerW + decor).Render(bodyStr)
-	return panel + "\n" + statusLine
+	return panel + "\n" + statusLine + "\n" + footerLine
 }
+
+const copyrightText = "© 2026 Gal Villaret · jitenv — MIT"
+
+var copyrightStyle = lipgloss.NewStyle().
+	Foreground(colorMuted).
+	Faint(true)
 
 // modalOverlay returns a small centered bordered popup of the given
 // width, ready to be rendered in lieu of the body. Used by confirm

--- a/internal/tui/settings_screen.go
+++ b/internal/tui/settings_screen.go
@@ -94,34 +94,36 @@ func (s *settingsScreen) openHookPopup() tea.Cmd {
 
 	heading := "Shell hook"
 	choices := []string{"Install", "Back"}
-	if st.Installed {
+	if st.Installed && (st.Shell != "bash" || st.LoginPath == "" || st.LoginSources) {
 		heading = "Shell hook (installed)"
 		choices = []string{"Reinstall", "Back"}
+	} else if st.Installed {
+		heading = "Shell hook — login chain not wired"
+		choices = []string{"Fix login chain", "Back"}
 	}
 	cb := func(choice string) tea.Cmd {
 		switch choice {
-		case "Install":
-			added, err := shell.Install(st.RcPath, st.Line)
+		case "Install", "Reinstall", "Fix login chain":
+			rep, err := shell.InstallShell(st.Shell)
 			if err != nil {
 				return tea.Sequence(emit(popMsg{}), emit(errorMsg("install hook: "+err.Error())))
 			}
-			msg := fmt.Sprintf("hook installed in %s — open a new shell to activate", st.RcPath)
-			if !added {
-				msg = "hook already present in " + st.RcPath
+			parts := []string{}
+			if rep.RcAdded {
+				parts = append(parts, "added hook line to "+rep.RcPath)
+			} else {
+				parts = append(parts, "hook line already in "+rep.RcPath)
 			}
-			return tea.Sequence(emit(popMsg{}), emit(statusMsg(msg)))
-		case "Reinstall":
-			// The eval line never changes between versions, so a
-			// "reinstall" while already present is just a sanity
-			// check — confirm and report.
-			added, err := shell.Install(st.RcPath, st.Line)
-			if err != nil {
-				return tea.Sequence(emit(popMsg{}), emit(errorMsg("reinstall hook: "+err.Error())))
+			if st.Shell == "bash" {
+				switch {
+				case rep.LoginAdded && rep.LoginPath != "":
+					parts = append(parts, "wired login chain via "+rep.LoginPath)
+				case rep.LoginAlreadyOK && rep.LoginPath != "":
+					parts = append(parts, rep.LoginPath+" already sources ~/.bashrc")
+				}
 			}
-			msg := "hook line already present and correct in " + st.RcPath
-			if added {
-				msg = "hook line restored in " + st.RcPath
-			}
+			parts = append(parts, "open a new shell to activate")
+			msg := strings.Join(parts, " — ")
 			return tea.Sequence(emit(popMsg{}), emit(statusMsg(msg)))
 		}
 		return emit(popMsg{})
@@ -142,10 +144,13 @@ func (s *settingsScreen) View() string {
 	switch {
 	case st.Shell == "":
 		hookValue = dimText("(unsupported shell — only bash and zsh)")
-	case st.Installed:
-		hookValue = okStyle.Render("installed") + "  " + dimText("("+st.RcPath+")")
-	default:
+	case !st.Installed:
 		hookValue = warnStyle.Render("not installed") + "  " + dimText("("+st.RcPath+")")
+	case st.Shell == "bash" && st.LoginPath != "" && !st.LoginSources:
+		hookValue = warnStyle.Render("interactive only") + "  " +
+			dimText("(login chain "+st.LoginPath+" doesn't source ~/.bashrc)")
+	default:
+		hookValue = okStyle.Render("installed") + "  " + dimText("("+st.RcPath+")")
 	}
 
 	rows := []struct{ label, value string }{

--- a/internal/tui/settings_screen.go
+++ b/internal/tui/settings_screen.go
@@ -1,131 +1,164 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/shell"
 )
 
+// settingsScreen is a small list with two rows: idle timeout and the
+// shell-hook status. Enter on a row opens its own popup (an input for
+// the timeout, a confirm for the hook).
 type settingsScreen struct {
-	root     *rootModel
-	idle     textinput.Model
-	btnFocus int
-	buttons  []button
-	err      string
+	root   *rootModel
+	cursor int // 0 = idle timeout, 1 = shell hook
 }
 
 func newSettingsScreen(r *rootModel) screen {
-	ti := textinput.New()
-	ti.Prompt = ""
-	ti.Placeholder = "30m"
-	ti.CharLimit = 32
-	ti.SetValue(r.cfg.Agent.IdleTimeout)
-	ti.Focus()
-	return &settingsScreen{
-		root:     r,
-		idle:     ti,
-		btnFocus: -1,
-		buttons:  []button{newButton("Save"), newButton("Cancel")},
-	}
+	return &settingsScreen{root: r}
 }
 
-func (s *settingsScreen) Title() string  { return "settings" }
-func (s *settingsScreen) Status() string { return defaultFormStatus }
-func (s *settingsScreen) Init() tea.Cmd  { return nil }
+func (s *settingsScreen) Title() string { return "settings" }
+func (s *settingsScreen) Status() string {
+	return renderHelpKeys(
+		[2]string{"↑/↓", "move"},
+		[2]string{"Enter", "open"},
+		[2]string{"Esc", "back"},
+	)
+}
+func (s *settingsScreen) Init() tea.Cmd { return nil }
 
 func (s *settingsScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if k, ok := msg.(tea.KeyMsg); ok {
 		switch k.String() {
+		case "up", "k":
+			if s.cursor > 0 {
+				s.cursor--
+			}
+		case "down", "j":
+			if s.cursor < 1 {
+				s.cursor++
+			}
+		case "enter":
+			return s, s.activate()
 		case "esc":
 			return s, emit(popMsg{})
-		case "tab":
-			if s.btnFocus < 0 {
-				s.btnFocus = 0
-				s.idle.Blur()
-			} else if s.btnFocus < len(s.buttons)-1 {
-				s.btnFocus++
-			} else {
-				s.btnFocus = -1
-				s.idle.Focus()
-			}
-			return s, nil
-		case "shift+tab":
-			if s.btnFocus < 0 {
-				s.btnFocus = len(s.buttons) - 1
-				s.idle.Blur()
-			} else if s.btnFocus > 0 {
-				s.btnFocus--
-			} else {
-				s.btnFocus = -1
-				s.idle.Focus()
-			}
-			return s, nil
-		case "down":
-			if s.btnFocus < 0 {
-				s.btnFocus = 0
-				s.idle.Blur()
-			}
-			return s, nil
-		case "up":
-			if s.btnFocus >= 0 {
-				s.btnFocus = -1
-				s.idle.Focus()
-			}
-			return s, nil
-		case "left":
-			if s.btnFocus > 0 {
-				s.btnFocus--
-			}
-			return s, nil
-		case "right":
-			if s.btnFocus >= 0 && s.btnFocus < len(s.buttons)-1 {
-				s.btnFocus++
-			}
-			return s, nil
-		case "enter":
-			if s.btnFocus < 0 || s.buttons[s.btnFocus].label == "Save" {
-				return s, s.save()
-			}
-			if s.buttons[s.btnFocus].label == "Cancel" {
-				return s, emit(popMsg{})
-			}
 		}
-	}
-	if s.btnFocus < 0 {
-		var cmd tea.Cmd
-		s.idle, cmd = s.idle.Update(msg)
-		return s, cmd
 	}
 	return s, nil
 }
 
-func (s *settingsScreen) save() tea.Cmd {
-	v := strings.TrimSpace(s.idle.Value())
-	if v != "" {
-		if _, err := time.ParseDuration(v); err != nil {
-			s.err = "invalid duration (try 30m, 1h, 5s)"
-			return emit(errorMsg(s.err))
-		}
+func (s *settingsScreen) activate() tea.Cmd {
+	switch s.cursor {
+	case 0:
+		return s.openIdleInput()
+	case 1:
+		return s.openHookPopup()
 	}
-	s.err = ""
-	s.root.cfg.Agent.IdleTimeout = v
-	return tea.Sequence(emit(dirtyMsg{}), emit(statusMsg("settings updated")), emit(popMsg{}))
+	return nil
+}
+
+func (s *settingsScreen) openIdleInput() tea.Cmd {
+	commit := func(val string) tea.Cmd {
+		v := strings.TrimSpace(val)
+		if v != "" {
+			if _, err := time.ParseDuration(v); err != nil {
+				return emit(errorMsg("invalid duration (try 30m, 1h, 5s)"))
+			}
+		}
+		s.root.cfg.Agent.IdleTimeout = v
+		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}), emit(statusMsg("idle timeout updated")))
+	}
+	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
+		Title:       "agent idle timeout",
+		Prompt:      "Go duration string (e.g. 30m, 1h, 5s). Empty = use default (30m).",
+		Placeholder: "30m",
+		Initial:     s.root.cfg.Agent.IdleTimeout,
+		AllowBlank:  true,
+		SaveLabel:   "OK",
+	}, commit)})
+}
+
+func (s *settingsScreen) openHookPopup() tea.Cmd {
+	st, err := shell.CurrentStatus()
+	if err != nil {
+		return emit(errorMsg("hook status: " + err.Error()))
+	}
+	if st.Shell == "" {
+		return emit(errorMsg("unsupported shell — only bash and zsh"))
+	}
+
+	heading := "Shell hook"
+	choices := []string{"Install", "Back"}
+	if st.Installed {
+		heading = "Shell hook (installed)"
+		choices = []string{"Reinstall", "Back"}
+	}
+	cb := func(choice string) tea.Cmd {
+		switch choice {
+		case "Install":
+			added, err := shell.Install(st.RcPath, st.Line)
+			if err != nil {
+				return tea.Sequence(emit(popMsg{}), emit(errorMsg("install hook: "+err.Error())))
+			}
+			msg := fmt.Sprintf("hook installed in %s — open a new shell to activate", st.RcPath)
+			if !added {
+				msg = "hook already present in " + st.RcPath
+			}
+			return tea.Sequence(emit(popMsg{}), emit(statusMsg(msg)))
+		case "Reinstall":
+			// The eval line never changes between versions, so a
+			// "reinstall" while already present is just a sanity
+			// check — confirm and report.
+			added, err := shell.Install(st.RcPath, st.Line)
+			if err != nil {
+				return tea.Sequence(emit(popMsg{}), emit(errorMsg("reinstall hook: "+err.Error())))
+			}
+			msg := "hook line already present and correct in " + st.RcPath
+			if added {
+				msg = "hook line restored in " + st.RcPath
+			}
+			return tea.Sequence(emit(popMsg{}), emit(statusMsg(msg)))
+		}
+		return emit(popMsg{})
+	}
+	return emit(pushMsg{s: newPopupMenuScreen(s.root, heading, cb, choices...)})
 }
 
 func (s *settingsScreen) View() string {
 	var b strings.Builder
-	label := labelStyle
-	if s.btnFocus >= 0 {
-		label = mutedStyle
+
+	idle := s.root.cfg.Agent.IdleTimeout
+	if idle == "" {
+		idle = dimText("(default 30m)")
 	}
-	b.WriteString(label.Render("agent idle timeout") + "\n")
-	b.WriteString("  " + s.idle.View() + "\n")
-	b.WriteString("  " + dimText("Go duration string; empty = use default (30m)") + "\n\n")
-	if s.err != "" {
-		b.WriteString(errorStyle.Render(s.err) + "\n\n")
+
+	st, _ := shell.CurrentStatus()
+	hookValue := ""
+	switch {
+	case st.Shell == "":
+		hookValue = dimText("(unsupported shell — only bash and zsh)")
+	case st.Installed:
+		hookValue = okStyle.Render("installed") + "  " + dimText("("+st.RcPath+")")
+	default:
+		hookValue = warnStyle.Render("not installed") + "  " + dimText("("+st.RcPath+")")
 	}
-	b.WriteString(renderButtonRow(s.buttons, s.btnFocus) + "\n")
+
+	rows := []struct{ label, value string }{
+		{"agent idle timeout", idle},
+		{"shell hook", hookValue},
+	}
+	for i, r := range rows {
+		line := fmt.Sprintf("%-22s %s", r.label+":", r.value)
+		if i == s.cursor {
+			b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(line) + "\n")
+		} else {
+			b.WriteString("   " + listItemStyle.Render(line) + "\n")
+		}
+	}
 	return b.String()
 }


### PR DESCRIPTION
## Summary

- **Copyright footer** rendered below the status bar on every screen (`© 2026 Gal Villaret · jitenv — MIT`).
- **Hook warning when the agent is not loaded.** When the bash/zsh hook intercepts a `/`, `./`, `../` command and `jitenv is-mapped` exits 2 (agent unreachable), the hook prints a red message + counts down 10 s with `Ctrl+C` to abort. Override the wait with `JITENV_HOOK_DELAY=<seconds>`.
- **Hook installer covers login shells.** `jitenv hook install` (and the TUI Settings popup, and the unlock-time notice) now detect when `~/.bashrc` is the only place wired up and bash login shells would skip it. The installer appends a guarded `source ~/.bashrc` to whichever of `~/.bash_profile` / `~/.bash_login` / `~/.profile` exists (or creates `~/.bash_profile` if none do).
- **Sharable installer API.** Detection / install / status logic moved to `internal/shell` so the CLI, TUI, and `jitenv unlock` notice all drive the same idempotent code path.
- **Debug switch.** `JITENV_HOOK_DEBUG=1` makes the bash/zsh hook log which branch (`case0` / `case2` / `case*`) the trap took for each candidate command.
- **Tests.** New e2e test exercising the `unlock → run → lock → run` flow asserts env-vars-on-step-2 and warning-on-step-4. Unit tests for the multi-file login-chain logic cover create / append / sh-guard / already-sourced.

## Test plan

- [x] `make build` succeeds
- [x] `go vet ./...` clean
- [x] `go test ./...` green (full suite, including the new bash hook e2e)
- [x] On a real machine: `make install`, `jitenv hook install`, open a new terminal, confirm `type __jitenv_warn_no_agent` resolves to a function
- [x] `jitenv unlock`; `./testjitenv.sh` shows env vars
- [x] `jitenv lock`; `./testjitenv.sh` shows the red warning + counts down + runs without env vars
- [x] `jitenv hook status` reports both `installed: yes` and that the login chain sources `~/.bashrc`