### PR TITLE
Add CLAUDE.md with architecture orientation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build / test / lint
+
+```sh
+make build        # ./bin/jitenv (trimpath, -s -w)
+make install      # to $PREFIX/bin (default ~/.local/bin)
+make test         # go test ./...
+make fmt vet tidy
+
+# Run one package's tests
+go test ./internal/agent
+
+# Run a single test
+go test ./internal/run -run TestRunInjectsEnvAndExecs -v
+```
+
+Go 1.22+ (go.mod declares 1.25.6). Linux-only (uses `SO_PEERCRED`, `XDG_RUNTIME_DIR`, `Setsid` double-fork).
+
+The e2e tests under `internal/run` and `internal/shell` shell out to `go build` to produce a real binary against a temp config; they're slow but exercise the unlock → daemonize → hook → run loop end-to-end.
+
+## Big-picture architecture
+
+jitenv is a 3-process design that keeps secrets out of the parent shell:
+
+1. **CLI / TUI** (`cmd/jitenv` → `internal/cli`, `internal/tui`) — reads/writes the encrypted TOML config. The TUI decrypts in-process, edits, and re-encrypts on save.
+2. **Agent** (`internal/agent`) — long-lived per-user daemon, spawned by `jitenv unlock` via `SpawnDaemon` (re-execs `jitenv __agent` with the master key handed over fd 3). Listens on a Unix socket under `$XDG_RUNTIME_DIR/jitenv/`, mode 0600, peer UID checked via `SO_PEERCRED`. JSON ops: `status`, `is_mapped`, `fetch_env`, `lock`, `reload` (length-prefixed; see `internal/agent/protocol.go`).
+3. **Shell hook + `jitenv run`** (`internal/shell/snippets/{bash,zsh}.sh`, `internal/run`) — bash uses `extdebug` + `DEBUG` trap; zsh uses `preexec`. The hook intercepts only commands whose first token resolves to an absolute or `./`/`../` path, calls `jitenv is-mapped`, and on a hit re-runs the command via `jitenv run` which `syscall.Exec`s the file with the merged env (so secrets only ever live in that child's process tree).
+
+### Hook `is-mapped` exit codes (load-bearing)
+
+The bash/zsh snippets switch on the exit code of `jitenv is-mapped`:
+- **0** → mapped, route through `jitenv run`.
+- **1** → not mapped, run normally.
+- **2** → agent unreachable. The hook prints a red 10s warning and lets Ctrl-C abort. This is the "agent is locked" UX path; do not collapse it into 1.
+
+See `internal/cli/ismapped.go` for the exit-code contract and `bash.sh:74-100` for the dispatch.
+
+### Source plugin model
+
+`pkg/source` defines the public `Source` interface (`Name`, `Validate`, `Fetch`) and `Constructor`. Each backend in `internal/sources/<name>` registers itself via `init()` calling `sources.Register(...)`. `internal/sources/builtin` blank-imports them so the binary ships them all; that package is itself blank-imported by `cmd/jitenv/main.go` — adding a new source means adding it under `internal/sources/<name>` AND to `internal/sources/builtin/builtin.go`.
+
+The `local` source is special: it has no params and reads from `cfg.Secrets`, which the agent's resolver injects post-construction via a `SetBags(...)` type assertion (`bagSink` interface in `internal/agent/resolver.go`). Plaintext bag values therefore never leave agent memory.
+
+### Config + crypto
+
+`internal/config` owns the on-disk schema (`Config`, `Mapping`, `VarRef`, `SourceConfig`). `internal/crypto`:
+- Argon2id KDF (time=3, mem=64MiB, threads=4) with per-config salt.
+- Sensitive fields are stored as `enc:v1:<base64(nonce ‖ XChaCha20-Poly1305(plaintext))>` envelopes.
+- `Meta.Verify` is a sentinel envelope decrypted at unlock to verify the passphrase.
+- `DecryptStringsInPlace` walks `map[string]any` and replaces every envelope string — that's how arbitrary `[sources.<name>.params]` blocks get decrypted without per-source schema knowledge.
+
+Saves go through `config.AtomicSave` (sibling tempfile + rename, mode 0600). The TUI calls `pingAgentReload` after a successful save so a running agent picks up the new config without `lock`/`unlock`.
+
+### Mapping lookup
+
+`config.Index` (built once per resolver) splits mappings into an exact-path map plus a slice of glob entries (matched with `bmatcuk/doublestar/v4`). `Lookup` returns matching `VarRef`s in declaration order: exact first, then each matching glob; later entries with the same env var name win.
+
+A `VarRef` with empty `Name` means "expand the whole bag" — every key in the source's response becomes its own env var. `Name == ""` AND `Key != ""` is invalid (rejected by `Config.Validate`).
+
+### TUI architecture (`internal/tui`)
+
+Bubble Tea with a screen-stack `rootModel`. Each screen implements `Init / Update / View / Title / Status`. Screens push/pop via `pushMsg` / `popMsg` / `popUntilMsg`. UI pattern is uniform: every list page has a `< Create New … >` sentinel at the top and selecting an existing row opens a popup menu (`popup_menu.go`). Renames cascade: changing a bag/key/source name rewrites every `VarRef` that referenced it (see `internal/tui/references.go`).
+
+### Shell hook installer
+
+`internal/shell/install.go` is more than just appending one line: for bash it also walks `.bash_profile` → `.bash_login` → `.profile` and adds a guarded `. ~/.bashrc` line if none of them already source it (login shells otherwise skip `~/.bashrc`). zsh sources `~/.zshrc` for both interactive and login, so no second file is touched. `jitenv hook install` is idempotent. `unlock.go:warnIfHookMissing` flags both "no hook line" and "hook line present but login chain doesn't load it".
+
+## Conventions worth knowing
+
+- **Master key handling.** The key is `defer zeroBytes(...)`'d everywhere it lives outside the agent. Don't print it, don't pass it as a CLI flag (it's an inherited fd in `SpawnDaemon`). New code that touches the key should follow the same zero-on-defer pattern.
+- **Cobra layout.** Commands are constructed by `new<Name>Cmd()` functions and aggregated in `internal/cli/subcommands.go`. To add a top-level command, append it there. The hidden `__agent` command is the daemon entrypoint — it is not a user-facing command.
+- **Config path resolution.** `JITENV_CONFIG` > `$XDG_CONFIG_HOME/jitenv/config.toml` > `~/.config/jitenv/config.toml`. Always go through `config.Resolve` rather than reconstructing.
+- **Agent paths.** `$XDG_RUNTIME_DIR/jitenv/{agent.sock,agent.pid,agent.log}`, falling back to `/tmp/jitenv-<uid>/`. Use `agent.DefaultPaths()`.
+- **No third source UI.** AWS Secrets Manager and GitHub Variables sources are compiled in and work at runtime, but the TUI's "Remote Sources" page is currently hidden. Existing `[sources.*]` entries in `config.toml` keep working.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` at repo root with build/test commands and a high-level architecture tour focused on the bits that take reading multiple files to understand.

## Notable points covered
- 3-process design (CLI/TUI ↔ unix-socket agent ↔ shell hook + `jitenv run`)
- The `jitenv is-mapped` exit-code contract (0 / 1 / 2) that the bash/zsh snippets switch on
- Source plugin registration flow (`internal/sources/<name>` + blank-import in `internal/sources/builtin`)
- `local` source's `bagSink`/`SetBags` post-construction wiring
- Mapping lookup semantics (exact-then-globs, expand-whole-bag mode)
- Bash login-chain handling in the hook installer (the non-obvious bit beyond appending one line)
- Master-key handling conventions (`zeroBytes` defer, fd-3 handoff to `__agent`)

## Test plan
- [x] Open `CLAUDE.md` in a fresh Claude Code session and confirm the orientation makes sense without further code reading