### PR TITLE
fix(ci): authenticate release-please with PAT so tags fire release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,10 +17,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      # Uses GITHUB_TOKEN by default. If branch protection later blocks the
-      # github-actions[bot] from opening PRs, store a fine-grained PAT as
-      # RELEASE_PLEASE_TOKEN and pass `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}`.
+      # Uses a fine-grained PAT (RELEASE_PLEASE_TOKEN) instead of the default
+      # GITHUB_TOKEN so the tag created by release-please fires the downstream
+      # release.yml workflow. Tags created by GITHUB_TOKEN do NOT trigger
+      # other workflows (GitHub recursion guard); a user/PAT-authored tag
+      # does. If the PAT is unset, release-please will silently fall back to
+      # GITHUB_TOKEN and the release workflow will need to be triggered
+      # manually (or the tag re-pushed) to publish artifacts.
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: release-please-manifest.json

--- a/docs/superpowers/specs/2026-05-06-first-release-design.md
+++ b/docs/superpowers/specs/2026-05-06-first-release-design.md
@@ -105,9 +105,10 @@ No issue exclusions to start. The first run on the existing codebase will likely
 
 - Trigger: `push` on `main`.
 - Permissions: `contents: write`, `pull-requests: write`.
-- Step: `googleapis/release-please-action@v4` using `GITHUB_TOKEN` by default.
+- Concurrency: serial (`group: release-please`, `cancel-in-progress: false`) to avoid races on the manifest commit.
+- Step: `googleapis/release-please-action@v4` authenticated with a fine-grained PAT `RELEASE_PLEASE_TOKEN` (NOT the default `GITHUB_TOKEN` — see below).
 
-**Known token caveat:** if the repository later adopts a branch protection rule that forbids the `github-actions[bot]` from opening PRs, release-please will silently fail to open the release PR. The mitigation is a fine-grained PAT stored as a `RELEASE_PLEASE_TOKEN` secret. We do not pre-emptively add this for v0.1; we add it only if the default token is rejected.
+**Token model: PAT is required, not optional.** `googleapis/release-please-action` does two things: it opens a release PR, and when that PR merges it creates the corresponding `vX.Y.Z` git tag. Both operations honour the action's `token` input. With `GITHUB_TOKEN` the PR opens fine *but* the tag is created under the GitHub Actions identity, and **GitHub deliberately suppresses workflow runs triggered by the default `GITHUB_TOKEN`** (recursion guard). Consequence: `.github/workflows/release.yml`, which listens on `push: tags: [v*]`, never fires, and the published "release" has no artifacts attached. The fix is to authenticate release-please with a fine-grained PAT scoped to this repo (`contents: read+write`, `pull-requests: read+write`) stored as `RELEASE_PLEASE_TOKEN`. Tags created by a user-owned PAT trigger downstream workflows normally. This is documented as a hard requirement, not a "consider if branch protection rejects bot PRs" optional escape hatch — it bites the very first release if absent.
 
 ## 8. GoReleaser config — `.goreleaser.yaml`
 


### PR DESCRIPTION
## Summary

Wires `release-please` to use the new `RELEASE_PLEASE_TOKEN` fine-grained PAT instead of `GITHUB_TOKEN`. Tags created by `GITHUB_TOKEN` do not fire downstream workflows (GitHub recursion guard), which is why the v0.1.1 release was published with no artifacts and required a manual tag re-push to trigger `release.yml`.

Also updates the design spec (§7) to document this as a hard requirement, replacing the previous framing of "optional escape hatch for branch-protection-blocked bot PRs".

## Files changed

- `.github/workflows/release-please.yml` — passes `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}` to the action; updates the inline comment to explain why this matters.
- `docs/superpowers/specs/2026-05-06-first-release-design.md` — rewrites the "Known token caveat" paragraph as a hard "Token model: PAT is required" section.

## Test plan

- [x] `release-please.yml` parses (YAML)
- [x] After merge, on the next visible Conventional Commit (`feat:`, `fix:`, `perf:`, `revert:`, `docs:`) landing on `main`, release-please opens a release PR. Merging that PR creates a tag *and* fires `release.yml`, which uploads artifacts to the GitHub Release without manual intervention.