### PR TITLE
feat(packaging): postinstall/preremove hook reminder

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,6 +61,9 @@ nfpms:
         dst: /usr/share/doc/jitenv/LICENSE
       - src: README.md
         dst: /usr/share/doc/jitenv/README.md
+    scripts:
+      postinstall: packaging/postinstall.sh
+      preremove: packaging/preremove.sh
 
 checksum:
   name_template: SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -18,11 +18,45 @@ tree only — never into the parent shell.
 
 ## Install
 
+### From a release artifact (Linux)
+
+```sh
+# Debian / Ubuntu
+sudo dpkg -i jitenv_X.Y.Z_linux_amd64.deb
+
+# Fedora / RHEL / openSUSE
+sudo rpm -i jitenv_X.Y.Z_linux_amd64.rpm
+```
+
+The package's post-install prints a one-liner reminder. Activate the
+shell hook **once, as your normal user** (not as root):
+
+```sh
+jitenv hook install   # appends one line to ~/.bashrc or ~/.zshrc
+```
+
+`jitenv hook install` is idempotent — re-running it (or re-installing
+the package) won't duplicate lines. Removing the package leaves the
+hook line in place; the `preremove` script reminds you how to delete
+it manually.
+
+### From source
+
 ```sh
 go install github.com/gv/jitenv/cmd/jitenv@latest
 # or
 git clone https://github.com/gv/jitenv && cd jitenv && make install
+
+# Activate the shell hook
+jitenv hook install
 ```
+
+### Homebrew
+
+A formula is planned alongside the macOS port (see
+[#13](https://github.com/Galvill/jitenv/issues/13)). When it lands, the
+formula will print caveats with the same `jitenv hook install`
+command — Homebrew formulae do not modify a user's shell rc files.
 
 ## Quick start
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,6 +16,13 @@ How releases are cut, how to verify them as a user, and how to recover when the 
 
 That's it. No manual tagging, no manual artifact builds, no manual signing.
 
+The `.deb` and `.rpm` packages run `packaging/postinstall.sh` after
+unpacking — it prints a reminder telling the user to run
+`jitenv hook install` as their own user (the postinst runs as root and
+cannot safely modify a user's `~/.bashrc`). `packaging/preremove.sh`
+prints the matching cleanup hint on uninstall, but stays silent on
+package upgrades.
+
 ## Versioning rules
 
 `bump-minor-pre-major: true` is set in `release-please-config.json`. While we're pre-1.0:

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# postinstall script run by dpkg/rpm after `jitenv` is unpacked.
+#
+# Runs as root, so it cannot safely write into a user's $HOME. We print
+# a clear one-liner instead. `jitenv hook install` is itself idempotent
+# (see internal/shell/install.go), so re-running is always safe.
+
+set -e
+
+cat <<'EOF'
+
+jitenv installed.
+
+To activate the shell hook (env-var injection on mapped commands), run
+ONCE as your normal user (not as root):
+
+    jitenv hook install
+
+Then open a new shell. This appends a single eval line to your
+~/.bashrc or ~/.zshrc and is idempotent on re-run.
+
+To remove the hook later, edit ~/.bashrc / ~/.zshrc and delete the
+line `eval "$(jitenv hook bash)"` (or `... zsh`) along with its
+preceding "# jitenv: …" comment.
+
+EOF
+
+exit 0

--- a/packaging/preremove.sh
+++ b/packaging/preremove.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# preremove script run by dpkg/rpm before `jitenv` is uninstalled.
+#
+# Runs as root, so we can't reach into a user's $HOME to clean up the
+# hook line. Print a reminder on a real removal so the user knows
+# there's manual cleanup left to do — but stay silent on upgrades.
+
+set -e
+
+# dpkg passes "remove" / "upgrade <ver>" / "failed-upgrade <ver>" as $1.
+# rpm passes a numeric arg: "0" = final removal, "1" = upgrade.
+case "${1:-}" in
+    upgrade*|failed-upgrade*|1)
+        exit 0
+        ;;
+esac
+
+cat <<'EOF'
+
+Removing jitenv. The shell hook line in ~/.bashrc / ~/.zshrc was added
+by `jitenv hook install` and is NOT removed automatically — edit those
+files and delete:
+
+    eval "$(jitenv hook bash)"      # or `... zsh`
+
+along with the "# jitenv: …" comment line above it. Bash users who let
+the installer add a guarded `. ~/.bashrc` line to ~/.bash_profile /
+~/.profile may want to remove that line too if jitenv was the only
+reason for it.
+
+EOF
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds `packaging/postinstall.sh` and `packaging/preremove.sh`, wired into the nfpm `scripts:` block in `.goreleaser.yaml`.
- Postinstall prints a one-liner reminding the user to run `jitenv hook install` as their own user. The script does **not** auto-modify shell rc files: deb/rpm postinst runs as root, so any auto-install would touch root's `~/.bashrc` (or guess `SUDO_USER` and silently break for direct-as-root installs).
- Preremove prints cleanup instructions on real removal but stays silent on package upgrades (handles both dpkg `upgrade*` / `failed-upgrade*` args and rpm `1` numeric arg).
- Documents the new install flow in README and notes the postinst behaviour in `docs/RELEASING.md`.

`jitenv hook install` is already idempotent (`internal/shell/install.go`), so re-installing the package or re-running the command never duplicates lines.

Refs #12.

## Test plan
- [x] `make test` — all packages green (no behavioural changes, just packaging).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms the goreleaser config is still valid YAML.
- [x] `sh -n` syntax check on both scripts.
- [x] Reviewer: pull a snapshot via goreleaser and inspect the generated `.deb` / `.rpm` (`dpkg -I` / `rpm -qp --scripts`) to confirm the scripts are embedded.
- [x] Reviewer: smoke-test by installing the snapshot package locally and verifying the postinst message renders.

## Notes / scope
- A `jitenv hook uninstall` command would let preremove clean up automatically, but that's a separate UX change worth its own PR. Filed as a thought to consider after this lands.
- Homebrew formula doesn't exist yet; README mentions the planned shape (caveats with the same install command) and links #13 for the macOS port.