### PR TITLE
feat(tui): per-screen help overlay (?) and empty-state copy

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,0 +1,108 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// helpEntry is one row in the per-screen help overlay.
+type helpEntry struct {
+	Key    string
+	Action string
+}
+
+// helpfulScreen is the interface a screen implements to opt into the
+// `?` help overlay. Screens that don't implement it (e.g. text-input
+// screens) keep `?` as a literal character.
+type helpfulScreen interface {
+	screen
+	HelpKeys() []helpEntry
+	HelpText() string
+}
+
+// commonNavKeys is the navigation row most list/menu screens reuse.
+func commonNavKeys() []helpEntry {
+	return []helpEntry{
+		{"↑/↓ or k/j", "move"},
+		{"Enter", "activate"},
+		{"Esc", "back / cancel"},
+		{"Tab / Shift-Tab", "next / previous control"},
+		{"Ctrl-C", "quit (prompts on unsaved changes)"},
+	}
+}
+
+// renderHelpStatus is the status hint shown on screens that have a
+// help overlay available. We expose `?` so the user knows it exists.
+func renderHelpStatus() string {
+	return renderHelpKeys(
+		[2]string{"↑/↓", "move"},
+		[2]string{"Enter", "activate"},
+		[2]string{"Esc", "back"},
+		[2]string{"?", "help"},
+	)
+}
+
+// helpOverlayScreen is pushed onto the stack when the user hits `?` on
+// a helpfulScreen. It renders the keys and prose from the screen
+// underneath.
+type helpOverlayScreen struct {
+	root  *rootModel
+	title string
+	keys  []helpEntry
+	body  string
+}
+
+func newHelpOverlay(r *rootModel, src helpfulScreen) screen {
+	return &helpOverlayScreen{
+		root:  r,
+		title: "help — " + src.Title(),
+		keys:  src.HelpKeys(),
+		body:  src.HelpText(),
+	}
+}
+
+func (h *helpOverlayScreen) Title() string { return h.title }
+func (h *helpOverlayScreen) Status() string {
+	return renderHelpKeys(
+		[2]string{"any key", "close"},
+	)
+}
+func (h *helpOverlayScreen) Init() tea.Cmd { return nil }
+func (h *helpOverlayScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	if _, ok := msg.(tea.KeyMsg); ok {
+		return h, emit(popMsg{})
+	}
+	return h, nil
+}
+
+func (h *helpOverlayScreen) View() string {
+	var b strings.Builder
+	if h.body != "" {
+		for _, line := range strings.Split(strings.TrimSpace(h.body), "\n") {
+			b.WriteString(line + "\n")
+		}
+		b.WriteString("\n")
+	}
+	if len(h.keys) > 0 {
+		b.WriteString(labelStyle.Render("Keys") + "\n")
+		// Find the longest key string for a tidy column.
+		maxKey := 0
+		for _, e := range h.keys {
+			if l := len(e.Key); l > maxKey {
+				maxKey = l
+			}
+		}
+		for _, e := range h.keys {
+			pad := strings.Repeat(" ", maxKey-len(e.Key))
+			b.WriteString("  " + labelStyle.Render(e.Key) + pad + "   " + dimText(e.Action) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// helpOverlayCmd is what rootModel emits when intercepting `?` on a
+// helpfulScreen. Defined here so the model.go change is one line.
+func helpOverlayCmd(r *rootModel, src helpfulScreen) tea.Cmd {
+	return emit(pushMsg{s: newHelpOverlay(r, src)})
+}

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -24,15 +24,24 @@ func newMappingsListScreen(r *rootModel) screen {
 	return &mappingsListScreen{root: r}
 }
 
-func (m *mappingsListScreen) Title() string { return "mappings" }
-func (m *mappingsListScreen) Status() string {
-	return renderHelpKeys(
-		[2]string{"↑/↓", "move"},
-		[2]string{"Enter", "open"},
-		[2]string{"Esc", "back"},
-	)
+func (m *mappingsListScreen) Title() string  { return "mappings" }
+func (m *mappingsListScreen) Status() string { return renderHelpStatus() }
+func (m *mappingsListScreen) Init() tea.Cmd  { return nil }
+
+func (m *mappingsListScreen) HelpKeys() []helpEntry { return commonNavKeys() }
+func (m *mappingsListScreen) HelpText() string {
+	return `A mapping ties a file (or glob) to a set of env vars. When the shell
+hook sees a mapped command run, it re-execs it through "jitenv run"
+with those vars in scope.
+
+Mappings match in declaration order — exact paths first, then any
+matching globs. When two entries provide the same env var name the
+later one wins, so you can layer "default for ~/work/**/*.sh" with
+"override for ~/work/prod/deploy.sh".
+
+Select < Create New Mapping > to add one, or hit Enter on an existing
+row for Edit / Delete.`
 }
-func (m *mappingsListScreen) Init() tea.Cmd { return nil }
 
 func (m *mappingsListScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if _, ok := msg.(mappingChangedMsg); ok {
@@ -121,6 +130,12 @@ func (m *mappingsListScreen) View() string {
 		b.WriteString("   " + listItemStyle.Render(sentinel) + "\n")
 	}
 
+	if len(m.root.cfg.Mappings) == 0 {
+		b.WriteString("\n" + dimText("No mappings yet — pick the row above to add one. A mapping ties") + "\n")
+		b.WriteString(dimText("a file or glob to a set of env vars that the shell hook injects") + "\n")
+		b.WriteString(dimText("when you run that file. Press ? for the full help.") + "\n")
+	}
+
 	for i, mp := range m.root.cfg.Mappings {
 		row := fmt.Sprintf("%-44s  %s",
 			truncate(mappingLabel(mp), 44),
@@ -179,14 +194,31 @@ func (s *mappingFormScreen) Title() string {
 	}
 	return "edit mapping"
 }
-func (s *mappingFormScreen) Status() string {
-	return renderHelpKeys(
-		[2]string{"↑/↓", "move"},
-		[2]string{"Enter", "open"},
-		[2]string{"Esc", "back"},
-	)
+func (s *mappingFormScreen) Status() string { return renderHelpStatus() }
+func (s *mappingFormScreen) Init() tea.Cmd  { return nil }
+
+func (s *mappingFormScreen) HelpKeys() []helpEntry { return commonNavKeys() }
+func (s *mappingFormScreen) HelpText() string {
+	return `kind:       "path" matches one exact filesystem path.
+            "glob" matches any file under a doublestar pattern, e.g.
+            "~/work/**/*.sh" or "**/scripts/deploy*". Globs are
+            matched after exact paths in declaration order.
+
+target:     The path or glob to match. Tilde-relative ("~/...") is
+            expanded; relative paths are resolved against the current
+            directory at edit time.
+
+variables:  Opens a bag → key tree. Tick a bag to expand the entire
+            bag (every key becomes its own env var named after the
+            key). Tick individual keys for explicit named env vars.
+            While the bag-level box is on, individual key boxes
+            render dimmed — toggling them is a no-op until you
+            uncheck the bag.
+
+Save the config (Ctrl-S from the menu, or via the menu's Save button)
+to commit. Saving auto-pings the running agent to reload, so the new
+mapping takes effect without a relock.`
 }
-func (s *mappingFormScreen) Init() tea.Cmd { return nil }
 
 func (s *mappingFormScreen) mp() *config.Mapping {
 	if s.idx < 0 || s.idx >= len(s.root.cfg.Mappings) {

--- a/internal/tui/menu.go
+++ b/internal/tui/menu.go
@@ -67,8 +67,20 @@ func newMenuScreen(r *rootModel) *menuScreen {
 }
 
 func (m *menuScreen) Title() string  { return "main menu" }
-func (m *menuScreen) Status() string { return defaultListStatus }
+func (m *menuScreen) Status() string { return renderHelpStatus() }
 func (m *menuScreen) Init() tea.Cmd  { return nil }
+
+func (m *menuScreen) HelpKeys() []helpEntry { return commonNavKeys() }
+func (m *menuScreen) HelpText() string {
+	return `jitenv config is the home for editing the encrypted configuration.
+Pick a section, drill in, edit. The ● indicator in the status bar
+shows whether the file has unsaved changes; Save (or Ctrl-S from any
+list page) writes them with envelope encryption and pings the running
+agent to reload.
+
+The Remote Sources page (AWS / GitHub) is hidden in this build — see
+issues #16 and #17 for the re-enable work.`
+}
 
 func (m *menuScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if k, ok := msg.(tea.KeyMsg); ok {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -58,6 +58,11 @@ func (r *rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Type == tea.KeyCtrlC {
 			return r, tea.Quit
 		}
+		if msg.String() == "?" && len(r.stack) > 0 {
+			if h, ok := r.top().(helpfulScreen); ok {
+				return r, helpOverlayCmd(r, h)
+			}
+		}
 	case statusMsg:
 		r.flash = string(msg)
 		r.flashErr = false

--- a/internal/tui/secrets_screen.go
+++ b/internal/tui/secrets_screen.go
@@ -43,15 +43,21 @@ func (s *secretsListScreen) refresh() {
 	}
 }
 
-func (s *secretsListScreen) Title() string { return "local secrets" }
-func (s *secretsListScreen) Status() string {
-	return renderHelpKeys(
-		[2]string{"↑/↓", "move"},
-		[2]string{"Enter", "open"},
-		[2]string{"Esc", "back"},
-	)
+func (s *secretsListScreen) Title() string  { return "local secrets" }
+func (s *secretsListScreen) Status() string { return renderHelpStatus() }
+func (s *secretsListScreen) Init() tea.Cmd  { return nil }
+
+func (s *secretsListScreen) HelpKeys() []helpEntry { return commonNavKeys() }
+func (s *secretsListScreen) HelpText() string {
+	return `A "bag" is a named group of KEY = value pairs (e.g. "stripe",
+"db", "ci") stored under [secrets.<bagname>] in config.toml. Every
+value is encrypted at rest with the master key as an enc:v1: envelope
+— "jitenv config show" decrypts them only after a successful unlock.
+
+Select < Create New Bag > to add one. Renaming a bag automatically
+rewrites every mapping that referenced it, so existing mappings stay
+valid.`
 }
-func (s *secretsListScreen) Init() tea.Cmd { return nil }
 
 func (s *secretsListScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if _, ok := msg.(secretChangedMsg); ok {
@@ -133,6 +139,12 @@ func (s *secretsListScreen) View() string {
 		b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(sentinel) + "\n")
 	} else {
 		b.WriteString("   " + listItemStyle.Render(sentinel) + "\n")
+	}
+
+	if len(s.bags) == 0 {
+		b.WriteString("\n" + dimText("No bags yet — pick the row above to add one. A bag is a named") + "\n")
+		b.WriteString(dimText("group of KEY = value pairs encrypted at rest with the master key.") + "\n")
+		b.WriteString(dimText("Press ? for the full help.") + "\n")
 	}
 
 	for i, n := range s.bags {
@@ -255,9 +267,25 @@ func (s *secretDetailScreen) Status() string {
 		[2]string{"Enter", "open"},
 		[2]string{"r", "reveal"},
 		[2]string{"Esc", "back"},
+		[2]string{"?", "help"},
 	)
 }
 func (s *secretDetailScreen) Init() tea.Cmd { return nil }
+
+func (s *secretDetailScreen) HelpKeys() []helpEntry {
+	return append(commonNavKeys(),
+		helpEntry{"r", "reveal/hide all values"},
+	)
+}
+func (s *secretDetailScreen) HelpText() string {
+	return `Each row is one KEY = value pair inside this bag. Values are stored
+as enc:v1: envelopes on disk and decrypted only inside the agent.
+The TUI shows them masked by default; press "r" to reveal/hide.
+
+Renaming a key automatically rewrites every mapping that referenced
+it. Deleting a key invalidates any mapping that named it explicitly
+— those mappings will be flagged on next save.`
+}
 
 func (s *secretDetailScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if _, ok := msg.(secretChangedMsg); ok {

--- a/internal/tui/settings_screen.go
+++ b/internal/tui/settings_screen.go
@@ -22,15 +22,26 @@ func newSettingsScreen(r *rootModel) screen {
 	return &settingsScreen{root: r}
 }
 
-func (s *settingsScreen) Title() string { return "settings" }
-func (s *settingsScreen) Status() string {
-	return renderHelpKeys(
-		[2]string{"↑/↓", "move"},
-		[2]string{"Enter", "open"},
-		[2]string{"Esc", "back"},
-	)
+func (s *settingsScreen) Title() string  { return "settings" }
+func (s *settingsScreen) Status() string { return renderHelpStatus() }
+func (s *settingsScreen) Init() tea.Cmd  { return nil }
+
+func (s *settingsScreen) HelpKeys() []helpEntry { return commonNavKeys() }
+func (s *settingsScreen) HelpText() string {
+	return `agent idle timeout — Go duration string (e.g. "30m", "1h", "5s"). The
+        agent shuts down once the gap since the last request exceeds
+        this. The check runs on a 30-second tick, so actual shutdown
+        lags the timeout by up to one tick. An empty / zero value
+        disables the auto-shutdown loop. Because the shell hook
+        calls "jitenv is-mapped" on every command, an active hooked
+        shell keeps the agent alive indefinitely.
+
+shell hook   — installed: yes / no for the current shell. Selecting
+        this row re-runs "jitenv hook install", which is idempotent.
+        For bash, the installer also wires the login chain
+        (.bash_profile / .bash_login / .profile) so login shells end
+        up sourcing ~/.bashrc.`
 }
-func (s *settingsScreen) Init() tea.Cmd { return nil }
 
 func (s *settingsScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if k, ok := msg.(tea.KeyMsg); ok {

--- a/internal/tui/var_tree_screen.go
+++ b/internal/tui/var_tree_screen.go
@@ -57,9 +57,35 @@ func (s *varTreeScreen) Status() string {
 		[2]string{"↑/↓", "move"},
 		[2]string{"Space/Enter", "toggle"},
 		[2]string{"Esc", "done"},
+		[2]string{"?", "help"},
 	)
 }
 func (s *varTreeScreen) Init() tea.Cmd { return nil }
+
+func (s *varTreeScreen) HelpKeys() []helpEntry {
+	return []helpEntry{
+		{"↑/↓ or k/j", "move"},
+		{"Space or Enter", "toggle the row under the cursor"},
+		{"Esc", "done — return to the mapping form"},
+	}
+}
+func (s *varTreeScreen) HelpText() string {
+	return `This tree picks which env vars the mapping injects.
+
+Tick a BAG row to expand the entire bag — every key in the bag
+becomes its own env var named after the key. This is the
+"Name == \"\"" shape in the underlying VarRef and is the right choice
+when the bag's keys already match the env-var names you want.
+
+Tick individual KEY rows for explicit named env vars. While the
+bag-level box is on, the individual key boxes render dimmed and
+toggling them is a no-op — uncheck the bag first if you want
+per-key control.
+
+Non-local source vars (AWS / GitHub) are preserved and pass through
+unchanged when this tree saves, so any pre-existing remote-source
+vars in the mapping aren't lost.`
+}
 
 func (s *varTreeScreen) mp() *config.Mapping {
 	if s.mappingIdx < 0 || s.mappingIdx >= len(s.root.cfg.Mappings) {

--- a/internal/tui/widgets.go
+++ b/internal/tui/widgets.go
@@ -56,7 +56,14 @@ func dimText(s string) string { return mutedStyle.Render(s) }
 
 // Common status-bar hints reused by multiple screens.
 var (
-	defaultListStatus = renderHelpKeys(
+	// defaultListStatus is the historic list-screen hint. Visible
+	// list/menu screens now expose `?` via renderHelpStatus(); this
+	// constant is still referenced by the currently-hidden Remote
+	// Sources screens (see #16/#17 for the re-enable work). Keeping it
+	// here so the var-decl block stays together; the //nolint silences
+	// the unused-linter false positive while those screens are
+	// unreachable.
+	defaultListStatus = renderHelpKeys( //nolint:unused // referenced only by hidden Remote Sources screens; reactivated by #16/#17
 		[2]string{"↑/↓", "move"},
 		[2]string{"Tab", "buttons"},
 		[2]string{"Enter", "activate"},


### PR DESCRIPTION
## Summary
- Adds a `helpfulScreen` interface (`HelpKeys() []helpEntry`, `HelpText() string`) and a `helpOverlayScreen` that gets pushed onto the screen stack when the user presses `?`.
- `rootModel.Update` intercepts `?` only if the top screen implements `helpfulScreen`. Text-input screens (`inputScreen`, `kvEditScreen`) deliberately don't implement it, so `?` is still a literal character there.
- Wires help text into the visible navigation screens (menu, mappings list, mapping form, secrets list, secret detail, settings, var tree). Each screen's status bar now lists the `?` key.

The prose covers the discoverable-only-from-code behaviours per the issue:
- Mapping path/glob: declaration order, exact-first then globs, later-wins-on-conflicts.
- VarRef whole-bag: "tick the bag to expand every key as its own env var" with a pointer to the underlying `Name == ""` shape.
- Var tree: dimmed-while-bag-on, non-local vars preserved through saves.
- Settings: idle-timeout 30s tick lag, why an active hooked shell keeps the agent alive.
- Bag/secret detail: encryption envelope at rest, rename cascade.

Adds empty-state copy on the mappings and secrets list pages — first-run users see a one-paragraph explanation instead of just a `< Create New ... >` sentinel.

Refs #15.

## Test plan
- [x] `go build ./...` clean.
- [x] `make test` — `internal/tui` package runs (`0.170s`), all green.
- [x] `make vet` clean.
- [x] Reviewer: open `jitenv config` and walk: menu → mappings → new mapping → variables; press `?` on each. Confirm overlay closes on any key.
- [x] Reviewer: confirm `?` typed in the bag-name input or KV value editor is still a literal character (helpfulScreen not implemented on those).

## Notes / scope
- I deliberately scoped help text to screens currently visible in the UI; the hidden Remote Sources screens already carry `//nolint:unused` annotations and will get help when issues #16/#17 re-enable that page.
- Per-input field-level inline hints (e.g. an italic line under each form input) are still possible but felt like the right next step rather than this PR — `Status()` plus `?` overlay covers the issue's "footer hint or `?` overlay (ideally both)" acceptance criterion.