### PR TITLE
fix(tui): wire remote-source variables into the mapping form

### DIFF
--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -332,7 +333,83 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 }
 
 func (s *mappingFormScreen) openVarTree() tea.Cmd {
-	return emit(pushMsg{s: newVarTreeScreen(s.root, s.idx)})
+	remotes := remoteSourceNames(s.root)
+	if len(remotes) == 0 {
+		return emit(pushMsg{s: newVarTreeScreen(s.root, s.idx)})
+	}
+	choices := []string{"Local secrets…"}
+	for _, n := range remotes {
+		choices = append(choices, "Add from "+n+"…")
+	}
+	choices = append(choices, "Back")
+	cb := func(choice string) tea.Cmd {
+		switch {
+		case choice == "Local secrets…":
+			return tea.Sequence(emit(popMsg{}),
+				emit(pushMsg{s: newVarTreeScreen(s.root, s.idx)}))
+		case strings.HasPrefix(choice, "Add from "):
+			name := strings.TrimSuffix(strings.TrimPrefix(choice, "Add from "), "…")
+			return tea.Sequence(emit(popMsg{}),
+				s.startRemoteVarWizard(name))
+		}
+		return emit(popMsg{})
+	}
+	return emit(pushMsg{s: newPopupMenuScreen(s.root,
+		"Variables", cb, choices...)})
+}
+
+// startRemoteVarWizard launches the var wizard pre-seeded with the
+// chosen source. The wizard's onComplete appends the finished VarRef to
+// this mapping and unwinds back to the form.
+func (s *mappingFormScreen) startRemoteVarWizard(sourceName string) tea.Cmd {
+	idx := s.idx
+	onComplete := func(ref config.VarRef) tea.Cmd {
+		mp := s.mp()
+		if mp == nil {
+			return emit(popMsg{})
+		}
+		// If a var with the same source/ref/key/name already exists,
+		// replace it; otherwise append. Keeps re-running the wizard
+		// for the same target idempotent.
+		replaced := false
+		for i, existing := range mp.Vars {
+			if existing.Source == ref.Source && existing.Ref == ref.Ref &&
+				existing.Key == ref.Key && existing.Name == ref.Name {
+				mp.Vars[i] = ref
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			mp.Vars = append(mp.Vars, ref)
+		}
+		// Unwind every wizard screen back to the mapping form.
+		isForm := func(scr screen) bool {
+			f, ok := scr.(*mappingFormScreen)
+			return ok && f.idx == idx
+		}
+		return tea.Sequence(
+			emit(popUntilMsg{pred: isForm}),
+			emit(dirtyMsg{}),
+			emit(mappingChangedMsg{}),
+			emit(statusMsg(fmt.Sprintf("added %s ← %s", ref.Name, ref.Source))),
+		)
+	}
+	return startVarWizard(s.root, config.VarRef{Source: sourceName}, onComplete)
+}
+
+// remoteSourceNames returns the sorted list of configured non-local
+// source names (managed types like local/noop are excluded).
+func remoteSourceNames(r *rootModel) []string {
+	var out []string
+	for n, sc := range r.cfg.Sources {
+		if isManagedSourceType(sc.Type) {
+			continue
+		}
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func (s *mappingFormScreen) View() string {
@@ -370,25 +447,41 @@ func (s *mappingFormScreen) View() string {
 			b.WriteString("   " + listItemStyle.Render(line) + "\n")
 		}
 	}
+	if remotes := remoteVarSummary(s.root, mp); len(remotes) > 0 {
+		b.WriteString("\n" + dimText("Remote variables:") + "\n")
+		for _, r := range remotes {
+			b.WriteString("   " + dimText("• "+r) + "\n")
+		}
+	}
 	return b.String()
 }
 
+// remoteVarSummary returns a one-line summary per non-local VarRef in
+// the mapping, for read-only display on the mapping form.
+func remoteVarSummary(r *rootModel, mp *config.Mapping) []string {
+	var out []string
+	for _, v := range mp.Vars {
+		sc, ok := r.cfg.Sources[v.Source]
+		if ok && sc.Type == "local" {
+			continue
+		}
+		out = append(out, summariseVar(r, v))
+	}
+	return out
+}
+
 // localVarCount counts how many env vars this mapping currently
-// produces from the local-secret store. Bag-level (expand-all) entries
-// count as the bag's key count; individual keys count as 1 each.
-// Non-local vars are not counted because they are managed elsewhere.
+// produces. Local bag-level (expand-all) entries count as the bag's
+// key count; everything else counts as 1.
 func localVarCount(r *rootModel, mp *config.Mapping) int {
 	n := 0
 	for _, v := range mp.Vars {
 		sc, ok := r.cfg.Sources[v.Source]
-		if !ok || sc.Type != "local" {
+		if ok && sc.Type == "local" && v.Key == "" {
+			n += len(r.cfg.Secrets[v.Ref])
 			continue
 		}
-		if v.Key == "" {
-			n += len(r.cfg.Secrets[v.Ref])
-		} else {
-			n++
-		}
+		n++
 	}
 	return n
 }


### PR DESCRIPTION
## Summary

The mapping form's **variables** row only opened `newVarTreeScreen`, which is local-only. AWS- and GitHub-source vars had no entry point — users could configure the source, click *Test* and see "connection OK", and then have nowhere to actually pick a variable.

When at least one non-local source is configured, the variables row now opens a small popup menu:

```
Local secrets…
Add from <source-name>…           (one per remote source)
Back
```

Picking a remote entry launches the existing `var_wizard` (`startVarWizard` → `pickSourceStep` → `dispatchByType` → AWS generic flow / GitHub scope flow) pre-seeded with that source. The wizard's `onComplete`:

- Appends the finished `VarRef` to the mapping (replacing one with the same source/ref/key/name to keep re-runs idempotent).
- `popUntilMsg` back to the mapping form, skipping past the popup, source picker, and any input screens in between.
- Emits `dirtyMsg` + `mappingChangedMsg` so the form's "N selected" count refreshes.

Adds a read-only "Remote variables:" listing under the form rows (using the existing `summariseVar` helper) so the user can verify what they added without diving back into the wizard.

`localVarCount` is updated to count non-local vars too — single-key remote refs as 1, local bag-expands as the bag's key count. The header counter stays accurate.

Single-source local-only configs are unchanged: the popup is skipped and the var-tree opens directly.

## Test plan
- [x] `make test` — green.
- [x] `golangci-lint run ./...` clean.
- [ ] Reviewer: configure an AWS source, hit Test → OK. Open / create a mapping. On the variables row press Enter; the popup should now show "Local secrets…", "Add from <aws-source>…", "Back".
- [ ] Reviewer: walk the wizard (Identifier → optional sub-key → env var name) and confirm landing back on the mapping form with the new var listed under "Remote variables:" and the count incremented.
- [ ] Reviewer: same flow for GitHub source (scope picker → owner/repo → variable name → env name).
- [ ] Reviewer: configure NO remote sources and confirm the variables row still opens the local var-tree directly (no popup).

## Follow-up scope (intentionally not in this PR)
- Editing or removing an existing remote VarRef from the mapping. The form lists them read-only; today removal still requires editing `config.toml` by hand or re-creating the mapping.
- The `//nolint:unused` markers in `var_wizard.go` are now redundant (the wizard is reachable). They're harmless under the current linter set; cleaning them up is a separate cosmetic PR.