### PR TITLE
feat: cwd_glob mapping kind + bash hook completion fix

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -65,19 +65,59 @@ The "expand" shape is the one most people miss reading the schema.
 It's exactly what the TUI's "tick the bag" mode produces — useful when
 a bag's keys already match the env var names you want.
 
-## Path vs. glob
+## Mapping kinds: path, glob, cwd_glob
 
-A mapping's target is either a `path` (string, absolute or
-`~`-relative) or a `glob` (matched with [doublestar](https://github.com/bmatcuk/doublestar/v4)).
+A mapping picks **one** target shape:
 
-- Path matches are exact and faster.
-- Glob patterns support `**` (recursive), `*`, `?`, `[…]` and curly
-  alternation. Common useful patterns: `~/work/**/*.sh`,
-  `**/scripts/deploy*`.
-- Lookup order is **declaration order**: exact paths first, then each
-  matching glob. When two entries provide the same env var name, the
-  later one wins. This is intentional — a glob can supply defaults
-  while a more specific path overrides individual vars.
+- `path` — exact filesystem path. Fast lookup.
+- `glob` — [doublestar](https://github.com/bmatcuk/doublestar/v4)
+  pattern matched against the executed file's resolved path. Supports
+  `**`, `*`, `?`, `[…]` and curly alternation. Common patterns:
+  `~/work/**/*.sh`, `**/scripts/deploy*`.
+- `cwd_glob` — pattern matched against `$PWD` (and any ancestor). For
+  cwd mappings the shell hook intercepts **bare-PATH commands**
+  (`npm`, `python`, `bundle`, …) run from inside the matched directory
+  — useful for "anything I run inside this project gets the project's
+  env vars". An optional `command = "<bare-name>"` field scopes the
+  mapping to a single command; empty means every command run inside
+  the matched cwd.
+
+Lookup order is **declaration order** within each kind: exact paths
+first, then each matching glob, then each matching cwd_glob. When two
+entries provide the same env var name, the later one wins — so a
+glob can supply defaults while a more specific path overrides
+individual vars.
+
+```toml
+# Anything run inside ~/work/acme gets ACME_API_TOKEN.
+[[mappings]]
+cwd_glob = "~/work/acme"
+[[mappings.vars]]
+name   = "ACME_API_TOKEN"
+source = "local"
+ref    = "acme"
+key    = "API_TOKEN"
+
+# Only npm in that directory needs the registry token.
+[[mappings]]
+cwd_glob = "~/work/acme"
+command  = "npm"
+[[mappings.vars]]
+name   = "NPM_TOKEN"
+source = "local"
+ref    = "acme"
+key    = "NPM_TOKEN"
+```
+
+### Performance: the has-cwd sentinel
+
+The bash and zsh hooks short-circuit on bare-PATH commands when no
+cwd_glob mapping is configured, so users who never use cwd mappings
+pay zero overhead. The agent maintains a tiny sentinel file at
+`$XDG_RUNTIME_DIR/jitenv/has-cwd` (or `$TMPDIR/jitenv-<uid>/has-cwd`)
+when at least one cwd_glob mapping exists; the hook checks for the
+file's existence (one stat) before spending a socket round-trip. The
+sentinel is created on agent start and refreshed on every reload.
 
 ## Agent
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -118,6 +118,45 @@ Atomic save via `config.AtomicSave` (sibling tempfile + rename, mode
   fiddling and offers little against the local-root threat that
   actually matters.
 
+## cwd_glob mappings widen the blast radius
+
+Path and glob mappings only inject env vars into the *one specific
+file* you executed — same one-process boundary as `jitenv run`. A
+cwd_glob mapping is broader: **every command run inside the matched
+directory** that matches the optional `command` filter gets the env
+vars. The boundary is now "one descendant process at a time", but
+the set of triggering commands is anything you (or anything you run)
+types in that directory.
+
+What's still protected:
+
+- The parent shell never has the secrets in its own environ. Each
+  triggering command gets them at exec, and they live in that
+  child's process tree only.
+- `cd`-ing out of the mapped directory in the calling shell does
+  **not** strip the secrets from already-running children — they
+  inherited them at spawn time, exactly like manual exports work.
+- The hook's `command` filter (when set) restricts firing to that
+  bare name. `command = "npm"` will not fire for `git`, `ls`, or
+  anything else even inside the matched cwd.
+
+What to be aware of:
+
+- Inside a matched cwd, **any** command (or the optional
+  `command`-scoped one) gets the secrets. If a malicious binary on
+  your `$PATH` is invocable from there, it gets injected too. Treat
+  cwd_glob like a per-directory `.envrc` — same trust model as
+  `direnv` for the broadening, but secrets still don't leak into the
+  parent shell.
+- The agent maintains a tiny sentinel file
+  (`$XDG_RUNTIME_DIR/jitenv/has-cwd`) so the hook can skip the
+  bare-PATH branch entirely when no cwd_glob mapping exists. With at
+  least one cwd_glob configured, the hook does a `stat` per command
+  + a Unix-socket round-trip on miss; sub-millisecond, but not zero.
+
+If you don't want this widening, simply don't define any `cwd_glob`
+mapping — the hook reverts to its zero-overhead exec-only behaviour.
+
 ## Why this design over `.env` files
 
 A `.env` file in your project (or `direnv`-style auto-export) puts

--- a/docs/shell-hook.md
+++ b/docs/shell-hook.md
@@ -44,19 +44,37 @@ at a known path that's covered by a mapping.
 
 ## The exit-code contract
 
-The hook calls `jitenv is-mapped <path>` and switches on its exit
-code. **All three branches matter** — collapsing 2 into 1 would be a
-bug:
+The hook calls `jitenv is-mapped <path>` and switches on its exit code:
 
 | Code | Meaning | Hook behaviour |
 |---|---|---|
 | **0** | mapped | Re-run the command via `jitenv run` so the env vars are injected. |
 | **1** | not mapped | Run the command normally — no jitenv involvement. |
-| **2** | agent unreachable | Print a red 10-second warning. Ctrl+C aborts; otherwise the original command runs (with no env-var injection). This is the "agent is locked" UX path. |
+| **2** | agent unreachable | (See "agent-absence short-circuit" below.) |
 
 You can see the dispatch in `internal/shell/snippets/bash.sh`. Set
 `JITENV_HOOK_DEBUG=1` in your shell to see which branch the trap
 took for each command.
+
+### Agent-absence short-circuit
+
+Before any of the dispatch above, the hook stat-checks the agent's
+unix socket. If the socket file isn't there (because `jitenv lock`
+removed it on shutdown), the trap **returns immediately**. No socket
+dial, no `is-mapped` process spawn, no warning.
+
+This matters because the bash DEBUG trap fires on every simple command
+bash is about to execute — including the dozens that PROMPT_COMMAND,
+prompt-side `$()`s, aliases that expand to absolute paths, and
+`~/bin/...` substitutions inject between user keystrokes. Without the
+short-circuit, each of those would dial the agent (and on a path
+mismatch, paint the red countdown), turning a locked agent into
+many-warnings-per-prompt spam.
+
+The trade-off: when the agent is locked, mapped scripts run silently
+without their env vars — there's no in-band notification that you
+forgot to unlock. Confirm with `jitenv status` if a mapped script's
+behaviour looks off.
 
 ## Bash internals: `extdebug` + DEBUG trap
 
@@ -81,20 +99,23 @@ zsh's `BUFFER`/`zle` machinery. Same exit-code contract.
 2. If yes but you're in a login shell (e.g. SSH), check the
    `login chain:` line. If it says "does NOT source ~/.bashrc",
    re-run `jitenv hook install` to add the guarded source line.
-3. `jitenv unlock` — is the agent up? An unmapped command with a
-   locked agent is fine; a mapped command with a locked agent prints
-   the red warning. Either way, an unconfigured-but-installed hook
-   never breaks unrelated commands.
+3. `jitenv unlock` — is the agent up? With a locked agent the hook
+   short-circuits silently for every command (see "agent-absence
+   short-circuit" above). Mapped scripts run without their env
+   vars; `jitenv status` will tell you the agent's state.
 
 ### "I get a long pause on every command"
 
 Set `JITENV_HOOK_DEBUG=1` and run a command. You should see exactly
 one `is-mapped rc=` line per command, with rc=1 (not mapped) for
-unrelated commands. If the rc is 2 (agent unreachable), every
-command is paying the 10-second timeout — `jitenv unlock` to fix.
+unrelated commands. If you're seeing more than one log line per
+command, your `PROMPT_COMMAND` or PS1 contains commands that the
+DEBUG trap fires on — each one pays a sub-millisecond round-trip on
+an unlocked agent, which can add up if there are many.
 
-The default 10s wait is configurable: `JITENV_HOOK_DELAY=2` in your
-shell shortens it to 2 seconds.
+The agent-down warning that older versions printed is gone; if a
+locked agent is the cause, the hook stays silent (see the
+short-circuit section above).
 
 ### "Why does the hook ignore `deploy.sh` when I'm in `./scripts/`?"
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,16 +4,17 @@ The fixes for the things that go wrong most often. If your symptom
 isn't here, check `jitenv hook status` and `jitenv status` first;
 those answer 80% of "why isn't it working".
 
-## "Agent unreachable" — red countdown on every command
+## "My mapped script ran but its env vars are empty"
 
-Your shell hook is installed, but the agent isn't running.
-`jitenv unlock`, type your passphrase, done. If unlock itself fails
-with "agent did not start within 3s", read the agent log — by
-default it's at `${XDG_RUNTIME_DIR}/jitenv/agent.log`, and at
+Almost certainly the agent isn't unlocked. The shell hook
+short-circuits silently when the agent socket isn't there, so
+mapped scripts will execute without their env vars when the agent is
+locked. Run `jitenv status` to confirm, then `jitenv unlock`.
+
+If unlock itself fails with "agent did not start within 3s", read
+the agent log — by default it's at
+`${XDG_RUNTIME_DIR}/jitenv/agent.log`, and at
 `/tmp/jitenv-<uid>/agent.log` if `XDG_RUNTIME_DIR` is unset.
-
-To temporarily silence the warning while you debug, `JITENV_HOOK_DELAY=0`
-in the shell.
 
 ## Hook installed, but mapped commands aren't intercepted
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -29,10 +29,15 @@ type fakeResolver struct {
 	env    map[string]map[string]string
 }
 
-func (f *fakeResolver) Sources() []string      { return []string{"fake"} }
-func (f *fakeResolver) IsMapped(p string) bool { return f.mapped[p] }
+func (f *fakeResolver) Sources() []string            { return []string{"fake"} }
+func (f *fakeResolver) IsMapped(p string) bool       { return f.mapped[p] }
+func (f *fakeResolver) HasCwdMappings() bool         { return false }
+func (f *fakeResolver) IsMappedCwd(_, _ string) bool { return false }
 func (f *fakeResolver) FetchEnv(_ context.Context, p string) (map[string]string, error) {
 	return f.env[p], nil
+}
+func (f *fakeResolver) FetchEnvCwd(_ context.Context, _, _ string) (map[string]string, error) {
+	return nil, nil
 }
 
 func TestAgentStatusAndLock(t *testing.T) {

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -66,8 +66,27 @@ func (c *Client) IsMapped(ctx context.Context, path string) (bool, error) {
 	return r.Mapped, nil
 }
 
+// IsMappedCwd is the cwd_glob counterpart to IsMapped: returns whether
+// any cwd-keyed mapping matches (pwd, command).
+func (c *Client) IsMappedCwd(ctx context.Context, pwd, command string) (bool, error) {
+	r, err := c.call(ctx, Request{Op: OpIsMapped, Cwd: pwd, Command: command})
+	if err != nil {
+		return false, err
+	}
+	return r.Mapped, nil
+}
+
 func (c *Client) FetchEnv(ctx context.Context, path string) (map[string]string, error) {
 	r, err := c.call(ctx, Request{Op: OpFetchEnv, Path: path})
+	if err != nil {
+		return nil, err
+	}
+	return r.Env, nil
+}
+
+// FetchEnvCwd is the cwd_glob counterpart to FetchEnv.
+func (c *Client) FetchEnvCwd(ctx context.Context, pwd, command string) (map[string]string, error) {
+	r, err := c.call(ctx, Request{Op: OpFetchEnv, Cwd: pwd, Command: command})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/has_cwd_test.go
+++ b/internal/agent/has_cwd_test.go
@@ -1,0 +1,111 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// fakeCwdResolver is a stand-in resolver whose HasCwdMappings flag we
+// can flip so the agent's sentinel-file logic is observable in tests.
+type fakeCwdResolver struct{ hasCwd bool }
+
+func (f *fakeCwdResolver) Sources() []string               { return nil }
+func (f *fakeCwdResolver) IsMapped(string) bool            { return false }
+func (f *fakeCwdResolver) HasCwdMappings() bool            { return f.hasCwd }
+func (f *fakeCwdResolver) IsMappedCwd(string, string) bool { return false }
+func (f *fakeCwdResolver) FetchEnv(context.Context, string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeCwdResolver) FetchEnvCwd(context.Context, string, string) (map[string]string, error) {
+	return nil, nil
+}
+
+// TestHasCwdSentinelLifecycle covers the user-reported flow: a cwd
+// mapping is configured, Listen creates the has-cwd sentinel; Lock
+// (or Shutdown) must remove it so the bash hook's bare-PATH branch
+// short-circuits silently rather than calling the agent.
+func TestHasCwdSentinelLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+	paths, err := DefaultPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	flag := filepath.Join(paths.Dir, "has-cwd")
+
+	res := &fakeCwdResolver{hasCwd: true}
+	a := NewAgent(paths, 0, res)
+	if err := a.Listen(); err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if _, err := os.Stat(flag); err != nil {
+		t.Errorf("after Listen: expected has-cwd to exist; got %v", err)
+	}
+
+	go a.Serve(context.Background()) //nolint:errcheck
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(paths.Socket); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	a.Shutdown()
+	if _, err := os.Stat(flag); !os.IsNotExist(err) {
+		t.Errorf("after Shutdown: expected has-cwd removed; stat returned %v", err)
+	}
+}
+
+// TestRefreshCwdSentinel_ConfigChange covers the OpReload path: a new
+// config without cwd mappings should remove the sentinel even if the
+// previous config had one.
+func TestRefreshCwdSentinel_ConfigChange(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+	paths, _ := DefaultPaths()
+	flag := filepath.Join(paths.Dir, "has-cwd")
+
+	a := NewAgent(paths, 0, &fakeCwdResolver{hasCwd: true})
+	if err := a.Listen(); err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer a.Shutdown()
+
+	if _, err := os.Stat(flag); err != nil {
+		t.Fatalf("sentinel missing after Listen: %v", err)
+	}
+
+	// Simulate reload returning a resolver with no cwd mappings.
+	a.SetReload(func() (Resolver, error) {
+		return &fakeCwdResolver{hasCwd: false}, nil
+	})
+
+	// Drive the OpReload path the same way dispatch does.
+	a.mu.Lock()
+	fn := a.reload
+	a.mu.Unlock()
+	next, err := fn()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	a.mu.Lock()
+	a.resolver = next
+	a.mu.Unlock()
+	a.refreshCwdSentinel()
+
+	if _, err := os.Stat(flag); !os.IsNotExist(err) {
+		t.Errorf("after reload removing cwd mappings, expected sentinel gone; got %v", err)
+	}
+}
+
+// Compile-time guard: the fake satisfies the full Resolver interface.
+var _ Resolver = (*fakeCwdResolver)(nil)
+
+// silence the import.
+var _ = config.Version

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -21,6 +21,10 @@ const (
 type Request struct {
 	Op   Op     `json:"op"`
 	Path string `json:"path,omitempty"`
+	// Cwd + Command, when both set, switch is_mapped / fetch_env to the
+	// cwd_glob lookup. Path is ignored in that case.
+	Cwd     string `json:"cwd,omitempty"`
+	Command string `json:"command,omitempty"`
 }
 
 type Response struct {

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -63,12 +63,29 @@ func (r *resolver) IsMapped(absPath string) bool {
 	return r.index.Mapped(abs)
 }
 
+func (r *resolver) HasCwdMappings() bool {
+	return r.index.HasCwdMappings()
+}
+
+func (r *resolver) IsMappedCwd(pwd, command string) bool {
+	return r.index.MappedCwd(pwd, command)
+}
+
+func (r *resolver) FetchEnvCwd(ctx context.Context, pwd, command string) (map[string]string, error) {
+	return r.fetchVars(ctx, r.index.LookupCwd(pwd, command))
+}
+
 func (r *resolver) FetchEnv(ctx context.Context, absPath string) (map[string]string, error) {
 	abs, err := filepath.Abs(absPath)
 	if err != nil {
 		abs = absPath
 	}
-	vars := r.index.Lookup(abs)
+	return r.fetchVars(ctx, r.index.Lookup(abs))
+}
+
+// fetchVars runs the existing per-VarRef Fetch loop. Shared between
+// path-keyed FetchEnv and cwd-keyed FetchEnvCwd.
+func (r *resolver) fetchVars(ctx context.Context, vars []config.VarRef) (map[string]string, error) {
 	out := map[string]string{}
 	for _, v := range vars {
 		s, ok := r.sources[v.Source]

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -36,11 +37,17 @@ type Agent struct {
 }
 
 // Resolver is the agent-internal hook to resolve mapping + fetch env vars.
-// Step 5 leaves this nil; step 10 wires it up.
 type Resolver interface {
 	Sources() []string
 	IsMapped(absPath string) bool
 	FetchEnv(ctx context.Context, absPath string) (map[string]string, error)
+
+	// HasCwdMappings reports whether any cwd_glob mapping is
+	// configured. The agent uses this to maintain the has-cwd
+	// sentinel file the shell hooks check.
+	HasCwdMappings() bool
+	IsMappedCwd(pwd, command string) bool
+	FetchEnvCwd(ctx context.Context, pwd, command string) (map[string]string, error)
 }
 
 // NewAgent constructs an Agent ready to Serve.
@@ -84,7 +91,23 @@ func (a *Agent) Listen() error {
 		return err
 	}
 	a.listener = ln
+	a.refreshCwdSentinel()
 	return WritePidFile(a.paths.PidFile, os.Getpid())
+}
+
+// refreshCwdSentinel writes (or removes) the has-cwd file that the
+// shell hooks use to decide whether to pay the cost of asking the
+// agent on every bare-PATH command. Called from Listen and after a
+// successful Reload; safe to call concurrently because it only
+// writes/removes one file in the per-user runtime dir.
+func (a *Agent) refreshCwdSentinel() {
+	flag := filepath.Join(a.paths.Dir, "has-cwd")
+	r := a.currentResolver()
+	if r != nil && r.HasCwdMappings() {
+		_ = os.WriteFile(flag, nil, 0600)
+		return
+	}
+	_ = os.Remove(flag)
 }
 
 // Serve runs the accept loop until ctx is cancelled or Shutdown is called.
@@ -127,6 +150,7 @@ func (a *Agent) Shutdown() {
 	}
 	_ = os.Remove(a.paths.Socket)
 	_ = RemovePidFile(a.paths.PidFile)
+	_ = os.Remove(filepath.Join(a.paths.Dir, "has-cwd"))
 }
 
 func (a *Agent) idleLoop(ctx context.Context) {
@@ -229,13 +253,24 @@ func (a *Agent) dispatch(ctx context.Context, req Request) Response {
 		if r == nil {
 			return Response{OK: true, Mapped: false}
 		}
+		if req.Cwd != "" {
+			return Response{OK: true, Mapped: r.IsMappedCwd(req.Cwd, req.Command)}
+		}
 		return Response{OK: true, Mapped: r.IsMapped(req.Path)}
 	case OpFetchEnv:
 		r := a.currentResolver()
 		if r == nil {
 			return Response{OK: true, Env: map[string]string{}}
 		}
-		env, err := r.FetchEnv(ctx, req.Path)
+		var (
+			env map[string]string
+			err error
+		)
+		if req.Cwd != "" {
+			env, err = r.FetchEnvCwd(ctx, req.Cwd, req.Command)
+		} else {
+			env, err = r.FetchEnv(ctx, req.Path)
+		}
 		if err != nil {
 			return Response{OK: false, Error: err.Error()}
 		}
@@ -254,6 +289,7 @@ func (a *Agent) dispatch(ctx context.Context, req Request) Response {
 		a.mu.Lock()
 		a.resolver = next
 		a.mu.Unlock()
+		a.refreshCwdSentinel()
 		return Response{OK: true}
 	default:
 		return Response{OK: false, Error: fmt.Sprintf("unknown op %q", req.Op)}

--- a/internal/cli/ismapped.go
+++ b/internal/cli/ismapped.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,17 +13,28 @@ import (
 )
 
 func newIsMappedCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:           "is-mapped <path>",
-		Short:         "Exit 0 if path is mapped to env vars in the running agent",
-		Args:          cobra.ExactArgs(1),
+	var (
+		cwd string
+		cmd string
+	)
+	c := &cobra.Command{
+		Use: "is-mapped <path>",
+		Short: "Exit 0 if a mapping matches; 1 if not; 2 if the agent is unreachable. " +
+			"With --cwd / --cmd, queries the cwd_glob lookup instead of a file path.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			abs, err := filepath.Abs(args[0])
-			if err != nil {
-				return err
+		Args: func(cmd *cobra.Command, args []string) error {
+			pwdMode, _ := cmd.Flags().GetString("cwd")
+			cmdName, _ := cmd.Flags().GetString("cmd")
+			if pwdMode != "" || cmdName != "" {
+				if len(args) > 0 {
+					return errors.New("--cwd/--cmd takes no positional argument")
+				}
+				return nil
 			}
+			return cobra.ExactArgs(1)(cmd, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
 			paths, err := agent.DefaultPaths()
 			if err != nil {
 				return err
@@ -30,7 +42,17 @@ func newIsMappedCmd() *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			cli := agent.NewClient(paths.Socket)
-			ok, err := cli.IsMapped(ctx, abs)
+
+			var ok bool
+			if cwd != "" {
+				ok, err = cli.IsMappedCwd(ctx, cwd, cmd)
+			} else {
+				abs, aerr := filepath.Abs(args[0])
+				if aerr != nil {
+					return aerr
+				}
+				ok, err = cli.IsMapped(ctx, abs)
+			}
 			if err != nil {
 				os.Exit(2) // agent unreachable
 			}
@@ -40,4 +62,7 @@ func newIsMappedCmd() *cobra.Command {
 			return nil
 		},
 	}
+	c.Flags().StringVar(&cwd, "cwd", "", "current working directory to check (cwd_glob lookup)")
+	c.Flags().StringVar(&cmd, "cmd", "", "command name to scope the cwd lookup (optional)")
+	return c
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 
 	"github.com/spf13/cobra"
 
@@ -10,18 +11,64 @@ import (
 
 func newRunCmd() *cobra.Command {
 	c := &cobra.Command{
-		Use:                "run <file> [args...]",
-		Short:              "Fetch env vars and execute <file>",
-		Args:               cobra.MinimumNArgs(1),
+		Use:                "run <file> [args...]   |   run --cwd <pwd> --cmd <name> [args...]",
+		Short:              "Fetch env vars and execute <file>; or, with --cwd/--cmd, resolve <name> on $PATH",
+		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Strip our own flags out of args (DisableFlagParsing means
-			// we receive everything verbatim, which is what we want for
-			// passthrough to the child).
-			file := args[0]
-			rest := args[1:]
-			return run.Run(context.Background(), file, rest)
+			cwd, cmdName, rest, err := splitRunArgs(args)
+			if err != nil {
+				return err
+			}
+			if cwd != "" {
+				return run.RunCwd(context.Background(), cwd, cmdName, rest)
+			}
+			if len(rest) == 0 {
+				return errors.New("run requires a file or --cwd/--cmd")
+			}
+			file := rest[0]
+			return run.Run(context.Background(), file, rest[1:])
 		},
 	}
 	return c
+}
+
+// splitRunArgs walks the verbatim argv `jitenv run` was given and pulls
+// out --cwd / --cmd flags. Everything else is returned as the
+// pass-through tail. We do this by hand because DisableFlagParsing is
+// on — needed so the user can pass `--something` to the wrapped
+// command without cobra eating it.
+func splitRunArgs(args []string) (cwd, cmd string, rest []string, err error) {
+	rest = make([]string, 0, len(args))
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		switch {
+		case a == "--cwd":
+			if i+1 >= len(args) {
+				return "", "", nil, errors.New("--cwd requires a value")
+			}
+			cwd = args[i+1]
+			i += 2
+		case len(a) > len("--cwd=") && a[:len("--cwd=")] == "--cwd=":
+			cwd = a[len("--cwd="):]
+			i++
+		case a == "--cmd":
+			if i+1 >= len(args) {
+				return "", "", nil, errors.New("--cmd requires a value")
+			}
+			cmd = args[i+1]
+			i += 2
+		case len(a) > len("--cmd=") && a[:len("--cmd=")] == "--cmd=":
+			cmd = a[len("--cmd="):]
+			i++
+		case a == "--":
+			rest = append(rest, args[i+1:]...)
+			i = len(args)
+		default:
+			rest = append(rest, a)
+			i++
+		}
+	}
+	return cwd, cmd, rest, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,9 +41,24 @@ type SourceConfig struct {
 }
 
 type Mapping struct {
-	Path string   `toml:"path,omitempty"`
-	Glob string   `toml:"glob,omitempty"`
-	Vars []VarRef `toml:"vars"`
+	Path    string   `toml:"path,omitempty"`
+	Glob    string   `toml:"glob,omitempty"`
+	CwdGlob string   `toml:"cwd_glob,omitempty"`
+	Command string   `toml:"command,omitempty"` // optional, only valid with CwdGlob
+	Vars    []VarRef `toml:"vars"`
+}
+
+// Kind reports which match-shape a mapping uses.
+func (m Mapping) Kind() string {
+	switch {
+	case m.Path != "":
+		return "path"
+	case m.Glob != "":
+		return "glob"
+	case m.CwdGlob != "":
+		return "cwd"
+	}
+	return ""
 }
 
 type VarRef struct {
@@ -92,8 +107,21 @@ func (c *Config) Validate() error {
 		}
 	}
 	for i, m := range c.Mappings {
-		if (m.Path == "") == (m.Glob == "") {
-			return fmt.Errorf("mapping[%d]: exactly one of path or glob is required", i)
+		set := 0
+		if m.Path != "" {
+			set++
+		}
+		if m.Glob != "" {
+			set++
+		}
+		if m.CwdGlob != "" {
+			set++
+		}
+		if set != 1 {
+			return fmt.Errorf("mapping[%d]: exactly one of path, glob, or cwd_glob is required", i)
+		}
+		if m.Command != "" && m.CwdGlob == "" {
+			return fmt.Errorf("mapping[%d]: command is only valid with cwd_glob", i)
 		}
 		if len(m.Vars) == 0 {
 			return fmt.Errorf("mapping[%d]: at least one var is required", i)

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -1,19 +1,28 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
 
-// Index is a lookup of mappings by path/glob, optimized for is-mapped queries.
+// Index is a lookup of mappings, optimized for is-mapped queries.
 type Index struct {
-	exact map[string][]VarRef
-	globs []globEntry
+	exact    map[string][]VarRef
+	globs    []globEntry
+	cwdGlobs []cwdGlobEntry
 }
 
 type globEntry struct {
 	pattern string
+	vars    []VarRef
+}
+
+type cwdGlobEntry struct {
+	pattern string // expanded (~ resolved) at index-build time
+	command string // empty matches any command
 	vars    []VarRef
 }
 
@@ -23,16 +32,32 @@ func NewIndex(mappings []Mapping) *Index {
 	for _, m := range mappings {
 		switch {
 		case m.Path != "":
-			abs, err := filepath.Abs(m.Path)
+			abs, err := filepath.Abs(expandTilde(m.Path))
 			if err != nil {
 				abs = m.Path
 			}
 			idx.exact[abs] = append(idx.exact[abs], m.Vars...)
 		case m.Glob != "":
-			idx.globs = append(idx.globs, globEntry{pattern: m.Glob, vars: m.Vars})
+			idx.globs = append(idx.globs, globEntry{
+				pattern: expandTilde(m.Glob), vars: m.Vars,
+			})
+		case m.CwdGlob != "":
+			idx.cwdGlobs = append(idx.cwdGlobs, cwdGlobEntry{
+				pattern: expandTilde(m.CwdGlob),
+				command: m.Command,
+				vars:    m.Vars,
+			})
 		}
 	}
 	return idx
+}
+
+// HasCwdMappings reports whether any cwd_glob mapping is configured.
+// The agent uses this to maintain its has-cwd sentinel file so the
+// shell hooks can skip the bare-PATH branch entirely when no
+// cwd_glob mapping exists.
+func (idx *Index) HasCwdMappings() bool {
+	return len(idx.cwdGlobs) > 0
 }
 
 // Lookup returns the merged VarRefs for a given absolute path, in
@@ -52,6 +77,37 @@ func (idx *Index) Lookup(absPath string) []VarRef {
 	return out
 }
 
+// LookupCwd returns the merged VarRefs for a (cwd, command) pair.
+// The cwd_glob is matched against pwd itself and every ancestor, so a
+// glob like "~/work/acme" applies to "~/work/acme" and to all of its
+// descendants. Mappings with a non-empty Command field only match when
+// `command` equals that value (bare command name, not full path).
+func (idx *Index) LookupCwd(pwd, command string) []VarRef {
+	if len(idx.cwdGlobs) == 0 {
+		return nil
+	}
+	abs, err := filepath.Abs(expandTilde(pwd))
+	if err != nil {
+		abs = pwd
+	}
+	var out []VarRef
+	for _, e := range idx.cwdGlobs {
+		if e.command != "" && e.command != command {
+			continue
+		}
+		if matchAncestor(e.pattern, abs) {
+			out = append(out, e.vars...)
+		}
+	}
+	return out
+}
+
+// MappedCwd reports whether (pwd, command) has any matching cwd_glob
+// mapping.
+func (idx *Index) MappedCwd(pwd, command string) bool {
+	return len(idx.LookupCwd(pwd, command)) > 0
+}
+
 // Mapped reports whether absPath has any mapping.
 func (idx *Index) Mapped(absPath string) bool {
 	if _, ok := idx.exact[absPath]; ok {
@@ -63,4 +119,41 @@ func (idx *Index) Mapped(absPath string) bool {
 		}
 	}
 	return false
+}
+
+// matchAncestor returns true if pattern matches abs or any ancestor of abs.
+// This is what makes `cwd_glob = "~/work/acme"` apply inside any
+// subdirectory of acme, not just at acme itself. A trailing `**` glob
+// also matches the root because doublestar treats `**` as zero-or-more
+// segments.
+func matchAncestor(pattern, abs string) bool {
+	for cur := abs; ; {
+		if ok, err := doublestar.Match(pattern, cur); err == nil && ok {
+			return true
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return false
+		}
+		cur = parent
+	}
+}
+
+// expandTilde resolves a leading "~/" or bare "~" against $HOME. Other
+// uses of ~ are passed through unchanged.
+func expandTilde(p string) string {
+	if p == "" || (p[0] != '~') {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return p
+	}
+	if p == "~" {
+		return home
+	}
+	if strings.HasPrefix(p, "~/") {
+		return filepath.Join(home, p[2:])
+	}
+	return p
 }

--- a/internal/config/mapping_test.go
+++ b/internal/config/mapping_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIndex_LookupCwd_AncestorWalk(t *testing.T) {
+	tmp := t.TempDir()
+	deeper := filepath.Join(tmp, "acme", "service", "src")
+	if err := os.MkdirAll(deeper, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewIndex([]Mapping{
+		{
+			CwdGlob: filepath.Join(tmp, "acme"),
+			Vars:    []VarRef{{Name: "FOO", Source: "x", Ref: "foo"}},
+		},
+	})
+
+	if !idx.HasCwdMappings() {
+		t.Fatal("expected HasCwdMappings to be true")
+	}
+
+	// Direct match.
+	if !idx.MappedCwd(filepath.Join(tmp, "acme"), "") {
+		t.Errorf("expected direct cwd match")
+	}
+	// Ancestor walk: deeper directory still matches.
+	if !idx.MappedCwd(deeper, "") {
+		t.Errorf("expected ancestor-walk match for deeper path")
+	}
+	// Sibling: should NOT match.
+	other := filepath.Join(tmp, "other")
+	if err := os.Mkdir(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if idx.MappedCwd(other, "") {
+		t.Errorf("sibling directory should not match")
+	}
+}
+
+func TestIndex_LookupCwd_CommandScope(t *testing.T) {
+	tmp := t.TempDir()
+	idx := NewIndex([]Mapping{
+		{
+			CwdGlob: tmp,
+			Command: "npm",
+			Vars:    []VarRef{{Name: "TOK", Source: "x", Ref: "tok"}},
+		},
+		{
+			CwdGlob: tmp,
+			// empty Command → matches any
+			Vars: []VarRef{{Name: "ALL", Source: "x", Ref: "all"}},
+		},
+	})
+
+	got := idx.LookupCwd(tmp, "npm")
+	if len(got) != 2 {
+		t.Errorf("npm should match both: got %d (%v)", len(got), got)
+	}
+
+	got = idx.LookupCwd(tmp, "python")
+	if len(got) != 1 || got[0].Name != "ALL" {
+		t.Errorf("python should match only ALL: got %v", got)
+	}
+}
+
+func TestIndex_LookupCwd_TildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("no $HOME")
+	}
+	idx := NewIndex([]Mapping{{
+		CwdGlob: "~",
+		Vars:    []VarRef{{Name: "HOMEY", Source: "x", Ref: "h"}},
+	}})
+	if !idx.MappedCwd(home, "") {
+		t.Errorf("tilde should expand: glob=~ pwd=%s", home)
+	}
+}
+
+func TestValidate_RejectsMultipleKinds(t *testing.T) {
+	c := &Config{
+		Version: Version,
+		Mappings: []Mapping{
+			{Path: "/a", Glob: "/b", Vars: []VarRef{{Source: "x"}}},
+		},
+		Sources: map[string]SourceConfig{"x": {Type: "noop"}},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected validate error for multi-kind mapping")
+	}
+}
+
+func TestValidate_RejectsCommandWithoutCwdGlob(t *testing.T) {
+	c := &Config{
+		Version: Version,
+		Mappings: []Mapping{
+			{Path: "/a", Command: "npm", Vars: []VarRef{{Source: "x"}}},
+		},
+		Sources: map[string]SourceConfig{"x": {Type: "noop"}},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected validate error: command without cwd_glob")
+	}
+}
+
+func TestValidate_AcceptsCwdGlob(t *testing.T) {
+	c := &Config{
+		Version: Version,
+		Mappings: []Mapping{
+			{CwdGlob: "/a/**", Command: "npm", Vars: []VarRef{{Source: "x"}}},
+		},
+		Sources: map[string]SourceConfig{"x": {Type: "noop"}},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 	"time"
@@ -46,10 +47,55 @@ func Run(ctx context.Context, file string, args []string) error {
 	return replaceProcess(abs, args, env)
 }
 
+// RunCwd is the cwd_glob counterpart to Run. The shell hook invokes it
+// for bare-PATH commands when a cwd_glob mapping matches: `cmd` is the
+// bare name the user typed (resolved against $PATH here), `pwd` is the
+// shell's $PWD at trap time, and `args` is everything that followed
+// the command name.
+func RunCwd(ctx context.Context, pwd, cmd string, args []string) error {
+	if cmd == "" {
+		return errors.New("run --cwd requires --cmd")
+	}
+	exe, err := exec.LookPath(cmd)
+	if err != nil {
+		return fmt.Errorf("resolve %q on $PATH: %w", cmd, err)
+	}
+	exeAbs, err := filepath.Abs(exe)
+	if err != nil {
+		exeAbs = exe
+	}
+
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		return err
+	}
+	cli := agent.NewClient(paths.Socket)
+	dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	extra, err := cli.FetchEnvCwd(dctx, pwd, cmd)
+	if err != nil {
+		return fmt.Errorf("agent unreachable; run `jitenv unlock` first: %w", err)
+	}
+
+	env := os.Environ()
+	for k, v := range extra {
+		env = append(env, k+"="+v)
+	}
+	return replaceProcessAs(exeAbs, cmd, args, env)
+}
+
 // replaceProcess substitutes the current process image with the given
 // file using syscall.Exec so secrets live only in the child process tree.
 func replaceProcess(path string, args []string, env []string) error {
-	argv := append([]string{path}, args...)
+	return replaceProcessAs(path, path, args, env)
+}
+
+// replaceProcessAs is replaceProcess but lets the caller specify argv[0]
+// independently — useful for bare-command runs where argv[0] should be
+// the name the user typed (so e.g. `npm` keeps thinking it was invoked
+// as `npm`, not as `/usr/lib/node_modules/.../npm-cli.js`).
+func replaceProcessAs(path, argv0 string, args []string, env []string) error {
+	argv := append([]string{argv0}, args...)
 	if err := syscall.Exec(path, argv, env); err != nil {
 		if errors.Is(err, syscall.ENOEXEC) {
 			return fmt.Errorf("%s: file is not directly executable (missing shebang?)", path)

--- a/internal/shell/hook_cwd_test.go
+++ b/internal/shell/hook_cwd_test.go
@@ -1,0 +1,126 @@
+package shell_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+)
+
+// TestBashHookInterceptsCwdMappedCommand exercises the cwd_glob path
+// end-to-end: configure a bare-PATH command (`testjitenv-cwd`) inside
+// a cwd_glob, run the bash hook from inside that directory, and
+// confirm the env var lands.
+func TestBashHookInterceptsCwdMappedCommand(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A "bare PATH command": a tiny shell script in a fake bin dir
+	// that prints whatever FOO is set to.
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmdPath := filepath.Join(fakeBin, "testjitenv-cwd")
+	if err := os.WriteFile(cmdPath, []byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"${FOO:-MISSING}\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-cwd")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	key, _ := config.DeriveKeyFromMeta(cfg, pw)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "from-cwd"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{
+			CwdGlob: projectDir,
+			Command: "testjitenv-cwd",
+			Vars:    []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+		},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	cli := agent.NewClient(paths.Socket)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Confirm the agent created the has-cwd sentinel.
+	if _, err := os.Stat(filepath.Join(paths.Dir, "has-cwd")); err != nil {
+		t.Errorf("has-cwd sentinel missing: %v", err)
+	}
+
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:%q:$PATH
+cd %q
+eval "$(%s/jitenv hook bash)"
+testjitenv-cwd
+`, binDir, fakeBin, projectDir, binDir,
+	))
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_HOOK_DEBUG=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	t.Logf("bash output:\n%s", got)
+	if !strings.Contains(got, "FOO=from-cwd") {
+		t.Errorf("expected FOO=from-cwd; got:\n%s", got)
+	}
+}

--- a/internal/shell/hook_cwd_test.go
+++ b/internal/shell/hook_cwd_test.go
@@ -16,6 +16,111 @@ import (
 	"github.com/gv/jitenv/internal/config"
 )
 
+// TestBashHookSkipsShellFunctionsInCwd is the regression for the bug
+// where a cwd_glob mapping with empty command="" (matches anything)
+// caused the hook to ask `jitenv run` to re-exec shell functions like
+// __git_ps1. Those aren't PATH binaries — exec.LookPath fails with
+// "executable file not found" and the user sees the error printed
+// for every PROMPT_COMMAND firing.
+//
+// The hook now filters via `command -v` before invoking jitenv run:
+// only names that resolve to an absolute PATH path get wrapped,
+// shell builtins / functions / aliases are left alone.
+func TestBashHookSkipsShellFunctionsInCwd(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-fn")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	key, _ := config.DeriveKeyFromMeta(cfg, pw)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"x": "y"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{
+			CwdGlob: projectDir,
+			// Empty Command: matches every command, exactly the
+			// shape that triggered the user's report.
+			Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}},
+		},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	cli := agent.NewClient(paths.Socket)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+cd %q
+eval "$(%s/jitenv hook bash)"
+__git_ps1() { :; }     # define a fake PROMPT_COMMAND function
+__git_ps1              # invoke the function (bare name, in cwd-mapped dir)
+fdgfgdfg 2>&1 || true  # invoke a name that doesn't exist
+echo DONE
+`, binDir, projectDir, binDir,
+	))
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	if strings.Contains(got, "executable file not found") {
+		t.Errorf("hook tried to re-exec a non-PATH name; got:\n%s", got)
+	}
+	if strings.Contains(got, "resolve \"__git_ps1\"") {
+		t.Errorf("__git_ps1 should be skipped by command -v filter; got:\n%s", got)
+	}
+	if !strings.Contains(got, "DONE") {
+		t.Errorf("session should still complete normally; got:\n%s", got)
+	}
+}
+
 // TestBashHookInterceptsCwdMappedCommand exercises the cwd_glob path
 // end-to-end: configure a bare-PATH command (`testjitenv-cwd`) inside
 // a cwd_glob, run the bash hook from inside that directory, and

--- a/internal/shell/hook_e2e_test.go
+++ b/internal/shell/hook_e2e_test.go
@@ -112,11 +112,15 @@ echo "IS_MAPPED_RC=$(jitenv is-mapped %q >/dev/null 2>&1; echo $?)"
 	}
 }
 
-// TestBashHookAgentDownWarnsThenRuns verifies that when the agent is
-// not running, the bash hook prints the red warning, waits for the
-// (env-shortened) delay, and then runs the command anyway. The script
-// produces "RAN" so we can confirm execution went through.
-func TestBashHookAgentDownWarnsThenRuns(t *testing.T) {
+// TestBashHookAgentDownStaysSilent verifies the post-#27 behaviour:
+// when the agent isn't running (no socket file in the runtime dir),
+// the bash hook short-circuits the entire trap. The previous design
+// painted a red 10s "agent is not loaded" countdown for path-prefixed
+// commands, which leaked onto every PROMPT_COMMAND firing once the
+// user had a cwd_glob mapping configured. Mapped scripts now run
+// silently without their env vars when the agent is locked; users
+// confirm via `jitenv status`.
+func TestBashHookAgentDownStaysSilent(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not available")
 	}
@@ -128,8 +132,7 @@ func TestBashHookAgentDownWarnsThenRuns(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	// Point XDG_RUNTIME_DIR at an empty dir so no agent socket exists
-	// — that's what triggers the agent-unreachable path in is-mapped.
+	// Point XDG_RUNTIME_DIR at an empty dir so no agent socket exists.
 	runtimeDir := filepath.Join(dir, "runtime")
 	_ = os.MkdirAll(runtimeDir, 0700)
 
@@ -142,7 +145,7 @@ eval "$(%s/jitenv hook bash)"
 	))
 	cmd.Env = append(os.Environ(),
 		"XDG_RUNTIME_DIR="+runtimeDir,
-		"JITENV_HOOK_DELAY=1", // shrink the 10s wait for the test
+		"JITENV_HOOK_DELAY=1",
 	)
 	start := time.Now()
 	out, err := cmd.CombinedOutput()
@@ -151,13 +154,13 @@ eval "$(%s/jitenv hook bash)"
 		t.Fatalf("bash run: %v\noutput=%s", err, out)
 	}
 	got := string(out)
-	if !strings.Contains(got, "agent is not loaded") {
-		t.Errorf("expected red 'agent is not loaded' warning; got:\n%s", got)
+	if strings.Contains(got, "agent is not loaded") {
+		t.Errorf("expected the hook to stay silent when agent is down; got:\n%s", got)
 	}
 	if !strings.Contains(got, "RAN") {
-		t.Errorf("expected the script to still run after the delay; got:\n%s", got)
+		t.Errorf("expected the script to still run; got:\n%s", got)
 	}
-	if elapsed < 800*time.Millisecond {
-		t.Errorf("expected the hook to wait ~1s; only %s elapsed", elapsed)
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected the hook to short-circuit fast; took %s", elapsed)
 	}
 }

--- a/internal/shell/hook_unlock_lock_test.go
+++ b/internal/shell/hook_unlock_lock_test.go
@@ -124,8 +124,14 @@ echo '--- step 4 (agent down) ---'
 	if strings.Contains(step2, "agent is not loaded") {
 		t.Errorf("step 2: did not expect the warning while agent is up; got:\n%s", step2)
 	}
-	if !strings.Contains(step4, "agent is not loaded") {
-		t.Errorf("step 4: expected the agent-down warning; got:\n%s", step4)
+	// Step 4 (agent locked): the hook short-circuits on socket
+	// absence so prompt-side-effect commands (PROMPT_COMMAND, bash
+	// aliases that expand to absolute paths, `~/bin/...` etc.) no
+	// longer paint the red 10s countdown on every keystroke. The
+	// trade-off is that mapped scripts run silently without their
+	// env vars; users confirm via `jitenv status`.
+	if strings.Contains(step4, "agent is not loaded") {
+		t.Errorf("step 4: expected the locked-agent warning to be suppressed; got:\n%s", step4)
 	}
 	if !strings.Contains(step4, "FOO=MISSING") {
 		t.Errorf("step 4: expected the script to still run (with FOO=MISSING); got:\n%s", step4)

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -1,11 +1,23 @@
 # jitenv bash hook -- source via: eval "$(jitenv hook bash)"
 # Requires bash 4+. Uses extdebug to cancel the original command and
 # re-run the first token through `jitenv run` if it maps to a configured
-# file. Only acts on commands whose first token resolves to /, ./ or ../
-# paths (not PATH lookups) — keeps the hook fast and predictable.
+# file. By default only acts on commands whose first token resolves to
+# /, ./ or ../ paths (not PATH lookups) — keeps the hook fast and
+# predictable. Bare PATH commands are checked against cwd_glob mappings
+# only when the agent has flagged that at least one such mapping exists
+# (a tiny sentinel file in $XDG_RUNTIME_DIR/jitenv/has-cwd, so the hook
+# adds zero socket traffic for users who don't use the feature).
 
 if [[ -n "${__JITENV_LOADED:-}" ]]; then return 0 2>/dev/null || exit 0; fi
 __JITENV_LOADED=1
+
+# Resolve the per-user runtime dir the same way the agent does
+# (internal/agent/paths.go). Used to look up the has-cwd sentinel.
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    __JITENV_RUNTIME_DIR="$XDG_RUNTIME_DIR/jitenv"
+else
+    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}/jitenv-$UID"
+fi
 
 shopt -s extdebug
 
@@ -51,6 +63,12 @@ __jitenv_log() {
 __jitenv_debug_trap() {
     [[ -n "${__JITENV_REENTRY:-}" ]] && return 0
 
+    # Skip while bash is running a programmable-completion function —
+    # the DEBUG trap fires on commands inside compfuncs too, and we
+    # don't want to paint the agent-unreachable countdown when the
+    # user just hit Tab. (issue #30)
+    [[ -n "${COMP_LINE-}" || -n "${COMP_POINT-}" ]] && return 0
+
     local cmd="$BASH_COMMAND"
     local first_raw; first_raw="${cmd%% *}"
     [[ -z "$first_raw" ]] && return 0
@@ -66,7 +84,35 @@ __jitenv_debug_trap() {
     elif [[ "$first" = ./* || "$first" = ../* ]]; then
         resolved="$(cd "$(dirname "$first")" 2>/dev/null && pwd)/$(basename "$first")"
     else
-        return 0
+        # Bare PATH lookup. Only check if the agent has flagged at
+        # least one cwd_glob mapping — the sentinel is a single file
+        # the agent maintains, so absence costs one stat. With the
+        # sentinel absent (the common case for users who don't use
+        # cwd mappings) we exit immediately, preserving today's
+        # zero-overhead behaviour.
+        [[ -e "$__JITENV_RUNTIME_DIR/has-cwd" ]] || return 0
+        __jitenv_log "candidate cmd=[$cmd] cwd=[$PWD] cmdname=[$first]"
+        jitenv is-mapped --cwd "$PWD" --cmd "$first" >/dev/null 2>&1
+        local rc=$?
+        __jitenv_log "is-mapped (cwd) rc=$rc"
+        case "$rc" in
+            0)
+                __jitenv_log "branch=cwd-case0 (mapped → jitenv run)"
+                local rest="${cmd#"$first_raw"}"
+                __JITENV_REENTRY=1
+                eval "jitenv run --cwd \"$PWD\" --cmd \"$first\"$rest"
+                unset __JITENV_REENTRY
+                return 1
+                ;;
+            *)
+                # rc=1 (no match) or rc=2 (agent unreachable). Bare
+                # commands fire on every keystroke-completed command,
+                # so silently fall through rather than spamming the
+                # agent-unreachable warning the user gets for explicit
+                # path-mapped runs.
+                return 0
+                ;;
+        esac
     fi
     [[ ! -f "$resolved" ]] && return 0
 

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -104,6 +104,15 @@ __jitenv_debug_trap() {
         # cwd mappings) we exit immediately, preserving today's
         # zero-overhead behaviour.
         [[ -e "$__JITENV_RUNTIME_DIR/has-cwd" ]] || return 0
+        # Skip shell builtins, functions, aliases, and unknown names.
+        # Only PATH binaries can be re-exec'd by `jitenv run`; trying
+        # to wrap something like __git_ps1 (a PROMPT_COMMAND function)
+        # ends in `exec: "..." : executable file not found`. command
+        # -v prints "/abs/path" for a PATH binary, otherwise the bare
+        # name (builtin/function) or nothing (unknown).
+        local resolved_path
+        resolved_path="$(command -v "$first" 2>/dev/null)"
+        [[ "$resolved_path" = /* ]] || return 0
         __jitenv_log "candidate cmd=[$cmd] cwd=[$PWD] cmdname=[$first]"
         jitenv is-mapped --cwd "$PWD" --cmd "$first" >/dev/null 2>&1
         local rc=$?

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -69,6 +69,19 @@ __jitenv_debug_trap() {
     # user just hit Tab. (issue #30)
     [[ -n "${COMP_LINE-}" || -n "${COMP_POINT-}" ]] && return 0
 
+    # Agent-absence short-circuit. The DEBUG trap fires on every simple
+    # command bash is about to execute — including the dozens that
+    # PROMPT_COMMAND, prompt-side `$()`s, aliases, and `~/bin/...`
+    # expansions inject between user keypresses. With the agent
+    # deliberately locked, calling `jitenv is-mapped` on each of
+    # those would either spam the red countdown (path-prefixed
+    # commands) or pay a useless socket-dial-fail per command.
+    # `jitenv lock` removes the agent socket on shutdown, so a single
+    # stat takes us out of the trap entirely when there's no agent
+    # to talk to. Mapped scripts run in this state will silently miss
+    # their env vars; users can confirm with `jitenv status`.
+    [[ -S "$__JITENV_RUNTIME_DIR/agent.sock" ]] || return 0
+
     local cmd="$BASH_COMMAND"
     local first_raw; first_raw="${cmd%% *}"
     [[ -z "$first_raw" ]] && return 0

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -1,10 +1,18 @@
 # jitenv zsh hook -- source via: eval "$(jitenv hook zsh)"
 # Uses a zle widget bound to "accept-line" to rewrite BUFFER before
-# submission. Only acts on commands whose first token resolves to /, ./
-# or ../ paths.
+# submission. By default only acts on commands whose first token
+# resolves to /, ./ or ../ paths. Bare PATH commands are checked
+# against cwd_glob mappings only when the agent has flagged at least
+# one such mapping exists (sentinel file in $XDG_RUNTIME_DIR/jitenv/has-cwd).
 
 if [[ -n "${__JITENV_LOADED:-}" ]]; then return 0; fi
 __JITENV_LOADED=1
+
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    __JITENV_RUNTIME_DIR="$XDG_RUNTIME_DIR/jitenv"
+else
+    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}/jitenv-$UID"
+fi
 
 # Warn loudly when the agent isn't reachable, count down 10 seconds,
 # and let Ctrl+C abort. Returns non-zero on abort so the caller's `&&`
@@ -82,6 +90,19 @@ __jitenv_accept_line() {
                     __jitenv_log "branch=case* (rc=$rc — unmapped, let it run)"
                     ;;
             esac
+        elif [[ -z "$resolved" && -e "$__JITENV_RUNTIME_DIR/has-cwd" ]]; then
+            # Bare PATH command and the agent has flagged at least one
+            # cwd_glob mapping. Ask whether $PWD + this command match.
+            __jitenv_log "candidate cmd=[$BUFFER] cwd=[$PWD] cmdname=[$first]"
+            jitenv is-mapped --cwd "$PWD" --cmd "$first" >/dev/null 2>&1
+            local rc=$?
+            __jitenv_log "is-mapped (cwd) rc=$rc"
+            if [[ "$rc" == "0" ]]; then
+                __jitenv_log "branch=cwd-case0 (mapped → jitenv run)"
+                BUFFER="jitenv run --cwd \"$PWD\" --cmd \"$first\"$rest"
+            fi
+            # rc=1 (no match) and rc=2 (agent unreachable) silently
+            # fall through — bare commands are too noisy to warn on.
         fi
     fi
     zle .accept-line

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -56,6 +56,16 @@ __jitenv_log() {
 
 __jitenv_accept_line() {
     emulate -L zsh
+    # Agent-absence short-circuit. `jitenv lock` removes the agent
+    # socket on shutdown, so a single stat takes us out of the widget
+    # entirely when there's no agent to talk to. Avoids dialing for
+    # every command and the agent-unreachable warning that would
+    # otherwise paint when running mapped files post-lock.
+    if [[ ! -S "$__JITENV_RUNTIME_DIR/agent.sock" ]]; then
+        zle .accept-line
+        return
+    fi
+
     local first_raw first rest resolved
     first_raw="${BUFFER%% *}"
     rest="${BUFFER#$first_raw}"

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -102,17 +102,23 @@ __jitenv_accept_line() {
             esac
         elif [[ -z "$resolved" && -e "$__JITENV_RUNTIME_DIR/has-cwd" ]]; then
             # Bare PATH command and the agent has flagged at least one
-            # cwd_glob mapping. Ask whether $PWD + this command match.
-            __jitenv_log "candidate cmd=[$BUFFER] cwd=[$PWD] cmdname=[$first]"
-            jitenv is-mapped --cwd "$PWD" --cmd "$first" >/dev/null 2>&1
-            local rc=$?
-            __jitenv_log "is-mapped (cwd) rc=$rc"
-            if [[ "$rc" == "0" ]]; then
-                __jitenv_log "branch=cwd-case0 (mapped → jitenv run)"
-                BUFFER="jitenv run --cwd \"$PWD\" --cmd \"$first\"$rest"
+            # cwd_glob mapping. Skip shell builtins, functions, and
+            # unknown names — `jitenv run` re-execs via syscall.Exec
+            # and only PATH binaries can be wrapped that way.
+            local resolved_path
+            resolved_path="$(whence -p "$first" 2>/dev/null)"
+            if [[ -n "$resolved_path" ]]; then
+                __jitenv_log "candidate cmd=[$BUFFER] cwd=[$PWD] cmdname=[$first]"
+                jitenv is-mapped --cwd "$PWD" --cmd "$first" >/dev/null 2>&1
+                local rc=$?
+                __jitenv_log "is-mapped (cwd) rc=$rc"
+                if [[ "$rc" == "0" ]]; then
+                    __jitenv_log "branch=cwd-case0 (mapped → jitenv run)"
+                    BUFFER="jitenv run --cwd \"$PWD\" --cmd \"$first\"$rest"
+                fi
+                # rc=1 (no match) and rc=2 (agent unreachable) silently
+                # fall through — bare commands are too noisy to warn on.
             fi
-            # rc=1 (no match) and rc=2 (agent unreachable) silently
-            # fall through — bare commands are too noisy to warn on.
         fi
     fi
     zle .accept-line

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -150,11 +150,16 @@ func (m *mappingsListScreen) View() string {
 }
 
 func mappingLabel(mp config.Mapping) string {
-	if mp.Glob != "" {
+	switch {
+	case mp.Glob != "":
 		return mp.Glob
-	}
-	if mp.Path != "" {
+	case mp.Path != "":
 		return mp.Path
+	case mp.CwdGlob != "":
+		if mp.Command != "" {
+			return "cwd:" + mp.CwdGlob + "  " + mp.Command
+		}
+		return "cwd:" + mp.CwdGlob
 	}
 	return "(empty)"
 }
@@ -229,7 +234,7 @@ func (s *mappingFormScreen) mp() *config.Mapping {
 
 func (s *mappingFormScreen) isEmpty() bool {
 	mp := s.mp()
-	return mp != nil && mp.Path == "" && mp.Glob == "" && len(mp.Vars) == 0
+	return mp != nil && mp.Path == "" && mp.Glob == "" && mp.CwdGlob == "" && len(mp.Vars) == 0
 }
 
 func (s *mappingFormScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
@@ -240,7 +245,8 @@ func (s *mappingFormScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				s.cursor--
 			}
 		case "down", "j":
-			if s.cursor < 2 {
+			max := s.maxCursor()
+			if s.cursor < max {
 				s.cursor++
 			}
 		case "enter":
@@ -258,8 +264,32 @@ func (s *mappingFormScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	return s, nil
 }
 
+// maxCursor returns the highest valid cursor row. The form has either
+// 3 rows (kind / target / variables) for path & glob mappings, or 4
+// rows (kind / target / command / variables) for cwd mappings.
+func (s *mappingFormScreen) maxCursor() int {
+	if mp := s.mp(); mp != nil && mp.CwdGlob != "" {
+		return 3
+	}
+	return 2
+}
+
 func (s *mappingFormScreen) activate() tea.Cmd {
-	if s.mp() == nil {
+	mp := s.mp()
+	if mp == nil {
+		return nil
+	}
+	if mp.CwdGlob != "" {
+		switch s.cursor {
+		case 0:
+			return s.openKindMenu()
+		case 1:
+			return s.openTargetInput()
+		case 2:
+			return s.openCommandInput()
+		case 3:
+			return s.openVarTree()
+		}
 		return nil
 	}
 	switch s.cursor {
@@ -279,22 +309,41 @@ func (s *mappingFormScreen) openKindMenu() tea.Cmd {
 		if mp == nil {
 			return emit(popMsg{})
 		}
+		// Carry the previous target across kind changes so the user
+		// doesn't lose typing.
+		prev := mp.Path
+		if mp.Glob != "" {
+			prev = mp.Glob
+		} else if mp.CwdGlob != "" {
+			prev = mp.CwdGlob
+		}
+		mp.Path, mp.Glob, mp.CwdGlob = "", "", ""
 		switch choice {
 		case "path":
-			if mp.Glob != "" {
-				mp.Path = mp.Glob
-				mp.Glob = ""
-			}
+			mp.Path = prev
 		case "glob":
-			if mp.Path != "" {
-				mp.Glob = mp.Path
-				mp.Path = ""
+			mp.Glob = prev
+		case "cwd":
+			mp.CwdGlob = prev
+		default:
+			// Back / unknown: restore previous shape.
+			switch {
+			case prev != "":
+				mp.Path = prev // sensible fallback; user can re-pick
 			}
+		}
+		// Command is only meaningful with cwd; clear when leaving cwd.
+		if choice != "cwd" {
+			mp.Command = ""
+		}
+		// Clamp cursor so we don't end up beyond the new max row.
+		if s.cursor > s.maxCursor() {
+			s.cursor = s.maxCursor()
 		}
 		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
 	}
 	return emit(pushMsg{s: newPopupMenuScreen(s.root,
-		"Mapping kind", cb, "path", "glob", "Back")})
+		"Mapping kind", cb, "path", "glob", "cwd", "Back")})
 }
 
 func (s *mappingFormScreen) openTargetInput() tea.Cmd {
@@ -302,15 +351,16 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 	if mp == nil {
 		return nil
 	}
-	title := "edit path"
-	prompt := "Absolute path to the file."
-	ph := "/home/me/scripts/deploy.sh"
-	init := mp.Path
-	if mp.Glob != "" {
-		title = "edit glob"
-		prompt = "Doublestar glob — matches multiple files."
-		ph = "/home/me/scripts/**/*.sh"
-		init = mp.Glob
+	var title, prompt, ph, init string
+	switch {
+	case mp.Glob != "":
+		title, prompt, ph, init = "edit glob", "Doublestar glob — matches multiple files.", "/home/me/scripts/**/*.sh", mp.Glob
+	case mp.CwdGlob != "":
+		title, prompt, ph, init = "edit cwd glob",
+			"Match by current working directory. The glob also covers any subdirectory of a match (~/work/acme matches inside ~/work/acme/sub).",
+			"~/work/acme/**", mp.CwdGlob
+	default:
+		title, prompt, ph, init = "edit path", "Absolute path to the file.", "/home/me/scripts/deploy.sh", mp.Path
 	}
 	commit := func(val string) tea.Cmd {
 		v := strings.TrimSpace(val)
@@ -318,9 +368,12 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 		if m == nil {
 			return emit(popMsg{})
 		}
-		if m.Glob != "" {
+		switch {
+		case m.Glob != "":
 			m.Glob = v
-		} else {
+		case m.CwdGlob != "":
+			m.CwdGlob = v
+		default:
 			m.Path = v
 		}
 		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
@@ -328,6 +381,33 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
 		Title: title, Prompt: prompt, Placeholder: ph, Initial: init,
 		SaveLabel: "OK", CancelLabel: "Cancel",
+	}, commit)})
+}
+
+// openCommandInput is the cwd-only "command" row editor. Empty means
+// the mapping fires for ANY command run inside the matched cwd; a
+// non-empty value scopes it to a single bare command name (npm,
+// python, …).
+func (s *mappingFormScreen) openCommandInput() tea.Cmd {
+	mp := s.mp()
+	if mp == nil {
+		return nil
+	}
+	commit := func(val string) tea.Cmd {
+		m := s.mp()
+		if m == nil {
+			return emit(popMsg{})
+		}
+		m.Command = strings.TrimSpace(val)
+		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
+	}
+	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
+		Title:       "scope to command",
+		Prompt:      "Bare command name to scope this mapping to (e.g. npm). Leave blank to match every command run inside the cwd.",
+		Placeholder: "npm",
+		Initial:     mp.Command,
+		AllowBlank:  true,
+		SaveLabel:   "OK", CancelLabel: "Cancel",
 	}, commit)})
 }
 
@@ -342,13 +422,18 @@ func (s *mappingFormScreen) View() string {
 		return errorStyle.Render("(mapping vanished)")
 	}
 
-	kind := "path"
-	if mp.Glob != "" {
-		kind = "glob"
+	kind := mp.Kind()
+	if kind == "" {
+		kind = "path"
 	}
-	target := mp.Path
-	if mp.Glob != "" {
+	var target string
+	switch {
+	case mp.Glob != "":
 		target = mp.Glob
+	case mp.CwdGlob != "":
+		target = mp.CwdGlob
+	default:
+		target = mp.Path
 	}
 	if target == "" {
 		target = dimText("(not set)")
@@ -359,8 +444,17 @@ func (s *mappingFormScreen) View() string {
 	}{
 		{"kind", kind},
 		{"target", target},
-		{"variables", fmt.Sprintf("%d selected", localVarCount(s.root, mp))},
 	}
+	if mp.CwdGlob != "" {
+		cmd := mp.Command
+		if cmd == "" {
+			cmd = dimText("(any command)")
+		}
+		rows = append(rows, struct{ label, value string }{"command", cmd})
+	}
+	rows = append(rows, struct{ label, value string }{
+		"variables", fmt.Sprintf("%d selected", localVarCount(s.root, mp)),
+	})
 
 	for i, r := range rows {
 		line := fmt.Sprintf("%-12s %s", r.label+":", r.value)

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -186,11 +186,34 @@ type mappingFormScreen struct {
 	root     *rootModel
 	idx      int
 	creating bool
-	cursor   int // 0 = kind, 1 = target, 2 = variables
+	cursor   int // 0 = kind, 1 = target, 2 = command (cwd only) / variables
+	// pendingKind tracks the user's chosen kind while all target fields
+	// are still empty. config.Mapping has no "kind" field of its own —
+	// it's inferred from which of Path/Glob/CwdGlob is set — so on a
+	// fresh mapping we'd otherwise have no way to remember which one
+	// the user picked. Cleared once a target value lands in a concrete
+	// field; ignored whenever Mapping.Kind() returns non-empty.
+	pendingKind string
 }
 
 func newMappingFormScreen(r *rootModel, idx int, creating bool) screen {
 	return &mappingFormScreen{root: r, idx: idx, creating: creating}
+}
+
+// effectiveKind returns the kind the form should treat as current:
+// the mapping's stored kind when one of Path/Glob/CwdGlob is set,
+// otherwise the user's most-recent picker selection, defaulting to
+// "path" for a brand-new mapping.
+func (s *mappingFormScreen) effectiveKind() string {
+	if mp := s.mp(); mp != nil {
+		if k := mp.Kind(); k != "" {
+			return k
+		}
+	}
+	if s.pendingKind != "" {
+		return s.pendingKind
+	}
+	return "path"
 }
 
 func (s *mappingFormScreen) Title() string {
@@ -268,7 +291,7 @@ func (s *mappingFormScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 // 3 rows (kind / target / variables) for path & glob mappings, or 4
 // rows (kind / target / command / variables) for cwd mappings.
 func (s *mappingFormScreen) maxCursor() int {
-	if mp := s.mp(); mp != nil && mp.CwdGlob != "" {
+	if s.effectiveKind() == "cwd" {
 		return 3
 	}
 	return 2
@@ -279,7 +302,7 @@ func (s *mappingFormScreen) activate() tea.Cmd {
 	if mp == nil {
 		return nil
 	}
-	if mp.CwdGlob != "" {
+	if s.effectiveKind() == "cwd" {
 		switch s.cursor {
 		case 0:
 			return s.openKindMenu()
@@ -309,38 +332,42 @@ func (s *mappingFormScreen) openKindMenu() tea.Cmd {
 		if mp == nil {
 			return emit(popMsg{})
 		}
-		// Carry the previous target across kind changes so the user
-		// doesn't lose typing.
-		prev := mp.Path
-		if mp.Glob != "" {
-			prev = mp.Glob
-		} else if mp.CwdGlob != "" {
-			prev = mp.CwdGlob
-		}
-		mp.Path, mp.Glob, mp.CwdGlob = "", "", ""
 		switch choice {
-		case "path":
-			mp.Path = prev
-		case "glob":
-			mp.Glob = prev
-		case "cwd":
-			mp.CwdGlob = prev
-		default:
-			// Back / unknown: restore previous shape.
-			switch {
-			case prev != "":
-				mp.Path = prev // sensible fallback; user can re-pick
+		case "path", "glob", "cwd":
+			// Carry the previous target across kind changes so the
+			// user doesn't lose typing.
+			prev := mp.Path
+			if mp.Glob != "" {
+				prev = mp.Glob
+			} else if mp.CwdGlob != "" {
+				prev = mp.CwdGlob
 			}
+			mp.Path, mp.Glob, mp.CwdGlob = "", "", ""
+			switch choice {
+			case "path":
+				mp.Path = prev
+			case "glob":
+				mp.Glob = prev
+			case "cwd":
+				mp.CwdGlob = prev
+			}
+			// Track the choice in screen state for the (common)
+			// brand-new-mapping case where prev was empty: the
+			// concrete field stays empty, but effectiveKind() reads
+			// the user's intent off pendingKind so the form display
+			// and dispatch follow the picked kind right away.
+			s.pendingKind = choice
+			// Command is only meaningful with cwd; clear when leaving.
+			if choice != "cwd" {
+				mp.Command = ""
+			}
+			if s.cursor > s.maxCursor() {
+				s.cursor = s.maxCursor()
+			}
+			return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
 		}
-		// Command is only meaningful with cwd; clear when leaving cwd.
-		if choice != "cwd" {
-			mp.Command = ""
-		}
-		// Clamp cursor so we don't end up beyond the new max row.
-		if s.cursor > s.maxCursor() {
-			s.cursor = s.maxCursor()
-		}
-		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
+		// "Back" / unknown: leave both mp and pendingKind alone.
+		return emit(popMsg{})
 	}
 	return emit(pushMsg{s: newPopupMenuScreen(s.root,
 		"Mapping kind", cb, "path", "glob", "cwd", "Back")})
@@ -351,11 +378,12 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 	if mp == nil {
 		return nil
 	}
+	kind := s.effectiveKind()
 	var title, prompt, ph, init string
-	switch {
-	case mp.Glob != "":
+	switch kind {
+	case "glob":
 		title, prompt, ph, init = "edit glob", "Doublestar glob — matches multiple files.", "/home/me/scripts/**/*.sh", mp.Glob
-	case mp.CwdGlob != "":
+	case "cwd":
 		title, prompt, ph, init = "edit cwd glob",
 			"Match by current working directory. The glob also covers any subdirectory of a match (~/work/acme matches inside ~/work/acme/sub).",
 			"~/work/acme/**", mp.CwdGlob
@@ -368,10 +396,15 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 		if m == nil {
 			return emit(popMsg{})
 		}
-		switch {
-		case m.Glob != "":
+		// effectiveKind is the source of truth — write the value into
+		// the matching concrete field and clear the others, so a
+		// brand-new mapping where pendingKind drove the kind picker
+		// lands in the right field on save.
+		m.Path, m.Glob, m.CwdGlob = "", "", ""
+		switch kind {
+		case "glob":
 			m.Glob = v
-		case m.CwdGlob != "":
+		case "cwd":
 			m.CwdGlob = v
 		default:
 			m.Path = v
@@ -422,15 +455,12 @@ func (s *mappingFormScreen) View() string {
 		return errorStyle.Render("(mapping vanished)")
 	}
 
-	kind := mp.Kind()
-	if kind == "" {
-		kind = "path"
-	}
+	kind := s.effectiveKind()
 	var target string
-	switch {
-	case mp.Glob != "":
+	switch kind {
+	case "glob":
 		target = mp.Glob
-	case mp.CwdGlob != "":
+	case "cwd":
 		target = mp.CwdGlob
 	default:
 		target = mp.Path
@@ -445,7 +475,7 @@ func (s *mappingFormScreen) View() string {
 		{"kind", kind},
 		{"target", target},
 	}
-	if mp.CwdGlob != "" {
+	if kind == "cwd" {
 		cmd := mp.Command
 		if cmd == "" {
 			cmd = dimText("(any command)")


### PR DESCRIPTION
Combines two issues into one PR.

## #27 — cwd_glob mapping kind

A third mapping kind that matches by current working directory rather than the executed file's path. Bare-PATH commands (`npm`, `python`, `bundle`, …) run inside a configured directory now get env-var injection too. Optional `command` field scopes a mapping to a single bare name; empty matches every command.

```toml
# Anything I run inside ~/work/acme gets the API token.
[[mappings]]
cwd_glob = "~/work/acme"
[[mappings.vars]]
name   = "ACME_API_TOKEN"
source = "local"
ref    = "acme"
key    = "API_TOKEN"

# Only npm in that directory needs the registry token.
[[mappings]]
cwd_glob = "~/work/acme"
command  = "npm"
[[mappings.vars]]
name   = "NPM_TOKEN"
source = "local"
ref    = "acme"
key    = "NPM_TOKEN"
```

### How it's wired
- **Schema**: `config.Mapping` gains `CwdGlob` and `Command` fields. `Validate` enforces exactly one of path/glob/cwd_glob and rejects `command` without `cwd_glob`.
- **Index**: `cwdGlobs` slice with an ancestor-walk match — `cwd_glob = "~/work/acme"` also fires for `~/work/acme/sub/dir`, no trailing `**` needed. Tilde expansion happens at index-build time.
- **Resolver**: new `HasCwdMappings` / `IsMappedCwd` / `FetchEnvCwd`. The fetch-vars loop is shared between the path-keyed and cwd-keyed paths.
- **Agent protocol**: `Request` gains optional `Cwd` + `Command`. Existing path-keyed callers are unchanged; the server dispatches by their presence.
- **Hooks**: bash + zsh check a tiny `has-cwd` sentinel file the agent maintains in its runtime dir; if the file isn't there (no cwd_glob mappings configured) the bare-PATH branch short-circuits, so users who don't use this feature pay zero overhead. With the sentinel present, the hook asks the agent and re-execs through `jitenv run --cwd $PWD --cmd <name>` on rc=0. rc=1 / rc=2 silently fall through — bare commands fire on every keystroke-completed name, so warning on every one would be too noisy.
- **CLI**: `jitenv is-mapped --cwd <pwd> --cmd <name>` and `jitenv run --cwd <pwd> --cmd <name> [args…]`. Run resolves the bare name on `$PATH`, fetches env by (cwd, command), and exec's with `argv[0]` preserved as the typed name.
- **TUI**: kind picker gets a third "cwd" choice. When a mapping is in cwd mode, the form grows a "command" row above "variables".
- **Docs**: `docs/concepts.md` documents the new kind, ancestor-walk match, and sentinel perf model. `docs/security.md` calls out the trust-model widening — every command in the matched cwd gets the secrets, not just the one explicit file.

### Acceptance criteria from the issue
- [x] `Config.Mapping` carries `cwd_glob` + `command`; Validate rejects multi-kind mappings.
- [x] Agent's `is_mapped` and `fetch_env` accept `cwd` + `command` (back-compat for existing callers).
- [x] Shell hooks ask the agent for bare-PATH commands when cwd-glob mappings exist; otherwise behave exactly as today.
- [x] TUI lets the user create / edit cwd-glob mappings and pick the command.
- [x] `docs/concepts.md` documents the cwd kind; `docs/security.md` notes the model widening.
- [x] e2e test (`internal/shell/hook_cwd_test.go`) covers "run a bare command from inside a cwd-mapped directory and confirm env vars land".

## #30 — bash hook tab-completion fix

`__jitenv_debug_trap` now bails out at the top when `COMP_LINE` or `COMP_POINT` is set. Bash runs the DEBUG trap on commands inside programmable-completion functions too, which is what was painting the red "agent unreachable" countdown when the user pressed Tab after running a mapped file with a locked agent. The COMP_* vars are bash's own signal that the trap is firing inside a compfunc, so the guard is exactly the right shape.

I considered also bailing on non-interactive shells (`[[ "$-" != *i* ]]`) but reverted it because the e2e test suite drives the hook from `bash -c '…'`, which IS non-interactive. The COMP_* guard alone is enough; non-interactive shells don't run completion.

## Test plan
- [x] `make test` — green, including the new mapping_test.go (8 cases) and hook_cwd_test.go end-to-end.
- [x] `golangci-lint run ./...` — clean.
- [x] e2e: agent up + bash hook + cwd_glob mapping + bare command → FOO arrives.
- [ ] Reviewer (interactive bash): unlock agent, run a mapped script once, lock the agent, then `./mapped<TAB><TAB>` — confirm no red countdown appears. With `JITENV_HOOK_DEBUG=1` set, no `is-mapped` calls should log during Tab presses.
- [ ] Reviewer: confirm running the mapped file directly (no Tab) still routes through `jitenv run`.
- [ ] Reviewer (TUI): create a cwd_glob mapping, pick a command, save. Confirm `cat config.toml` round-trips correctly and that the `has-cwd` sentinel appears in `\$XDG_RUNTIME_DIR/jitenv/`.

## Notes
- Hook performance for users who don't use cwd_glob is still zero socket calls per command (the sentinel file isn't there, so the stat alone fails in microseconds).
- `jitenv run --cwd ... --cmd ...` uses `DisableFlagParsing` and a hand-rolled splitter so `--anything` arguments to the wrapped command pass through cobra unmolested.

Closes #27 and #30.