### PR TITLE
fix(hook): skip DEBUG trap during bash completion

### DIFF
--- a/internal/shell/hook_e2e_test.go
+++ b/internal/shell/hook_e2e_test.go
@@ -161,3 +161,59 @@ eval "$(%s/jitenv hook bash)"
 		t.Errorf("expected the hook to wait ~1s; only %s elapsed", elapsed)
 	}
 }
+
+// TestBashHookSkipsCommandNotFoundHandle is the regression for the
+// user report: typing a non-existent command with the agent locked
+// painted the agent-unreachable warning for /usr/lib/command-not-found.
+// That path comes from bash's command_not_found_handle wrapper
+// (Debian/Ubuntu's apt-suggest helper). The DEBUG trap fires on the
+// command inside the wrapper, sees a path-prefixed name, and warns —
+// once per typo. The hook now bails out when FUNCNAME shows the
+// handler on the call stack, so a typo with a locked agent stays
+// quiet.
+func TestBashHookSkipsCommandNotFoundHandle(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	// Stand in for /usr/lib/command-not-found: a real script the
+	// fake handler will invoke. The mere fact that the trap fires
+	// for a path-prefixed file with a locked agent is what used to
+	// paint the warning, so the script's contents don't matter.
+	cnf := filepath.Join(dir, "command-not-found")
+	if err := os.WriteFile(cnf, []byte("#!/bin/sh\necho 'apt would suggest something here' >&2\nexit 127\n"), 0755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Empty runtime dir → no agent socket → locked-agent path.
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+eval "$(%s/jitenv hook bash)"
+command_not_found_handle() {
+    %q "$@"
+    return 127
+}
+xyzfdsa-typo
+`, binDir, binDir, cnf,
+	))
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_HOOK_DELAY=1",
+	)
+	start := time.Now()
+	out, _ := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+	got := string(out)
+	if strings.Contains(got, "agent is not loaded") {
+		t.Errorf("hook leaked the agent-down warning for command_not_found_handle; got:\n%s", got)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("hook should short-circuit on command_not_found_handle; took %s\n%s", elapsed, got)
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -51,6 +51,13 @@ __jitenv_log() {
 __jitenv_debug_trap() {
     [[ -n "${__JITENV_REENTRY:-}" ]] && return 0
 
+    # Skip while bash is running a programmable-completion function —
+    # the DEBUG trap fires on commands inside compfuncs too, and we
+    # don't want to paint the agent-unreachable countdown when the
+    # user just hit Tab. COMP_LINE / COMP_POINT are only set during
+    # completion, so they're a clean signal. (issue #30)
+    [[ -n "${COMP_LINE-}" || -n "${COMP_POINT-}" ]] && return 0
+
     local cmd="$BASH_COMMAND"
     local first_raw; first_raw="${cmd%% *}"
     [[ -z "$first_raw" ]] && return 0

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -58,6 +58,17 @@ __jitenv_debug_trap() {
     # completion, so they're a clean signal. (issue #30)
     [[ -n "${COMP_LINE-}" || -n "${COMP_POINT-}" ]] && return 0
 
+    # Skip when bash is running its command-not-found handler. On
+    # Debian/Ubuntu the handler shells out to /usr/lib/command-not-found
+    # to suggest an apt package; that path-prefixed call would
+    # otherwise hit the warn branch with a locked agent and paint the
+    # countdown for every typo. The handler runs as the bash function
+    # `command_not_found_handle` (or `_handler` on some distros), so
+    # FUNCNAME shows it on the call stack while the trap fires.
+    case " ${FUNCNAME[*]} " in
+        *" command_not_found_handle "*|*" command_not_found_handler "*) return 0 ;;
+    esac
+
     local cmd="$BASH_COMMAND"
     local first_raw; first_raw="${cmd%% *}"
     [[ -z "$first_raw" ]] && return 0


### PR DESCRIPTION
Single-file fix for #30.

## Problem

Bash runs the DEBUG trap on commands inside programmable-completion functions too. After running a mapped file once, pressing Tab to complete the next command fires the trap on each compfunc-internal command. With a locked agent, the path-mapped branch hits `rc=2` and paints the red 10-second "agent is not loaded" countdown on every Tab press.

zsh's `preexec` widget does not fire during completion, so this is bash-only.

## Fix

`COMP_LINE` and `COMP_POINT` are set by bash only while a completion function is running. Bailing out at the top of `__jitenv_debug_trap` when either is set is the right shape — exactly the signal bash uses to scope completion state.

```sh
[[ -n "${COMP_LINE-}" || -n "${COMP_POINT-}" ]] && return 0
```

Seven lines added (5 of comment + 1 of code + 1 blank), no other changes.

## Test plan
- [x] `make test` — green; existing path-mapped + agent-down suite unchanged.
- [x] `go vet ./...` clean.
- [x] Reviewer (interactive bash): unlock agent, run a mapped script once, lock the agent, then `./mapped<Tab><Tab>`. Confirm no red countdown appears.
- [x] Reviewer: with `JITENV_HOOK_DEBUG=1` set, confirm no `is-mapped rc=` lines log during Tab presses.
- [x] Reviewer: confirm running the mapped file directly (no Tab) still routes through `jitenv run`.

Closes #30.