### PR TITLE
feat: cwd_glob mappings via PATH-prepend wrappers

### DIFF
--- a/cmd/jitenv/main.go
+++ b/cmd/jitenv/main.go
@@ -3,12 +3,23 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/gv/jitenv/internal/cli"
+	"github.com/gv/jitenv/internal/shim"
 	_ "github.com/gv/jitenv/internal/sources/builtin"
 )
 
 func main() {
+	// When invoked under any name other than "jitenv", we are running
+	// as a wrapper symlink for a cwd_glob mapping (e.g.
+	// ~/.cache/jitenv/shells/<pid>/bin/npm → jitenv). Dispatch to the
+	// shim entrypoint without going through cobra so cold start stays
+	// fast for these per-command wrappings.
+	if base := filepath.Base(os.Args[0]); base != "jitenv" && base != "" {
+		shim.Main(base, os.Args[1:])
+		return
+	}
 	if err := cli.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -65,19 +65,68 @@ The "expand" shape is the one most people miss reading the schema.
 It's exactly what the TUI's "tick the bag" mode produces — useful when
 a bag's keys already match the env var names you want.
 
-## Path vs. glob
+## Mapping kinds: path, glob, cwd_glob
 
-A mapping's target is either a `path` (string, absolute or
-`~`-relative) or a `glob` (matched with [doublestar](https://github.com/bmatcuk/doublestar/v4)).
+A mapping picks **one** target shape:
 
-- Path matches are exact and faster.
-- Glob patterns support `**` (recursive), `*`, `?`, `[…]` and curly
-  alternation. Common useful patterns: `~/work/**/*.sh`,
-  `**/scripts/deploy*`.
-- Lookup order is **declaration order**: exact paths first, then each
-  matching glob. When two entries provide the same env var name, the
-  later one wins. This is intentional — a glob can supply defaults
-  while a more specific path overrides individual vars.
+- `path` — exact filesystem path. Fast lookup.
+- `glob` — [doublestar](https://github.com/bmatcuk/doublestar/v4)
+  pattern matched against an executed file's resolved path. Supports
+  `**`, `*`, `?`, `[…]` and curly alternation. Common useful patterns:
+  `~/work/**/*.sh`, `**/scripts/deploy*`.
+- `cwd_glob` — pattern matched against `$PWD` (and any ancestor). For
+  cwd mappings the shell hook generates a per-shell symlink farm on
+  `chpwd`, one symlink per command in the required `commands = [...]`
+  list. The user runs `npm` (etc.); the shell resolves the wrapper
+  symlink first; the wrapper (`jitenv __shim`) fetches env vars from
+  the agent and `syscall.Exec`s the real binary.
+
+Lookup order for path/glob is **declaration order**: exact paths
+first, then each matching glob. When two entries provide the same
+env-var name, the later one wins. cwd_glob mappings live on a
+separate index keyed by command name.
+
+```toml
+# Anything I run inside ~/work/acme gets the API token, but only
+# for the listed commands. The empty / wildcard form is rejected.
+[[mappings]]
+cwd_glob = "~/work/acme"
+commands = ["npm", "yarn"]
+[[mappings.vars]]
+name   = "ACME_API_TOKEN"
+source = "local"
+ref    = "acme"
+key    = "API_TOKEN"
+```
+
+### How cwd_glob works under the hood
+
+The shell hook prepends a per-shell wrapper directory
+(`$XDG_RUNTIME_DIR/jitenv/shells/<pid>/bin`) to `$PATH` once at hook
+load. The directory starts empty.
+
+On every `chpwd` (zsh native; bash via a one-liner PWD-diff inside
+`PROMPT_COMMAND`), the hook calls `jitenv __chpwd <pid> <oldpwd>
+<newpwd>`. That subcommand asks the agent for the union of `commands`
+across cwd_glob mappings whose pattern matches the new pwd, and
+reconciles the wrapper directory: adds missing symlinks, removes
+extras. Outside any mapped directory, the directory is empty and
+the shell falls through to the real `$PATH` entries — zero overhead
+on commands you didn't opt into wrapping.
+
+When the user runs e.g. `npm`, the shell resolves the wrapper
+symlink first; the symlink points at the jitenv binary itself.
+`os.Args[0]` tells main.go this is a shim invocation (not the
+canonical `jitenv` name), and dispatch goes to `jitenv __shim`.
+The shim resolves the real `npm` via `$PATH` minus its own
+directory (so it doesn't loop back into itself), asks the agent
+for env vars keyed by (cwd, command), and `syscall.Exec`s the real
+command with the merged env.
+
+Stale wrapper directories left behind by crashed shells are
+GC'd by the agent on the next `Listen`: any `<pid>/` whose pid is no
+longer alive is removed. `XDG_RUNTIME_DIR` itself wipes at logout on
+systemd-logind systems, so this GC is mostly belt-and-suspenders.
 
 ## Agent
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -118,6 +118,42 @@ Atomic save via `config.AtomicSave` (sibling tempfile + rename, mode
   fiddling and offers little against the local-root threat that
   actually matters.
 
+## cwd_glob mappings widen the blast radius
+
+Path and glob mappings only inject env vars into the *one specific
+file* you executed. A cwd_glob mapping is broader: every command in
+its required `commands = [...]` list, run inside the matched
+directory, gets the env vars. The boundary is "one descendant
+process at a time", but the set of triggering commands is anything
+you (or anything you run) types in that directory whose name
+appears in the explicit list.
+
+What's still protected:
+
+- The parent shell never has the secrets in its own environ. Each
+  triggering command gets them at exec, and they live in that
+  child's process tree only.
+- Only commands you explicitly listed get wrapped. Wildcard
+  ("any command") is rejected; the symlink farm is built strictly
+  from the `commands` list.
+- `cd`-ing out of the mapped directory in the calling shell
+  removes the wrapper symlinks on the next prompt — but doesn't
+  strip the secrets from already-running children, which inherited
+  them at spawn time.
+
+What to be aware of:
+
+- A malicious binary on `$PATH` named the same as a wrapped command
+  (e.g. you have `commands = ["npm"]` and there's a rogue `npm`
+  earlier in `$PATH` than the system one) would receive the env
+  vars too. Same exposure profile as `direnv`'s `PATH_add`.
+- The wrapper directory lives under `$XDG_RUNTIME_DIR/jitenv/shells/`
+  with mode 0700 — anyone who can write to that path could plant
+  a malicious symlink. The runtime dir itself is mode 0700 and
+  user-only by systemd-tmpfiles.
+- On agent down, the shim runs the real command with the parent
+  env (no wrapping). Same UX as the locked-agent path elsewhere.
+
 ## Why this design over `.env` files
 
 A `.env` file in your project (or `direnv`-style auto-export) puts

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -34,6 +34,10 @@ func (f *fakeResolver) IsMapped(p string) bool { return f.mapped[p] }
 func (f *fakeResolver) FetchEnv(_ context.Context, p string) (map[string]string, error) {
 	return f.env[p], nil
 }
+func (f *fakeResolver) FetchEnvCwd(_ context.Context, _, _ string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeResolver) CwdCommands(string) []string { return nil }
 
 func TestAgentStatusAndLock(t *testing.T) {
 	a, p := newTestAgent(t, nil)

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -74,6 +74,26 @@ func (c *Client) FetchEnv(ctx context.Context, path string) (map[string]string, 
 	return r.Env, nil
 }
 
+// FetchEnvCwd is the cwd_glob counterpart to FetchEnv. Used by the
+// wrapper-symlink shim.
+func (c *Client) FetchEnvCwd(ctx context.Context, pwd, command string) (map[string]string, error) {
+	r, err := c.call(ctx, Request{Op: OpFetchEnvCwd, Cwd: pwd, Command: command})
+	if err != nil {
+		return nil, err
+	}
+	return r.Env, nil
+}
+
+// CwdCommands asks the agent which command names should be wrapped at
+// pwd. Returns nil when no cwd_glob mapping matches.
+func (c *Client) CwdCommands(ctx context.Context, pwd string) ([]string, error) {
+	r, err := c.call(ctx, Request{Op: OpCwdCommands, Cwd: pwd})
+	if err != nil {
+		return nil, err
+	}
+	return r.Commands, nil
+}
+
 // Reload asks the agent to re-read the config file from disk and rebuild
 // its resolver. Used by the TUI after a successful save.
 func (c *Client) Reload(ctx context.Context) error {

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -8,10 +8,18 @@ import (
 
 // Paths describes the per-user runtime locations the agent uses.
 type Paths struct {
-	Dir     string
-	Socket  string
-	PidFile string
-	LogFile string
+	Dir       string
+	Socket    string
+	PidFile   string
+	LogFile   string
+	ShellsDir string // per-shell wrapper-symlink dirs live here
+}
+
+// ShellWrapDir returns the per-shell wrapper-symlink directory for the
+// given shell pid. The chpwd helper populates it; the shim subcommand
+// runs out of it.
+func (p Paths) ShellWrapDir(shellPid int) string {
+	return filepath.Join(p.ShellsDir, fmt.Sprintf("%d", shellPid), "bin")
 }
 
 // DefaultPaths returns the per-user paths under $XDG_RUNTIME_DIR (preferred)
@@ -27,9 +35,48 @@ func DefaultPaths() (Paths, error) {
 		return Paths{}, err
 	}
 	return Paths{
-		Dir:     dir,
-		Socket:  filepath.Join(dir, "agent.sock"),
-		PidFile: filepath.Join(dir, "agent.pid"),
-		LogFile: filepath.Join(dir, "agent.log"),
+		Dir:       dir,
+		Socket:    filepath.Join(dir, "agent.sock"),
+		PidFile:   filepath.Join(dir, "agent.pid"),
+		LogFile:   filepath.Join(dir, "agent.log"),
+		ShellsDir: filepath.Join(dir, "shells"),
 	}, nil
+}
+
+// GcOrphanShells walks ShellsDir and removes any <pid>/ subdirectory
+// whose pid is no longer alive. Used at agent startup to reap wrapper
+// dirs left behind by crashed shells.
+func GcOrphanShells(shellsDir string) error {
+	entries, err := os.ReadDir(shellsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, perr := parseShellPid(e.Name())
+		if perr != nil {
+			continue
+		}
+		if pid > 0 && PidAlive(pid) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(shellsDir, e.Name()))
+	}
+	return nil
+}
+
+func parseShellPid(name string) (int, error) {
+	pid := 0
+	for _, c := range name {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a pid")
+		}
+		pid = pid*10 + int(c-'0')
+	}
+	return pid, nil
 }

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -11,24 +11,29 @@ import (
 type Op string
 
 const (
-	OpStatus   Op = "status"
-	OpIsMapped Op = "is_mapped"
-	OpFetchEnv Op = "fetch_env"
-	OpLock     Op = "lock"
-	OpReload   Op = "reload"
+	OpStatus      Op = "status"
+	OpIsMapped    Op = "is_mapped"
+	OpFetchEnv    Op = "fetch_env"
+	OpLock        Op = "lock"
+	OpReload      Op = "reload"
+	OpFetchEnvCwd Op = "fetch_env_cwd" // shim → agent: env vars for (cwd, command)
+	OpCwdCommands Op = "cwd_commands"  // chpwd helper → agent: list of commands wrapped at this cwd
 )
 
 type Request struct {
-	Op   Op     `json:"op"`
-	Path string `json:"path,omitempty"`
+	Op      Op     `json:"op"`
+	Path    string `json:"path,omitempty"`
+	Cwd     string `json:"cwd,omitempty"`
+	Command string `json:"command,omitempty"`
 }
 
 type Response struct {
-	OK     bool              `json:"ok"`
-	Error  string            `json:"error,omitempty"`
-	Mapped bool              `json:"mapped,omitempty"`
-	Env    map[string]string `json:"env,omitempty"`
-	Status *Status           `json:"status,omitempty"`
+	OK       bool              `json:"ok"`
+	Error    string            `json:"error,omitempty"`
+	Mapped   bool              `json:"mapped,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	Status   *Status           `json:"status,omitempty"`
+	Commands []string          `json:"commands,omitempty"`
 }
 
 type Status struct {

--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -68,7 +68,20 @@ func (r *resolver) FetchEnv(ctx context.Context, absPath string) (map[string]str
 	if err != nil {
 		abs = absPath
 	}
-	vars := r.index.Lookup(abs)
+	return r.fetchVars(ctx, r.index.Lookup(abs))
+}
+
+func (r *resolver) FetchEnvCwd(ctx context.Context, pwd, command string) (map[string]string, error) {
+	return r.fetchVars(ctx, r.index.LookupCwd(pwd, command))
+}
+
+func (r *resolver) CwdCommands(pwd string) []string {
+	return r.index.CwdCommands(pwd)
+}
+
+// fetchVars runs the per-VarRef Fetch loop. Shared between path-keyed
+// FetchEnv and cwd-keyed FetchEnvCwd.
+func (r *resolver) fetchVars(ctx context.Context, vars []config.VarRef) (map[string]string, error) {
 	out := map[string]string{}
 	for _, v := range vars {
 		s, ok := r.sources[v.Source]
@@ -84,7 +97,6 @@ func (r *resolver) FetchEnv(ctx context.Context, absPath string) (map[string]str
 			return nil, fmt.Errorf("fetch %s: %w", labelOrAll(v.Name), err)
 		}
 		if v.Name == "" {
-			// Expand-all: every key in `raw` becomes its own env var.
 			for k, val := range raw {
 				out[k] = val
 			}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -36,11 +36,17 @@ type Agent struct {
 }
 
 // Resolver is the agent-internal hook to resolve mapping + fetch env vars.
-// Step 5 leaves this nil; step 10 wires it up.
 type Resolver interface {
 	Sources() []string
 	IsMapped(absPath string) bool
 	FetchEnv(ctx context.Context, absPath string) (map[string]string, error)
+
+	// FetchEnvCwd serves the wrapper shim: env vars for (pwd, command).
+	// Empty map when no cwd_glob mapping matches.
+	FetchEnvCwd(ctx context.Context, pwd, command string) (map[string]string, error)
+	// CwdCommands serves the chpwd helper: union of every cwd_glob
+	// mapping's commands list whose pattern matches pwd.
+	CwdCommands(pwd string) []string
 }
 
 // NewAgent constructs an Agent ready to Serve.
@@ -69,7 +75,11 @@ func (a *Agent) currentResolver() Resolver {
 }
 
 // Listen creates the unix socket. Caller must call Serve to accept.
+//
+// Also runs a one-time GC pass over ShellsDir, removing wrapper dirs
+// for shell pids that aren't alive anymore. Cheap, idempotent.
 func (a *Agent) Listen() error {
+	_ = GcOrphanShells(a.paths.ShellsDir)
 	if existing, _ := ReadPidFile(a.paths.PidFile); existing > 0 && PidAlive(existing) {
 		return fmt.Errorf("agent already running (pid %d)", existing)
 	}
@@ -240,6 +250,22 @@ func (a *Agent) dispatch(ctx context.Context, req Request) Response {
 			return Response{OK: false, Error: err.Error()}
 		}
 		return Response{OK: true, Env: env}
+	case OpFetchEnvCwd:
+		r := a.currentResolver()
+		if r == nil {
+			return Response{OK: true, Env: map[string]string{}}
+		}
+		env, err := r.FetchEnvCwd(ctx, req.Cwd, req.Command)
+		if err != nil {
+			return Response{OK: false, Error: err.Error()}
+		}
+		return Response{OK: true, Env: env}
+	case OpCwdCommands:
+		r := a.currentResolver()
+		if r == nil {
+			return Response{OK: true, Commands: nil}
+		}
+		return Response{OK: true, Commands: r.CwdCommands(req.Cwd)}
 	case OpReload:
 		a.mu.Lock()
 		fn := a.reload

--- a/internal/agentwarn/agentwarn.go
+++ b/internal/agentwarn/agentwarn.go
@@ -1,0 +1,91 @@
+// Package agentwarn renders the "agent is not loaded" countdown
+// shared by the path-mapped runner (jitenv run) and the cwd_glob shim.
+//
+// During the countdown the user can:
+//
+//	wait     → caller proceeds with the parent environment.
+//	Enter    → caller proceeds immediately, no further wait.
+//	Ctrl+C   → caller aborts; nothing runs.
+//
+// JITENV_HOOK_DELAY (default 10) controls the wait length to match
+// the shell-hook knob.
+package agentwarn
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+)
+
+// WarnAndWait paints the warning + countdown to stderr and returns
+// true when the user aborted via Ctrl+C (caller should not exec).
+// Returns false on Enter or timeout (caller should exec, possibly
+// without injected env vars).
+func WarnAndWait(target string) bool {
+	const red = "\033[1;31m"
+	const reset = "\033[0m"
+
+	total := 10
+	if v := os.Getenv("JITENV_HOOK_DELAY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			total = n
+		}
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
+		red, target, reset)
+	fmt.Fprintf(os.Stderr,
+		"%sWill run the command anyway in %ds. Press Enter to skip, Ctrl+C to abort.%s\n",
+		red, total, reset)
+
+	if total == 0 {
+		return false
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	// Drain stdin in a goroutine; signal on the first newline. We
+	// don't tear it down at return time: the caller is about to
+	// syscall.Exec, which replaces the process image and reaps the
+	// goroutine for free.
+	enterCh := make(chan struct{}, 1)
+	go func() {
+		buf := make([]byte, 1)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if err != nil || n == 0 {
+				return
+			}
+			if buf[0] == '\n' || buf[0] == '\r' {
+				select {
+				case enterCh <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+
+	for i := total; i > 0; i-- {
+		fmt.Fprintf(os.Stderr, "\r%s  %2ds remaining %s", red, i, reset)
+		select {
+		case <-sigCh:
+			fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
+			return true
+		case <-enterCh:
+			fmt.Fprintln(os.Stderr)
+			return false
+		case <-tick.C:
+		}
+	}
+	fmt.Fprintln(os.Stderr)
+	return false
+}

--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -1,0 +1,130 @@
+// Package chpwd is the entrypoint for the `jitenv __chpwd` subcommand.
+// The shell hooks call it on every directory change with the shell pid,
+// the previous PWD, and the new PWD.
+//
+// Behaviour:
+//
+//  1. Ask the agent for the union of cwd_glob mappings' commands lists
+//     that match newPwd.
+//  2. Compute the delta against the per-shell wrapper bin dir and add
+//     / remove symlinks accordingly.
+//  3. The wrapper dir is always present in $PATH (the shell hook puts
+//     it there at init time); we just populate or empty it.
+//
+// Agent-down → no-op, exit 0. The shell hook can't tell anything from
+// a non-zero exit anyway, and we don't want to block the user's prompt.
+package chpwd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/gv/jitenv/internal/agent"
+)
+
+// Run is the chpwd entrypoint. Args are the verbatim positional args
+// after `jitenv __chpwd` — at least three: shell pid, oldpwd, newpwd.
+// oldpwd may be empty on the very first call from a shell.
+func Run(args []string) error {
+	if len(args) < 3 {
+		return errors.New("usage: jitenv __chpwd <shell-pid> <oldpwd> <newpwd>")
+	}
+	pid, err := strconv.Atoi(args[0])
+	if err != nil || pid <= 0 {
+		return fmt.Errorf("invalid shell pid %q", args[0])
+	}
+	newPwd := args[2]
+
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		return err
+	}
+	wrapDir := paths.ShellWrapDir(pid)
+
+	wanted, err := desiredCommands(paths.Socket, newPwd)
+	if err != nil {
+		// Agent unreachable or other error: leave the wrapper dir
+		// alone and stay quiet. Returning nil keeps the shell hook
+		// happy.
+		return nil
+	}
+	return reconcile(wrapDir, wanted)
+}
+
+func desiredCommands(socket, pwd string) ([]string, error) {
+	if _, err := os.Stat(socket); err != nil {
+		return nil, err // agent down
+	}
+	cli := agent.NewClient(socket)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	return cli.CwdCommands(ctx, pwd)
+}
+
+// reconcile makes the wrapper dir contain exactly one symlink per
+// `wanted` command, all pointing at the running jitenv binary. Extra
+// symlinks are removed. Cheap to call repeatedly with the same set —
+// it short-circuits when the dir already matches.
+func reconcile(wrapDir string, wanted []string) error {
+	if len(wanted) == 0 {
+		// No mapping → empty the dir if it exists. We don't remove
+		// the dir itself; the shell hook keeps it in $PATH.
+		entries, err := os.ReadDir(wrapDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, e := range entries {
+			_ = os.Remove(filepath.Join(wrapDir, e.Name()))
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(wrapDir, 0o700); err != nil {
+		return err
+	}
+
+	target, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	want := make(map[string]struct{}, len(wanted))
+	for _, c := range wanted {
+		want[c] = struct{}{}
+	}
+
+	// Drop unwanted symlinks.
+	entries, err := os.ReadDir(wrapDir)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if _, ok := want[name]; ok {
+			continue
+		}
+		_ = os.Remove(filepath.Join(wrapDir, name))
+	}
+
+	// Add missing ones.
+	for _, c := range wanted {
+		link := filepath.Join(wrapDir, c)
+		existing, err := os.Readlink(link)
+		if err == nil && existing == target {
+			continue
+		}
+		_ = os.Remove(link) // tolerate stale entries
+		if err := os.Symlink(target, link); err != nil {
+			return fmt.Errorf("symlink %s: %w", link, err)
+		}
+	}
+	return nil
+}

--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -4,27 +4,28 @@
 //
 // Behaviour:
 //
-//  1. Ask the agent for the union of cwd_glob mappings' commands lists
-//     that match newPwd.
-//  2. Compute the delta against the per-shell wrapper bin dir and add
-//     / remove symlinks accordingly.
-//  3. The wrapper dir is always present in $PATH (the shell hook puts
-//     it there at init time); we just populate or empty it.
+//  1. Read the config file directly (no agent required, no decryption
+//     required — cwd_glob and commands are plaintext fields).
+//  2. Compute the union of `commands` lists across cwd_glob mappings
+//     whose pattern matches newPwd.
+//  3. Reconcile the per-shell wrapper bin dir: add missing symlinks,
+//     remove extras.
 //
-// Agent-down → no-op, exit 0. The shell hook can't tell anything from
-// a non-zero exit anyway, and we don't want to block the user's prompt.
+// Reading config directly (rather than going through the agent) means
+// the wrapper symlinks are correct whether the agent is locked or
+// running. The agent stays in the critical path only at shim-time
+// (to fetch the actual env var values, which DO require decryption).
 package chpwd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
-	"time"
 
 	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
 )
 
 // Run is the chpwd entrypoint. Args are the verbatim positional args
@@ -48,42 +49,40 @@ func Run(args []string) error {
 
 	debugLog("pid=%d oldpwd=%q newpwd=%q wrapDir=%q", pid, args[1], newPwd, wrapDir)
 
-	wanted, err := desiredCommands(paths.Socket, newPwd)
+	wanted, err := desiredCommands(newPwd)
 	if err != nil {
-		debugLog("desiredCommands error: %v (agent down? config not reloaded?)", err)
-		// Agent unreachable or other error: leave the wrapper dir
-		// alone and stay quiet. Returning nil keeps the shell hook
-		// happy.
+		debugLog("desiredCommands error: %v", err)
+		// Config missing or malformed: leave the wrapper dir alone
+		// so a momentary parse error doesn't tear down a working
+		// state. Returning nil keeps the shell hook quiet.
 		return nil
 	}
-	debugLog("agent reports wanted=%v", wanted)
+	debugLog("config reports wanted=%v", wanted)
 	if err := reconcile(wrapDir, wanted); err != nil {
 		debugLog("reconcile error: %v", err)
 		return err
 	}
-	debugLog("reconcile ok")
+	debugLog("reconcile ok (%d symlinks)", len(wanted))
 	return nil
 }
 
-// debugLog writes one line to stderr when JITENV_HOOK_DEBUG is set.
-// The shell hooks already gate their own debug output the same way,
-// so users get a single switch to see the whole chpwd → shim → agent
-// path.
-func debugLog(format string, args ...any) {
-	if os.Getenv("JITENV_HOOK_DEBUG") == "" {
-		return
+// desiredCommands reads the on-disk config and returns the union of
+// every cwd_glob mapping's commands list whose pattern matches pwd.
+// No agent contact, no decryption — the cwd_glob and commands fields
+// are plaintext TOML.
+func desiredCommands(pwd string) ([]string, error) {
+	cfgPath, err := config.Resolve(os.Getenv("JITENV_CONFIG"))
+	if err != nil {
+		return nil, err
 	}
-	fmt.Fprintf(os.Stderr, "jitenv-chpwd: "+format+"\n", args...)
-}
-
-func desiredCommands(socket, pwd string) ([]string, error) {
-	if _, err := os.Stat(socket); err != nil {
-		return nil, err // agent down
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return nil, err
 	}
-	cli := agent.NewClient(socket)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	return cli.CwdCommands(ctx, pwd)
+	if len(cfg.Mappings) == 0 {
+		return nil, nil
+	}
+	return config.NewIndex(cfg.Mappings).CwdCommands(pwd), nil
 }
 
 // reconcile makes the wrapper dir contain exactly one symlink per
@@ -147,4 +146,15 @@ func reconcile(wrapDir string, wanted []string) error {
 		}
 	}
 	return nil
+}
+
+// debugLog writes one line to stderr when JITENV_HOOK_DEBUG is set.
+// The shell hooks already gate their own debug output the same way,
+// so users get a single switch to see the whole chpwd → shim → agent
+// path.
+func debugLog(format string, args ...any) {
+	if os.Getenv("JITENV_HOOK_DEBUG") == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "jitenv-chpwd: "+format+"\n", args...)
 }

--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -46,14 +46,34 @@ func Run(args []string) error {
 	}
 	wrapDir := paths.ShellWrapDir(pid)
 
+	debugLog("pid=%d oldpwd=%q newpwd=%q wrapDir=%q", pid, args[1], newPwd, wrapDir)
+
 	wanted, err := desiredCommands(paths.Socket, newPwd)
 	if err != nil {
+		debugLog("desiredCommands error: %v (agent down? config not reloaded?)", err)
 		// Agent unreachable or other error: leave the wrapper dir
 		// alone and stay quiet. Returning nil keeps the shell hook
 		// happy.
 		return nil
 	}
-	return reconcile(wrapDir, wanted)
+	debugLog("agent reports wanted=%v", wanted)
+	if err := reconcile(wrapDir, wanted); err != nil {
+		debugLog("reconcile error: %v", err)
+		return err
+	}
+	debugLog("reconcile ok")
+	return nil
+}
+
+// debugLog writes one line to stderr when JITENV_HOOK_DEBUG is set.
+// The shell hooks already gate their own debug output the same way,
+// so users get a single switch to see the whole chpwd → shim → agent
+// path.
+func debugLog(format string, args ...any) {
+	if os.Getenv("JITENV_HOOK_DEBUG") == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "jitenv-chpwd: "+format+"\n", args...)
 }
 
 func desiredCommands(socket, pwd string) ([]string, error) {

--- a/internal/cli/chpwd_internal.go
+++ b/internal/cli/chpwd_internal.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/gv/jitenv/internal/chpwd"
+)
+
+// newChpwdInternalCmd is the entrypoint shells call from their chpwd /
+// PROMPT_COMMAND hook. Hidden because end-users never run it directly.
+//
+//	jitenv __chpwd <shell-pid> <oldpwd> <newpwd>
+func newChpwdInternalCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "__chpwd <shell-pid> <oldpwd> <newpwd>",
+		Hidden: true,
+		Args:   cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return chpwd.Run(args)
+		},
+	}
+}

--- a/internal/cli/ismapped.go
+++ b/internal/cli/ismapped.go
@@ -1,42 +1,50 @@
 package cli
 
 import (
-	"context"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
 )
 
+// newIsMappedCmd answers "is this path covered by a mapping?" by
+// reading the config file directly. The agent isn't consulted —
+// path / glob / cwd_glob / commands are all plaintext TOML, so we
+// don't need the master key to answer. Reading config keeps the
+// answer correct whether the agent is locked, running with a stale
+// in-memory config, or never started.
+//
+// Exit codes (load-bearing — bash + zsh hooks switch on them):
+//
+//	0   path is mapped
+//	1   path is NOT mapped
+//	2   could not determine (config missing / unparseable)
 func newIsMappedCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:           "is-mapped <path>",
-		Short:         "Exit 0 if path is mapped to env vars in the running agent",
+		Short:         "Exit 0 if a mapping covers <path>, 1 if not, 2 if config is unreadable",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			abs, err := filepath.Abs(args[0])
 			if err != nil {
-				return err
+				os.Exit(2)
 			}
-			paths, err := agent.DefaultPaths()
+			cfgPath, err := config.Resolve(os.Getenv("JITENV_CONFIG"))
 			if err != nil {
-				return err
+				os.Exit(2)
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			cli := agent.NewClient(paths.Socket)
-			ok, err := cli.IsMapped(ctx, abs)
+			cfg, err := config.Load(cfgPath)
 			if err != nil {
-				os.Exit(2) // agent unreachable
+				os.Exit(2)
 			}
-			if !ok {
-				os.Exit(1)
+			if config.NewIndex(cfg.Mappings).Mapped(abs) {
+				return nil
 			}
+			os.Exit(1)
 			return nil
 		},
 	}

--- a/internal/cli/subcommands.go
+++ b/internal/cli/subcommands.go
@@ -16,5 +16,6 @@ func subcommands() []*cobra.Command {
 		newRunCmd(),
 		newHookCmd(),
 		newAgentInternalCmd(),
+		newChpwdInternalCmd(),
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,9 +41,24 @@ type SourceConfig struct {
 }
 
 type Mapping struct {
-	Path string   `toml:"path,omitempty"`
-	Glob string   `toml:"glob,omitempty"`
-	Vars []VarRef `toml:"vars"`
+	Path     string   `toml:"path,omitempty"`
+	Glob     string   `toml:"glob,omitempty"`
+	CwdGlob  string   `toml:"cwd_glob,omitempty"`
+	Commands []string `toml:"commands,omitempty"` // required when CwdGlob is set
+	Vars     []VarRef `toml:"vars"`
+}
+
+// Kind reports which match-shape a mapping uses.
+func (m Mapping) Kind() string {
+	switch {
+	case m.Path != "":
+		return "path"
+	case m.Glob != "":
+		return "glob"
+	case m.CwdGlob != "":
+		return "cwd"
+	}
+	return ""
 }
 
 type VarRef struct {
@@ -92,8 +107,31 @@ func (c *Config) Validate() error {
 		}
 	}
 	for i, m := range c.Mappings {
-		if (m.Path == "") == (m.Glob == "") {
-			return fmt.Errorf("mapping[%d]: exactly one of path or glob is required", i)
+		set := 0
+		if m.Path != "" {
+			set++
+		}
+		if m.Glob != "" {
+			set++
+		}
+		if m.CwdGlob != "" {
+			set++
+		}
+		if set != 1 {
+			return fmt.Errorf("mapping[%d]: exactly one of path, glob, or cwd_glob is required", i)
+		}
+		if m.CwdGlob == "" && len(m.Commands) > 0 {
+			return fmt.Errorf("mapping[%d]: commands is only valid with cwd_glob", i)
+		}
+		if m.CwdGlob != "" {
+			if len(m.Commands) == 0 {
+				return fmt.Errorf("mapping[%d]: cwd_glob requires a non-empty commands list", i)
+			}
+			for j, cmd := range m.Commands {
+				if cmd == "" {
+					return fmt.Errorf("mapping[%d].commands[%d]: empty command name", i, j)
+				}
+			}
 		}
 		if len(m.Vars) == 0 {
 			return fmt.Errorf("mapping[%d]: at least one var is required", i)

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -1,20 +1,30 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
 
-// Index is a lookup of mappings by path/glob, optimized for is-mapped queries.
+// Index is a lookup of mappings by path/glob/cwd_glob, optimized for
+// is-mapped queries.
 type Index struct {
-	exact map[string][]VarRef
-	globs []globEntry
+	exact    map[string][]VarRef
+	globs    []globEntry
+	cwdGlobs []cwdGlobEntry
 }
 
 type globEntry struct {
 	pattern string
 	vars    []VarRef
+}
+
+type cwdGlobEntry struct {
+	pattern  string // tilde-expanded at index-build time
+	commands []string
+	vars     []VarRef
 }
 
 // NewIndex builds an Index from the parsed config.
@@ -23,42 +33,150 @@ func NewIndex(mappings []Mapping) *Index {
 	for _, m := range mappings {
 		switch {
 		case m.Path != "":
-			abs, err := filepath.Abs(m.Path)
+			abs, err := filepath.Abs(expandTilde(m.Path))
 			if err != nil {
 				abs = m.Path
 			}
 			idx.exact[abs] = append(idx.exact[abs], m.Vars...)
 		case m.Glob != "":
-			idx.globs = append(idx.globs, globEntry{pattern: m.Glob, vars: m.Vars})
+			idx.globs = append(idx.globs, globEntry{
+				pattern: expandTilde(m.Glob),
+				vars:    m.Vars,
+			})
+		case m.CwdGlob != "":
+			idx.cwdGlobs = append(idx.cwdGlobs, cwdGlobEntry{
+				pattern:  expandTilde(m.CwdGlob),
+				commands: append([]string(nil), m.Commands...),
+				vars:     m.Vars,
+			})
 		}
 	}
 	return idx
 }
 
 // Lookup returns the merged VarRefs for a given absolute path, in
-// declaration order: exact first, then each matching glob. Later entries
-// for the same env var name win.
+// declaration order: exact first, then each matching glob.
 func (idx *Index) Lookup(absPath string) []VarRef {
 	var out []VarRef
 	if vs, ok := idx.exact[absPath]; ok {
 		out = append(out, vs...)
 	}
 	for _, g := range idx.globs {
-		ok, err := doublestar.Match(g.pattern, absPath)
-		if err == nil && ok {
+		if ok, err := doublestar.Match(g.pattern, absPath); err == nil && ok {
 			out = append(out, g.vars...)
 		}
 	}
 	return out
 }
 
-// Mapped reports whether absPath has any mapping.
+// Mapped reports whether absPath has any path/glob mapping.
 func (idx *Index) Mapped(absPath string) bool {
 	if _, ok := idx.exact[absPath]; ok {
 		return true
 	}
 	for _, g := range idx.globs {
 		if ok, err := doublestar.Match(g.pattern, absPath); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// LookupCwd returns the merged VarRefs for a (pwd, command) pair.
+// Walks pwd ancestors against each cwd_glob's pattern so a glob like
+// "~/work/acme" applies to acme and every subdirectory. The command
+// name MUST appear in the mapping's commands list.
+func (idx *Index) LookupCwd(pwd, command string) []VarRef {
+	if len(idx.cwdGlobs) == 0 {
+		return nil
+	}
+	abs, err := filepath.Abs(expandTilde(pwd))
+	if err != nil {
+		abs = pwd
+	}
+	var out []VarRef
+	for _, e := range idx.cwdGlobs {
+		if !containsString(e.commands, command) {
+			continue
+		}
+		if matchAncestor(e.pattern, abs) {
+			out = append(out, e.vars...)
+		}
+	}
+	return out
+}
+
+// CwdCommands returns the union of every commands list across cwd_glob
+// mappings whose pattern matches pwd (or any ancestor). Used by the
+// chpwd helper to build the per-shell wrapper-symlink directory.
+func (idx *Index) CwdCommands(pwd string) []string {
+	if len(idx.cwdGlobs) == 0 {
+		return nil
+	}
+	abs, err := filepath.Abs(expandTilde(pwd))
+	if err != nil {
+		abs = pwd
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, e := range idx.cwdGlobs {
+		if !matchAncestor(e.pattern, abs) {
+			continue
+		}
+		for _, cmd := range e.commands {
+			if _, dup := seen[cmd]; dup {
+				continue
+			}
+			seen[cmd] = struct{}{}
+			out = append(out, cmd)
+		}
+	}
+	return out
+}
+
+// MappedCwd reports whether (pwd, command) has any matching cwd_glob.
+func (idx *Index) MappedCwd(pwd, command string) bool {
+	return len(idx.LookupCwd(pwd, command)) > 0
+}
+
+// matchAncestor returns true if pattern matches abs or any ancestor.
+// `cwd_glob = "~/work/acme"` therefore covers ~/work/acme and every
+// subdirectory; `**`-suffix patterns also match the root because
+// doublestar treats `**` as zero-or-more segments.
+func matchAncestor(pattern, abs string) bool {
+	for cur := abs; ; {
+		if ok, err := doublestar.Match(pattern, cur); err == nil && ok {
+			return true
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return false
+		}
+		cur = parent
+	}
+}
+
+// expandTilde resolves a leading "~/" or bare "~" against $HOME.
+func expandTilde(p string) string {
+	if p == "" || p[0] != '~' {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return p
+	}
+	if p == "~" {
+		return home
+	}
+	if strings.HasPrefix(p, "~/") {
+		return filepath.Join(home, p[2:])
+	}
+	return p
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
 			return true
 		}
 	}

--- a/internal/config/mapping_test.go
+++ b/internal/config/mapping_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIndex_LookupCwd_AncestorWalk(t *testing.T) {
+	tmp := t.TempDir()
+	deeper := filepath.Join(tmp, "acme", "service", "src")
+	if err := os.MkdirAll(deeper, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewIndex([]Mapping{{
+		CwdGlob:  filepath.Join(tmp, "acme"),
+		Commands: []string{"npm"},
+		Vars:     []VarRef{{Name: "FOO", Source: "x", Ref: "foo"}},
+	}})
+
+	// Direct match.
+	if !idx.MappedCwd(filepath.Join(tmp, "acme"), "npm") {
+		t.Errorf("expected direct cwd match")
+	}
+	// Ancestor walk: deeper directory still matches.
+	if !idx.MappedCwd(deeper, "npm") {
+		t.Errorf("expected ancestor-walk match for deeper path")
+	}
+	// Sibling: should NOT match.
+	other := filepath.Join(tmp, "other")
+	if err := os.Mkdir(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if idx.MappedCwd(other, "npm") {
+		t.Errorf("sibling directory should not match")
+	}
+}
+
+func TestIndex_LookupCwd_RequiresExplicitCommand(t *testing.T) {
+	tmp := t.TempDir()
+	idx := NewIndex([]Mapping{{
+		CwdGlob:  tmp,
+		Commands: []string{"npm", "yarn"},
+		Vars:     []VarRef{{Name: "TOK", Source: "x", Ref: "tok"}},
+	}})
+
+	if !idx.MappedCwd(tmp, "npm") {
+		t.Errorf("npm should match")
+	}
+	if !idx.MappedCwd(tmp, "yarn") {
+		t.Errorf("yarn should match")
+	}
+	if idx.MappedCwd(tmp, "python") {
+		t.Errorf("python is not in commands list — should not match")
+	}
+}
+
+func TestIndex_CwdCommands_Union(t *testing.T) {
+	tmp := t.TempDir()
+	idx := NewIndex([]Mapping{
+		{CwdGlob: tmp, Commands: []string{"npm", "yarn"}, Vars: []VarRef{{Source: "x"}}},
+		{CwdGlob: tmp, Commands: []string{"yarn", "node"}, Vars: []VarRef{{Source: "x"}}},
+	})
+	got := idx.CwdCommands(tmp)
+	want := map[string]bool{"npm": true, "yarn": true, "node": true}
+	if len(got) != len(want) {
+		t.Fatalf("CwdCommands: got %v, want union of size %d", got, len(want))
+	}
+	for _, c := range got {
+		if !want[c] {
+			t.Errorf("unexpected command %q", c)
+		}
+	}
+}
+
+func TestIndex_LookupCwd_TildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("no $HOME")
+	}
+	idx := NewIndex([]Mapping{{
+		CwdGlob:  "~",
+		Commands: []string{"npm"},
+		Vars:     []VarRef{{Source: "x"}},
+	}})
+	if !idx.MappedCwd(home, "npm") {
+		t.Errorf("tilde should expand")
+	}
+}
+
+func TestValidate_RejectsMultipleKinds(t *testing.T) {
+	c := &Config{
+		Version: Version,
+		Mappings: []Mapping{
+			{Path: "/a", Glob: "/b", Vars: []VarRef{{Source: "x"}}},
+		},
+		Sources: map[string]SourceConfig{"x": {Type: "noop"}},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error for multi-kind mapping")
+	}
+}
+
+func TestValidate_RejectsCommandsWithoutCwdGlob(t *testing.T) {
+	c := &Config{
+		Version: Version,
+		Mappings: []Mapping{
+			{Path: "/a", Commands: []string{"npm"}, Vars: []VarRef{{Source: "x"}}},
+		},
+		Sources: map[string]SourceConfig{"x": {Type: "noop"}},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error: commands without cwd_glob")
+	}
+}
+
+func TestValidate_RejectsCwdGlobWithoutCommands(t *testing.T) {
+	c := &Config{
+		Version: Version,
+		Mappings: []Mapping{
+			{CwdGlob: "/a", Vars: []VarRef{{Source: "x"}}},
+		},
+		Sources: map[string]SourceConfig{"x": {Type: "noop"}},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error: cwd_glob without commands")
+	}
+}
+
+func TestValidate_AcceptsCwdGlobWithCommands(t *testing.T) {
+	c := &Config{
+		Version: Version,
+		Mappings: []Mapping{
+			{CwdGlob: "/a/**", Commands: []string{"npm"}, Vars: []VarRef{{Source: "x"}}},
+		},
+		Sources: map[string]SourceConfig{"x": {Type: "noop"}},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -14,10 +14,19 @@ import (
 	"time"
 
 	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/agentwarn"
 )
 
 // Run resolves file, asks the agent for any mapped env vars, then
 // replaces the current process with file+args+merged-env.
+//
+// When the agent is unreachable (locked, never started, …), the
+// command isn't refused: the user gets the same "agent is not
+// loaded — Press Enter to skip, Ctrl+C to abort" countdown the
+// shim uses, and after the wait the script runs with the parent
+// env. This is what the bash hook used to paint inline; moving it
+// here means `jitenv run`'s behaviour is consistent whether it was
+// invoked by the hook, by hand, or by another tool.
 func Run(ctx context.Context, file string, args []string) error {
 	abs, err := filepath.Abs(file)
 	if err != nil {
@@ -31,19 +40,40 @@ func Run(ctx context.Context, file string, args []string) error {
 	if err != nil {
 		return err
 	}
-	cli := agent.NewClient(paths.Socket)
+
+	env := os.Environ()
+	if extra, err := fetchOrWarn(ctx, paths.Socket, abs); err != nil {
+		return err
+	} else {
+		for k, v := range extra {
+			env = append(env, k+"="+v)
+		}
+	}
+	return replaceProcess(abs, args, env)
+}
+
+// fetchOrWarn tries to fetch env vars from the agent. On agent-down
+// it paints the warning + countdown; the returned map is nil (caller
+// should run with the parent env). Returns an error only when the
+// user aborted via Ctrl+C.
+func fetchOrWarn(ctx context.Context, socket, abs string) (map[string]string, error) {
+	if _, err := os.Stat(socket); err != nil {
+		if agentwarn.WarnAndWait(abs) {
+			return nil, errors.New("aborted")
+		}
+		return nil, nil
+	}
+	cli := agent.NewClient(socket)
 	dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	extra, err := cli.FetchEnv(dctx, abs)
 	if err != nil {
-		return fmt.Errorf("agent unreachable; run `jitenv unlock` first: %w", err)
+		if agentwarn.WarnAndWait(abs) {
+			return nil, errors.New("aborted")
+		}
+		return nil, nil
 	}
-
-	env := os.Environ()
-	for k, v := range extra {
-		env = append(env, k+"="+v)
-	}
-	return replaceProcess(abs, args, env)
+	return extra, nil
 }
 
 // replaceProcess substitutes the current process image with the given

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -101,16 +101,22 @@ func TestRunInjectsEnvAndExecs(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// Sanity: is-mapped via binary.
+	// Sanity: is-mapped via binary. Note: is-mapped reads config
+	// directly (no agent dial), so JITENV_CONFIG has to point at the
+	// test fixture for the lookup to find the script.
+	subprocEnv := append(os.Environ(),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_CONFIG="+cfgPath,
+	)
 	cmd := exec.Command(bin, "is-mapped", scriptPath)
-	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	cmd.Env = subprocEnv
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("is-mapped should exit 0; got %v", err)
 	}
 
 	// Run the script via `jitenv run` and capture stdout.
 	cmd = exec.Command(bin, "run", scriptPath)
-	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	cmd.Env = subprocEnv
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("run: %v\noutput=%s", err, out)
@@ -128,7 +134,7 @@ func TestRunInjectsEnvAndExecs(t *testing.T) {
 
 	// is-mapped on a non-mapped path should exit 1.
 	cmd = exec.Command(bin, "is-mapped", "/tmp/definitely-not-mapped.sh")
-	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	cmd.Env = subprocEnv
 	if err := cmd.Run(); err == nil {
 		t.Fatalf("is-mapped should exit non-zero for unmapped path")
 	} else if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 1 {

--- a/internal/shell/hook_e2e_test.go
+++ b/internal/shell/hook_e2e_test.go
@@ -95,11 +95,12 @@ func TestBashHookInterceptsMappedFile(t *testing.T) {
 	binDir := filepath.Dir(bin)
 	cmd := exec.Command("bash", "-c", fmt.Sprintf(
 		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
 eval "$(%s/jitenv hook bash)"
 echo "AGENT_STATUS=$(jitenv status 2>&1 | head -1)"
 echo "IS_MAPPED_RC=$(jitenv is-mapped %q >/dev/null 2>&1; echo $?)"
 %q
-`, binDir, binDir, scriptPath, scriptPath,
+`, binDir, cfgPath, binDir, scriptPath, scriptPath,
 	))
 	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
 	out, err := cmd.CombinedOutput()
@@ -112,11 +113,14 @@ echo "IS_MAPPED_RC=$(jitenv is-mapped %q >/dev/null 2>&1; echo $?)"
 	}
 }
 
-// TestBashHookAgentDownWarnsThenRuns verifies that when the agent is
-// not running, the bash hook prints the red warning, waits for the
-// (env-shortened) delay, and then runs the command anyway. The script
-// produces "RAN" so we can confirm execution went through.
-func TestBashHookAgentDownWarnsThenRuns(t *testing.T) {
+// TestBashHookAgentDownWarnsForMappedScript covers the post-refactor
+// UX: with a mapping configured for the script and the agent locked,
+// `jitenv run` (which the hook routes to) paints the warning +
+// countdown and then runs the script anyway. is-mapped reads config
+// directly so it knows the script IS mapped even with no agent —
+// previously the hook warned on every path-prefix command,
+// independent of whether anything was actually mapped.
+func TestBashHookAgentDownWarnsForMappedScript(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not available")
 	}
@@ -124,25 +128,46 @@ func TestBashHookAgentDownWarnsThenRuns(t *testing.T) {
 
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "show.sh")
-	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho RAN\n"), 0755); err != nil {
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
-	// Point XDG_RUNTIME_DIR at an empty dir so no agent socket exists
-	// — that's what triggers the agent-unreachable path in is-mapped.
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-mapped-down")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "from-noop"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: scriptPath, Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}}},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	// Empty runtime dir → no agent socket → locked-agent path.
 	runtimeDir := filepath.Join(dir, "runtime")
-	_ = os.MkdirAll(runtimeDir, 0700)
+	_ = os.MkdirAll(runtimeDir, 0o700)
 
 	binDir := filepath.Dir(bin)
 	cmd := exec.Command("bash", "-c", fmt.Sprintf(
 		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
 eval "$(%s/jitenv hook bash)"
 %q
-`, binDir, binDir, scriptPath,
+`, binDir, cfgPath, binDir, scriptPath,
 	))
 	cmd.Env = append(os.Environ(),
 		"XDG_RUNTIME_DIR="+runtimeDir,
-		"JITENV_HOOK_DELAY=1", // shrink the 10s wait for the test
+		"JITENV_HOOK_DELAY=1",
 	)
 	start := time.Now()
 	out, err := cmd.CombinedOutput()
@@ -159,6 +184,80 @@ eval "$(%s/jitenv hook bash)"
 	}
 	if elapsed < 800*time.Millisecond {
 		t.Errorf("expected the hook to wait ~1s; only %s elapsed", elapsed)
+	}
+}
+
+// TestBashHookAgentDownSilentForUnmapped is the regression for the
+// user report: typing ./gg.sh (which has no mapping) with the agent
+// locked used to print the same red countdown as ./testjitenv.sh
+// (mapped). is-mapped now reads config directly, so unmapped paths
+// return rc=1 without involving the agent — no warning, just runs.
+func TestBashHookAgentDownSilentForUnmapped(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	unmapped := filepath.Join(dir, "gg.sh")
+	if err := os.WriteFile(unmapped, []byte("#!/bin/sh\necho UNMAPPED-RAN\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-unmapped")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	// Map a DIFFERENT path so the index has entries, but unmapped
+	// stays unmapped.
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"x": "y"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: filepath.Join(dir, "different.sh"),
+			Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}}},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook bash)"
+%q
+`, binDir, cfgPath, binDir, unmapped,
+	))
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_HOOK_DELAY=1",
+	)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	if strings.Contains(got, "agent is not loaded") {
+		t.Errorf("expected NO warning for unmapped script; got:\n%s", got)
+	}
+	if !strings.Contains(got, "UNMAPPED-RAN") {
+		t.Errorf("expected the unmapped script to still run; got:\n%s", got)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected immediate run for unmapped script; took %s", elapsed)
 	}
 }
 

--- a/internal/shell/hook_unlock_lock_test.go
+++ b/internal/shell/hook_unlock_lock_test.go
@@ -94,6 +94,7 @@ func TestBashHookUnlockRunLockRun(t *testing.T) {
 	binDir := filepath.Dir(bin)
 	cmd := exec.Command("bash", "-c", fmt.Sprintf(
 		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
 eval "$(%s/jitenv hook bash)"
 echo '--- step 2 (agent up) ---'
 %q
@@ -102,7 +103,7 @@ jitenv lock
 sleep 0.5
 echo '--- step 4 (agent down) ---'
 %q
-`, binDir, binDir, scriptPath, scriptPath,
+`, binDir, cfgPath, binDir, scriptPath, scriptPath,
 	))
 	cmd.Env = append(os.Environ(),
 		"XDG_RUNTIME_DIR="+runtimeDir,

--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -104,11 +104,12 @@ func TestBashWrapperEndToEnd(t *testing.T) {
 	// simulate that. The function is what the hook installs.
 	cmd := exec.Command("bash", "-c", fmt.Sprintf(
 		`PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
 eval "$(%s/jitenv hook bash)"
 cd %q
 __jitenv_chpwd
 fakecmd
-`, binDir, fakeBin, binDir, projectDir,
+`, binDir, fakeBin, cfgPath, binDir, projectDir,
 	))
 	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
 	out, err := cmd.CombinedOutput()
@@ -121,6 +122,92 @@ fakecmd
 	}
 	if strings.Contains(got, "FOO=MISSING") {
 		t.Errorf("env var did not land; got:\n%s", got)
+	}
+}
+
+// TestBashWrapperAgentDownWarns is the locked-agent UX for cwd_glob:
+// chpwd creates the wrapper symlink (it reads config, no agent
+// needed), but when the wrapped command runs the shim sees an
+// agent-down, prints the red countdown, waits the JITENV_HOOK_DELAY,
+// and execs the real command anyway with the parent env. This test
+// shrinks the delay to 1 second so we don't sit around.
+func TestBashWrapperAgentDownWarns(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmdPath := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(cmdPath, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-warn")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "from-cwd"}},
+	}
+	cfg.Mappings = []config.Mapping{{
+		CwdGlob:  projectDir,
+		Commands: []string{"fakecmd"},
+		Vars:     []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+	}}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty runtime dir → no agent socket → shim hits the warn path.
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook bash)"
+cd %q
+__jitenv_chpwd
+fakecmd
+`, binDir, fakeBin, cfgPath, binDir, projectDir,
+	))
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_HOOK_DELAY=1", // shrink the 10s wait
+	)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "agent is not loaded") {
+		t.Errorf("expected red 'agent is not loaded' warning; got:\n%s", got)
+	}
+	if !strings.Contains(got, "RAN") {
+		t.Errorf("expected fakecmd to still run after the countdown; got:\n%s", got)
+	}
+	if elapsed < 800*time.Millisecond {
+		t.Errorf("expected the shim to wait ~1s; only %s elapsed", elapsed)
 	}
 }
 
@@ -204,10 +291,12 @@ func TestBashWrapperOutsideMappedDir(t *testing.T) {
 	binDir := filepath.Dir(bin)
 	cmd := exec.Command("bash", "-c", fmt.Sprintf(
 		`PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
 eval "$(%s/jitenv hook bash)"
 cd %q
+__jitenv_chpwd
 fakecmd
-`, binDir, fakeBin, binDir, otherDir,
+`, binDir, fakeBin, cfgPath, binDir, otherDir,
 	))
 	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
 	out, err := cmd.CombinedOutput()

--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -1,0 +1,221 @@
+package shell_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+)
+
+// TestBashWrapperEndToEnd is the cwd_glob success path:
+//   - cwd_glob = <project>, commands = ["fakecmd"]
+//   - bash sources the hook, cd's into <project>
+//   - chpwd helper populates the per-shell wrapper dir with a fakecmd
+//     symlink pointing at jitenv
+//   - running `fakecmd` re-execs through the shim, which fetches env
+//     vars from the agent and exec's the real fakecmd binary on
+//     $PATH (we plant one in a fake bin dir)
+//   - the resulting fakecmd inherits FOO=expected.
+func TestBashWrapperEndToEnd(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmdPath := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(cmdPath, []byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"${FOO:-MISSING}\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-wrapper")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	key, _ := config.DeriveKeyFromMeta(cfg, pw)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "from-cwd"}},
+	}
+	cfg.Mappings = []config.Mapping{{
+		CwdGlob:  projectDir,
+		Commands: []string{"fakecmd"},
+		Vars:     []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+	}}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	cli := agent.NewClient(paths.Socket)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	binDir := filepath.Dir(bin)
+	// PROMPT_COMMAND doesn't fire in `bash -c`; in real interactive
+	// shells it does, so this script calls __jitenv_chpwd by hand to
+	// simulate that. The function is what the hook installs.
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:%q:$PATH
+eval "$(%s/jitenv hook bash)"
+cd %q
+__jitenv_chpwd
+fakecmd
+`, binDir, fakeBin, binDir, projectDir,
+	))
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "FOO=from-cwd") {
+		t.Errorf("expected FOO=from-cwd; got:\n%s", got)
+	}
+	if strings.Contains(got, "FOO=MISSING") {
+		t.Errorf("env var did not land; got:\n%s", got)
+	}
+}
+
+// TestBashWrapperOutsideMappedDir exercises the "outside" case: cd
+// into a non-mapped dir; fakecmd runs with the parent env, no
+// wrapping (FOO=MISSING is the success signal).
+func TestBashWrapperOutsideMappedDir(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	otherDir := filepath.Join(dir, "elsewhere")
+	for _, d := range []string{projectDir, otherDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmdPath := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(cmdPath, []byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"${FOO:-MISSING}\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-out")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	key, _ := config.DeriveKeyFromMeta(cfg, pw)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "from-cwd"}},
+	}
+	cfg.Mappings = []config.Mapping{{
+		CwdGlob:  projectDir,
+		Commands: []string{"fakecmd"},
+		Vars:     []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+	}}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	if err := daemon.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatal(err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	cli := agent.NewClient(paths.Socket)
+	for ddl := time.Now().Add(3 * time.Second); time.Now().Before(ddl); {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	binDir := filepath.Dir(bin)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:%q:$PATH
+eval "$(%s/jitenv hook bash)"
+cd %q
+fakecmd
+`, binDir, fakeBin, binDir, otherDir,
+	))
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "FOO=MISSING") {
+		t.Errorf("expected FOO=MISSING (no wrapping outside mapped dir); got:\n%s", got)
+	}
+}

--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -308,3 +308,166 @@ fakecmd
 		t.Errorf("expected FOO=MISSING (no wrapping outside mapped dir); got:\n%s", got)
 	}
 }
+
+// TestBashWrapperReReconcilesOnConfigEdit covers the "edit config
+// while inside a cwd_glob mapping" path: previously the user had to
+// cd out and back in to pick up commands they'd added. The hook
+// stat's config.toml every PROMPT_COMMAND fire and re-runs chpwd
+// when the mtime changed.
+func TestBashWrapperReReconcilesOnConfigEdit(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-edit")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"x": "y"}},
+	}
+	cfg.Mappings = []config.Mapping{{
+		CwdGlob:  projectDir,
+		Commands: []string{"firstcmd"},
+		Vars:     []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}},
+	}}
+	writeCfg := func() {
+		t.Helper()
+		tmp, _ := os.CreateTemp(dir, "save-*.toml")
+		if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		tmp.Close()
+		if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+			t.Fatalf("rename: %v", err)
+		}
+	}
+	writeCfg()
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	// 1. Source the hook + cd in. Wrapper dir should contain only
+	//    firstcmd.
+	binDir := filepath.Dir(bin)
+	leg1 := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook bash)"
+cd %q
+__jitenv_chpwd
+ls $__JITENV_WRAP_DIR
+`, binDir, cfgPath, binDir, projectDir))
+	leg1.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out1, err := leg1.CombinedOutput()
+	if err != nil {
+		t.Fatalf("leg 1: %v\n%s", err, out1)
+	}
+	got1 := string(out1)
+	if !strings.Contains(got1, "firstcmd") || strings.Contains(got1, "secondcmd") {
+		t.Errorf("leg 1 wrap dir: expected only firstcmd; got:\n%s", got1)
+	}
+
+	// 2. Edit config to add secondcmd, bump mtime by 2s so stat
+	//    definitely returns a new value (1s resolution on stat -c %Y).
+	cfg.Mappings[0].Commands = []string{"firstcmd", "secondcmd"}
+	writeCfg()
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(cfgPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Re-source the hook in a fresh subshell, but DO NOT cd —
+	//    the wrapper dir from leg 1 is reused (same shell pid would
+	//    be ideal, but `bash -c` makes that hard; use the same pid
+	//    by piping a fixed PID env). Simpler: stat the per-shell
+	//    wrap dir created by leg 2 directly.
+	leg2 := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook bash)"
+cd %q
+__jitenv_chpwd
+ls $__JITENV_WRAP_DIR
+`, binDir, cfgPath, binDir, projectDir))
+	leg2.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out2, err := leg2.CombinedOutput()
+	if err != nil {
+		t.Fatalf("leg 2: %v\n%s", err, out2)
+	}
+	got2 := string(out2)
+	if !strings.Contains(got2, "firstcmd") || !strings.Contains(got2, "secondcmd") {
+		t.Errorf("leg 2 wrap dir: expected both firstcmd and secondcmd; got:\n%s", got2)
+	}
+
+	// 4. Most directly: same-shell mtime detection. Run a single
+	//    bash that cd's in (firstcmd only), then we'll write a new
+	//    config from inside bash and re-fire __jitenv_chpwd. The
+	//    hook should see the mtime change and reconcile, picking
+	//    up secondcmd without a cd.
+	cfg.Mappings[0].Commands = []string{"firstcmd"} // reset starting state
+	writeCfg()
+	// Reset mtime to "now" so leg 3's first __jitenv_chpwd has a
+	// stable baseline, then the in-script touch bumps it again.
+	now := time.Now()
+	if err := os.Chtimes(cfgPath, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	// We append to the config from inside bash by truncating and
+	// rewriting via a python heredoc would be overkill; just touch
+	// the file with a future mtime to simulate "user edited it".
+	// The hook only cares about mtime, not content, for reconcile;
+	// the actual `commands` list comes from a fresh config.Load.
+	editedCfg := *cfg
+	editedCfg.Mappings = append([]config.Mapping(nil), cfg.Mappings...)
+	editedCfg.Mappings[0].Commands = []string{"firstcmd", "secondcmd"}
+	editedPath := filepath.Join(dir, "edited.toml")
+	tmp, _ := os.Create(editedPath)
+	if err := toml.NewEncoder(tmp).Encode(&editedCfg); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	leg3 := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook bash)"
+cd %q
+__jitenv_chpwd
+echo "--- before-edit ---"
+ls $__JITENV_WRAP_DIR
+# Replace the config with the edited version + bump mtime.
+cp %q %q
+touch -d "+5 seconds" %q
+__jitenv_chpwd
+echo "--- after-edit ---"
+ls $__JITENV_WRAP_DIR
+`, binDir, cfgPath, binDir, projectDir, editedPath, cfgPath, cfgPath))
+	leg3.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out3, err := leg3.CombinedOutput()
+	if err != nil {
+		t.Fatalf("leg 3: %v\n%s", err, out3)
+	}
+	got3 := string(out3)
+	t.Logf("leg 3 output:\n%s", got3)
+
+	before := sectionBetween(got3, "--- before-edit ---", "--- after-edit ---")
+	after := sectionBetween(got3, "--- after-edit ---", "")
+	if !strings.Contains(before, "firstcmd") || strings.Contains(before, "secondcmd") {
+		t.Errorf("before edit: expected only firstcmd; got:\n%s", before)
+	}
+	if !strings.Contains(after, "firstcmd") || !strings.Contains(after, "secondcmd") {
+		t.Errorf("after edit: expected both firstcmd and secondcmd; got:\n%s", after)
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -27,21 +27,43 @@ esac
 # in PROMPT_COMMAND. The diff makes the per-prompt cost a single
 # string compare; the full helper only fires on actual directory
 # changes.
-__JITENV_LAST_PWD="$PWD"
+# Resolve the config-file path the same way the Go side does.
+__jitenv_cfg_path() {
+    if [[ -n "${JITENV_CONFIG:-}" ]]; then
+        printf '%s' "$JITENV_CONFIG"
+    else
+        printf '%s' "${XDG_CONFIG_HOME:-$HOME/.config}/jitenv/config.toml"
+    fi
+}
+# stat -c is GNU; -f is BSD/macOS. Echo 0 on any failure so the
+# comparison treats "missing" identically across runs.
+__jitenv_cfg_mtime() {
+    local cfg="$1"
+    [[ -e "$cfg" ]] || { printf '0'; return; }
+    stat -c %Y "$cfg" 2>/dev/null || stat -f %m "$cfg" 2>/dev/null || printf '0'
+}
 __jitenv_chpwd() {
-    if [[ "$PWD" != "${__JITENV_LAST_PWD-}" ]]; then
+    local cfg mtime
+    cfg="$(__jitenv_cfg_path)"
+    mtime="$(__jitenv_cfg_mtime "$cfg")"
+    # Fire when EITHER the directory changed OR the config file's
+    # mtime changed since the last fire. The mtime branch handles
+    # "user edits config while sitting in the mapped dir": symlinks
+    # get re-reconciled on the next prompt without requiring a cd.
+    if [[ "$PWD" != "${__JITENV_LAST_PWD-}" || "$mtime" != "${__JITENV_LAST_CFG_MTIME-}" ]]; then
         # No 2>/dev/null on purpose: the chpwd subcommand is silent
         # in normal operation (it only writes to stderr when
         # JITENV_HOOK_DEBUG is set). Swallowing stderr here would
-        # hide both the debug diagnostics and a "jitenv: command not
-        # found" if the binary ever falls off $PATH mid-session.
+        # hide debug diagnostics + a "jitenv: command not found"
+        # if the binary ever falls off $PATH mid-session.
         jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
         __JITENV_LAST_PWD="$PWD"
+        __JITENV_LAST_CFG_MTIME="$mtime"
     fi
 }
 # Run once at hook-load time so the wrapper dir is populated before
 # the first command in this shell.
-jitenv __chpwd "$$" "" "$PWD"
+__jitenv_chpwd
 PROMPT_COMMAND="__jitenv_chpwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 
 shopt -s extdebug

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -59,7 +59,7 @@ __jitenv_warn_no_agent() {
 
     printf '%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n' \
         "$red" "$target" "$reset" >&2
-    printf '%sWill run the command anyway in 10s. Press Ctrl+C now to abort.%s\n' \
+    printf '%sWill run the command anyway in 10s. Press Enter to skip, Ctrl+C to abort.%s\n' \
         "$red" "$reset" >&2
 
     local total=${JITENV_HOOK_DELAY:-10}
@@ -67,7 +67,12 @@ __jitenv_warn_no_agent() {
     for ((i=total; i>0; i--)); do
         (( aborted )) && break
         printf '\r%s  %2ds remaining %s' "$red" "$i" "$reset" >&2
-        sleep 1 2>/dev/null
+        # `read -t 1 -n 1` waits up to one second for one keystroke.
+        # On Enter (or any key) it returns 0 and we skip; on timeout
+        # it returns non-zero and we keep counting down.
+        if read -t 1 -n 1 -s -r -p "" 2>/dev/null; then
+            break
+        fi
         (( aborted )) && break
     done
 

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -30,13 +30,18 @@ esac
 __JITENV_LAST_PWD="$PWD"
 __jitenv_chpwd() {
     if [[ "$PWD" != "${__JITENV_LAST_PWD-}" ]]; then
-        jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD" 2>/dev/null
+        # No 2>/dev/null on purpose: the chpwd subcommand is silent
+        # in normal operation (it only writes to stderr when
+        # JITENV_HOOK_DEBUG is set). Swallowing stderr here would
+        # hide both the debug diagnostics and a "jitenv: command not
+        # found" if the binary ever falls off $PATH mid-session.
+        jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
         __JITENV_LAST_PWD="$PWD"
     fi
 }
 # Run once at hook-load time so the wrapper dir is populated before
 # the first command in this shell.
-jitenv __chpwd "$$" "" "$PWD" 2>/dev/null
+jitenv __chpwd "$$" "" "$PWD"
 PROMPT_COMMAND="__jitenv_chpwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 
 shopt -s extdebug

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -7,6 +7,38 @@
 if [[ -n "${__JITENV_LOADED:-}" ]]; then return 0 2>/dev/null || exit 0; fi
 __JITENV_LOADED=1
 
+# Per-shell wrapper-symlink dir. The chpwd helper populates it on
+# directory changes that hit a cwd_glob mapping; an empty dir is a
+# silent fall-through. We pre-create it and prepend to $PATH once,
+# right here, so PATH stays stable for the rest of the shell's life.
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    __JITENV_RUNTIME_DIR="$XDG_RUNTIME_DIR/jitenv"
+else
+    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}/jitenv-$UID"
+fi
+export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
+mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null
+case ":$PATH:" in
+    *":$__JITENV_WRAP_DIR:"*) : ;;
+    *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;
+esac
+
+# chpwd hook: bash has no native chpwd, so we run a tiny PWD-diff
+# in PROMPT_COMMAND. The diff makes the per-prompt cost a single
+# string compare; the full helper only fires on actual directory
+# changes.
+__JITENV_LAST_PWD="$PWD"
+__jitenv_chpwd() {
+    if [[ "$PWD" != "${__JITENV_LAST_PWD-}" ]]; then
+        jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD" 2>/dev/null
+        __JITENV_LAST_PWD="$PWD"
+    fi
+}
+# Run once at hook-load time so the wrapper dir is populated before
+# the first command in this shell.
+jitenv __chpwd "$$" "" "$PWD" 2>/dev/null
+PROMPT_COMMAND="__jitenv_chpwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+
 shopt -s extdebug
 
 # Print the "agent not loaded" warning in red and count down 10 seconds

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -136,6 +136,9 @@ __jitenv_debug_trap() {
     __jitenv_log "is-mapped rc=$rc"
     case "$rc" in
         0)
+            # Mapped — `jitenv run` handles env injection and the
+            # locked-agent UX (warn + countdown + run-with-parent-env)
+            # internally, so we just delegate.
             __jitenv_log "branch=case0 (mapped → jitenv run)"
             local rest="${cmd#"$first_raw"}"
             __JITENV_REENTRY=1
@@ -144,13 +147,11 @@ __jitenv_debug_trap() {
             return 1
             ;;
         2)
-            __jitenv_log "branch=case2 (agent unreachable → warn)"
-            # Agent unreachable. We can't tell whether the file is
-            # mapped, but the user clearly intends to use jitenv (the
-            # hook is installed) so warn loudly and offer an abort.
-            if ! __jitenv_warn_no_agent "$resolved"; then
-                return 1
-            fi
+            # Config unreadable. Different from "agent locked" — the
+            # latter no longer reaches this branch because is-mapped
+            # reads config directly. Warn once and let the command
+            # run; the user's jitenv install is broken in some way.
+            __jitenv_log "branch=case2 (config unreadable — letting command run)"
             return 0
             ;;
         *)

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -99,18 +99,16 @@ __jitenv_accept_line() {
             __jitenv_log "is-mapped rc=$rc"
             case "$rc" in
                 0)
+                    # Mapped. `jitenv run` paints its own warning +
+                    # countdown when the agent is locked, so we just
+                    # rewrite BUFFER and let it handle everything.
                     __jitenv_log "branch=case0 (mapped → jitenv run)"
                     BUFFER="jitenv run \"$resolved\"$rest"
                     ;;
-                2)
-                    __jitenv_log "branch=case2 (agent unreachable → warn)"
-                    # Agent unreachable — wrap the user's command so the
-                    # warning + 10s grace runs first. && short-circuits
-                    # the real command if the user aborts via Ctrl+C.
-                    BUFFER="__jitenv_warn_no_agent \"$resolved\" && { $BUFFER ; }"
-                    ;;
                 *)
-                    __jitenv_log "branch=case* (rc=$rc — unmapped, let it run)"
+                    # rc=1 (not mapped) or rc=2 (config unreadable) →
+                    # run the user's command unchanged.
+                    __jitenv_log "branch=case* (rc=$rc — let it run)"
                     ;;
             esac
         fi

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -20,17 +20,39 @@ case ":$PATH:" in
     *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;
 esac
 
-__jitenv_chpwd() {
-    # No 2>/dev/null on purpose: the chpwd subcommand is silent in
-    # normal operation; gating debug output with `2>/dev/null` here
-    # would hide JITENV_HOOK_DEBUG diagnostics + any
-    # "jitenv: command not found" if the binary falls off $PATH.
-    jitenv __chpwd "$$" "${OLDPWD:-}" "$PWD"
+__jitenv_cfg_path() {
+    if [[ -n "${JITENV_CONFIG:-}" ]]; then
+        print -r -- "$JITENV_CONFIG"
+    else
+        print -r -- "${XDG_CONFIG_HOME:-$HOME/.config}/jitenv/config.toml"
+    fi
 }
-typeset -ga chpwd_functions
-chpwd_functions+=(__jitenv_chpwd)
+__jitenv_cfg_mtime() {
+    local cfg="$1"
+    [[ -e "$cfg" ]] || { print -r -- 0; return; }
+    stat -c %Y "$cfg" 2>/dev/null || stat -f %m "$cfg" 2>/dev/null || print -r -- 0
+}
+# precmd-style hook: fires every time the prompt is about to redraw,
+# including after a cd (subsumes chpwd_functions). The PWD-diff +
+# mtime-diff inside makes the no-op case a tiny pair of comparisons.
+# The mtime branch handles "user edits config while sitting in the
+# mapped dir": symlinks get re-reconciled on the next prompt without
+# requiring a cd.
+__jitenv_chpwd() {
+    local cfg mtime
+    cfg="$(__jitenv_cfg_path)"
+    mtime="$(__jitenv_cfg_mtime "$cfg")"
+    if [[ "$PWD" != "${__JITENV_LAST_PWD-}" || "$mtime" != "${__JITENV_LAST_CFG_MTIME-}" ]]; then
+        # No 2>/dev/null on purpose; see bash.sh for the rationale.
+        jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
+        __JITENV_LAST_PWD="$PWD"
+        __JITENV_LAST_CFG_MTIME="$mtime"
+    fi
+}
+typeset -ga precmd_functions
+precmd_functions+=(__jitenv_chpwd)
 # Populate once at hook-load.
-jitenv __chpwd "$$" "" "$PWD"
+__jitenv_chpwd
 
 # Warn loudly when the agent isn't reachable, count down 10 seconds,
 # and let Ctrl+C abort. Returns non-zero on abort so the caller's `&&`

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -21,12 +21,16 @@ case ":$PATH:" in
 esac
 
 __jitenv_chpwd() {
-    jitenv __chpwd "$$" "${OLDPWD:-}" "$PWD" 2>/dev/null
+    # No 2>/dev/null on purpose: the chpwd subcommand is silent in
+    # normal operation; gating debug output with `2>/dev/null` here
+    # would hide JITENV_HOOK_DEBUG diagnostics + any
+    # "jitenv: command not found" if the binary falls off $PATH.
+    jitenv __chpwd "$$" "${OLDPWD:-}" "$PWD"
 }
 typeset -ga chpwd_functions
 chpwd_functions+=(__jitenv_chpwd)
 # Populate once at hook-load.
-jitenv __chpwd "$$" "" "$PWD" 2>/dev/null
+jitenv __chpwd "$$" "" "$PWD"
 
 # Warn loudly when the agent isn't reachable, count down 10 seconds,
 # and let Ctrl+C abort. Returns non-zero on abort so the caller's `&&`

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -46,7 +46,7 @@ __jitenv_warn_no_agent() {
 
     printf '%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n' \
         "$red" "$target" "$reset" >&2
-    printf '%sWill run the command anyway in 10s. Press Ctrl+C now to abort.%s\n' \
+    printf '%sWill run the command anyway in 10s. Press Enter to skip, Ctrl+C to abort.%s\n' \
         "$red" "$reset" >&2
 
     local total=${JITENV_HOOK_DELAY:-10}
@@ -54,7 +54,12 @@ __jitenv_warn_no_agent() {
     for ((i=total; i>0; i--)); do
         (( aborted )) && break
         printf '\r%s  %2ds remaining %s' "$red" "$i" "$reset" >&2
-        sleep 1
+        # zsh's read: -t timeout (seconds), -k 1 (one char), -s silent.
+        # Returns 0 if a key was read, non-zero on timeout — same shape
+        # as the bash version.
+        if read -t 1 -k 1 -s 2>/dev/null; then
+            break
+        fi
         (( aborted )) && break
     done
 

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -6,6 +6,28 @@
 if [[ -n "${__JITENV_LOADED:-}" ]]; then return 0; fi
 __JITENV_LOADED=1
 
+# Per-shell wrapper-symlink dir for cwd_glob mappings (mirrors
+# bash.sh).
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    __JITENV_RUNTIME_DIR="$XDG_RUNTIME_DIR/jitenv"
+else
+    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}/jitenv-$UID"
+fi
+export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
+mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null
+case ":$PATH:" in
+    *":$__JITENV_WRAP_DIR:"*) : ;;
+    *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;
+esac
+
+__jitenv_chpwd() {
+    jitenv __chpwd "$$" "${OLDPWD:-}" "$PWD" 2>/dev/null
+}
+typeset -ga chpwd_functions
+chpwd_functions+=(__jitenv_chpwd)
+# Populate once at hook-load.
+jitenv __chpwd "$$" "" "$PWD" 2>/dev/null
+
 # Warn loudly when the agent isn't reachable, count down 10 seconds,
 # and let Ctrl+C abort. Returns non-zero on abort so the caller's `&&`
 # short-circuits the actual command.

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -22,14 +22,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/agentwarn"
 )
 
 // errAgentDown is returned by fetchEnv when the agent socket is
@@ -67,11 +66,7 @@ func run(invokedAs string, args []string) error {
 	extra, fetchErr := fetchEnv(invokedAs)
 	switch {
 	case errors.Is(fetchErr, errAgentDown):
-		// Mapped command, agent is locked. Mirror the bash hook's
-		// path-mapped UX: red warning + countdown, Ctrl+C to abort.
-		// After the countdown, exec the real command anyway with
-		// the parent env (no injection).
-		if aborted := warnAgentDown(invokedAs); aborted {
+		if agentwarn.WarnAndWait(invokedAs) {
 			return errors.New("aborted")
 		}
 	case fetchErr != nil:
@@ -164,79 +159,4 @@ func fetchEnv(cmd string) (map[string]string, error) {
 		return nil, fmt.Errorf("%w: %v", errAgentDown, err)
 	}
 	return out, nil
-}
-
-// warnAgentDown paints the same red message + countdown the bash
-// hook uses for path-mapped scripts. Returns true if the user hit
-// Ctrl+C during the countdown (caller should abort the exec).
-// Pressing Enter skips the wait and proceeds immediately.
-//
-// Honors JITENV_HOOK_DELAY (default 10s) for the wait length, so it
-// matches the hook's existing knob.
-func warnAgentDown(cmdName string) bool {
-	const red = "\033[1;31m"
-	const reset = "\033[0m"
-
-	total := 10
-	if v := os.Getenv("JITENV_HOOK_DELAY"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			total = n
-		}
-	}
-
-	fmt.Fprintf(os.Stderr,
-		"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
-		red, cmdName, reset)
-	fmt.Fprintf(os.Stderr,
-		"%sWill run the command anyway in %ds. Press Enter to skip, Ctrl+C to abort.%s\n",
-		red, total, reset)
-
-	if total == 0 {
-		return false
-	}
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-	defer signal.Stop(sigCh)
-
-	// Drain stdin in a goroutine; signal on the first newline. Run
-	// without raw-mode shenanigans — terminals are cooked by default,
-	// so pressing Enter delivers a single '\n' immediately. We don't
-	// kill the goroutine at the end: syscall.Exec replaces the
-	// process image and reaps it.
-	enterCh := make(chan struct{}, 1)
-	go func() {
-		buf := make([]byte, 1)
-		for {
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return
-			}
-			if buf[0] == '\n' || buf[0] == '\r' {
-				select {
-				case enterCh <- struct{}{}:
-				default:
-				}
-				return
-			}
-		}
-	}()
-
-	tick := time.NewTicker(time.Second)
-	defer tick.Stop()
-
-	for i := total; i > 0; i-- {
-		fmt.Fprintf(os.Stderr, "\r%s  %2ds remaining %s", red, i, reset)
-		select {
-		case <-sigCh:
-			fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
-			return true
-		case <-enterCh:
-			fmt.Fprintln(os.Stderr)
-			return false
-		case <-tick.C:
-		}
-	}
-	fmt.Fprintln(os.Stderr)
-	return false
 }

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -1,0 +1,141 @@
+// Package shim is the entrypoint for the cwd_glob wrapper-symlink
+// scheme. It runs whenever a per-shell wrapper symlink is invoked
+// (e.g. `~/.cache/jitenv/shells/<pid>/bin/npm`); the wrapper points
+// at the jitenv binary, and main.go dispatches here when
+// `filepath.Base(os.Args[0]) != "jitenv"`.
+//
+// Behaviour:
+//
+//  1. Read the command name from os.Args[0].
+//  2. Resolve the real command via $PATH minus the wrapper directory
+//     (so we don't recurse into the same symlink).
+//  3. Ask the agent for env vars keyed by ($PWD, command). On agent-
+//     down (socket missing or unresponsive), fall through silently
+//     with the parent env — same UX as the locked-agent path in the
+//     bash hook.
+//  4. syscall.Exec the real command with merged env, preserving
+//     argv[0] as the typed command name.
+package shim
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gv/jitenv/internal/agent"
+)
+
+// Main is the shim entrypoint. invokedAs is filepath.Base(os.Args[0]),
+// args is os.Args[1:] (everything after argv[0]).
+func Main(invokedAs string, args []string) {
+	if err := run(invokedAs, args); err != nil {
+		fmt.Fprintf(os.Stderr, "jitenv shim: %s: %v\n", invokedAs, err)
+		os.Exit(127)
+	}
+}
+
+func run(invokedAs string, args []string) error {
+	// argv[0] is whatever the shell typed — usually the bare command
+	// name, not the symlink's full path. Rely on the shell hook
+	// exporting __JITENV_WRAP_DIR so we know which directory in $PATH
+	// to skip when resolving the real binary. Fallback to $0's dir
+	// for the rare invocation that doesn't go through the hook (e.g.
+	// `~/.cache/jitenv/shells/123/bin/npm` typed by hand).
+	selfDir := os.Getenv("__JITENV_WRAP_DIR")
+	if selfDir == "" {
+		selfDir = filepath.Dir(firstArg())
+	}
+	realPath, err := lookPathExcluding(invokedAs, selfDir)
+	if err != nil {
+		return err
+	}
+
+	env := os.Environ()
+	if extra, err := fetchEnv(invokedAs); err == nil {
+		for k, v := range extra {
+			env = append(env, k+"="+v)
+		}
+	}
+	// Agent-down errors are swallowed: we'd rather run the user's
+	// command without env vars than refuse to run it.
+
+	argv := append([]string{invokedAs}, args...)
+	if execErr := syscall.Exec(realPath, argv, env); execErr != nil {
+		if errors.Is(execErr, syscall.ENOEXEC) {
+			return fmt.Errorf("%s: file is not directly executable", realPath)
+		}
+		return fmt.Errorf("exec %s: %w", realPath, execErr)
+	}
+	return nil
+}
+
+func firstArg() string {
+	if len(os.Args) > 0 {
+		return os.Args[0]
+	}
+	return ""
+}
+
+// lookPathExcluding searches $PATH for `name`, skipping any entry that
+// equals (or is a symlink to) excludeDir. This keeps the wrapper from
+// re-invoking itself when its own bin dir is at the head of $PATH.
+func lookPathExcluding(name, excludeDir string) (string, error) {
+	if strings.ContainsRune(name, os.PathSeparator) {
+		// User invoked with a path; bypass PATH search.
+		return name, nil
+	}
+	excludeAbs, _ := filepath.Abs(excludeDir)
+
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		if abs == excludeAbs {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		// Same executable check os/exec uses: any executable bit set.
+		if info.Mode()&0o111 == 0 {
+			continue
+		}
+		return candidate, nil
+	}
+	return "", fmt.Errorf("%s: not found on $PATH (excluding %s)", name, excludeDir)
+}
+
+// fetchEnv asks the running agent for env vars keyed by ($PWD, cmd).
+// Returns an empty map (nil error) when the agent isn't running so
+// the caller can keep going.
+func fetchEnv(cmd string) (map[string]string, error) {
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(paths.Socket); err != nil {
+		return nil, nil // agent down; silent
+	}
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	cli := agent.NewClient(paths.Socket)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return cli.FetchEnvCwd(ctx, pwd, cmd)
+}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -22,13 +22,21 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/gv/jitenv/internal/agent"
 )
+
+// errAgentDown is returned by fetchEnv when the agent socket is
+// missing or unresponsive, distinct from a successful fetch that
+// happens to return zero env vars. The shim uses this to decide
+// whether to paint the agent-down warning.
+var errAgentDown = errors.New("agent unreachable")
 
 // Main is the shim entrypoint. invokedAs is filepath.Base(os.Args[0]),
 // args is os.Args[1:] (everything after argv[0]).
@@ -56,13 +64,26 @@ func run(invokedAs string, args []string) error {
 	}
 
 	env := os.Environ()
-	if extra, err := fetchEnv(invokedAs); err == nil {
+	extra, fetchErr := fetchEnv(invokedAs)
+	switch {
+	case errors.Is(fetchErr, errAgentDown):
+		// Mapped command, agent is locked. Mirror the bash hook's
+		// path-mapped UX: red warning + countdown, Ctrl+C to abort.
+		// After the countdown, exec the real command anyway with
+		// the parent env (no injection).
+		if aborted := warnAgentDown(invokedAs); aborted {
+			return errors.New("aborted")
+		}
+	case fetchErr != nil:
+		// Other error (config parse, fetch failure). Surface to
+		// stderr but don't block — the user explicitly invoked the
+		// command.
+		fmt.Fprintf(os.Stderr, "jitenv shim: %s: %v\n", invokedAs, fetchErr)
+	default:
 		for k, v := range extra {
 			env = append(env, k+"="+v)
 		}
 	}
-	// Agent-down errors are swallowed: we'd rather run the user's
-	// command without env vars than refuse to run it.
 
 	argv := append([]string{invokedAs}, args...)
 	if execErr := syscall.Exec(realPath, argv, env); execErr != nil {
@@ -120,15 +141,16 @@ func lookPathExcluding(name, excludeDir string) (string, error) {
 }
 
 // fetchEnv asks the running agent for env vars keyed by ($PWD, cmd).
-// Returns an empty map (nil error) when the agent isn't running so
-// the caller can keep going.
+// Returns errAgentDown when the agent socket is missing or the call
+// fails — distinct from a successful fetch that returns zero env vars
+// for an unmapped (pwd, cmd) pair.
 func fetchEnv(cmd string) (map[string]string, error) {
 	paths, err := agent.DefaultPaths()
 	if err != nil {
 		return nil, err
 	}
 	if _, err := os.Stat(paths.Socket); err != nil {
-		return nil, nil // agent down; silent
+		return nil, errAgentDown
 	}
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -137,5 +159,57 @@ func fetchEnv(cmd string) (map[string]string, error) {
 	cli := agent.NewClient(paths.Socket)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	return cli.FetchEnvCwd(ctx, pwd, cmd)
+	out, err := cli.FetchEnvCwd(ctx, pwd, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errAgentDown, err)
+	}
+	return out, nil
+}
+
+// warnAgentDown paints the same red message + countdown the bash
+// hook uses for path-mapped scripts. Returns true if the user hit
+// Ctrl+C during the countdown (caller should abort the exec).
+//
+// Honors JITENV_HOOK_DELAY (default 10s) for the wait length, so it
+// matches the hook's existing knob.
+func warnAgentDown(cmdName string) bool {
+	const red = "\033[1;31m"
+	const reset = "\033[0m"
+
+	total := 10
+	if v := os.Getenv("JITENV_HOOK_DELAY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			total = n
+		}
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
+		red, cmdName, reset)
+	fmt.Fprintf(os.Stderr,
+		"%sWill run the command anyway in %ds. Press Ctrl+C now to abort.%s\n",
+		red, total, reset)
+
+	if total == 0 {
+		return false
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+
+	for i := total; i > 0; i-- {
+		fmt.Fprintf(os.Stderr, "\r%s  %2ds remaining %s", red, i, reset)
+		select {
+		case <-sigCh:
+			fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
+			return true
+		case <-tick.C:
+		}
+	}
+	fmt.Fprintln(os.Stderr)
+	return false
 }

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -169,6 +169,7 @@ func fetchEnv(cmd string) (map[string]string, error) {
 // warnAgentDown paints the same red message + countdown the bash
 // hook uses for path-mapped scripts. Returns true if the user hit
 // Ctrl+C during the countdown (caller should abort the exec).
+// Pressing Enter skips the wait and proceeds immediately.
 //
 // Honors JITENV_HOOK_DELAY (default 10s) for the wait length, so it
 // matches the hook's existing knob.
@@ -187,7 +188,7 @@ func warnAgentDown(cmdName string) bool {
 		"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
 		red, cmdName, reset)
 	fmt.Fprintf(os.Stderr,
-		"%sWill run the command anyway in %ds. Press Ctrl+C now to abort.%s\n",
+		"%sWill run the command anyway in %ds. Press Enter to skip, Ctrl+C to abort.%s\n",
 		red, total, reset)
 
 	if total == 0 {
@@ -198,6 +199,29 @@ func warnAgentDown(cmdName string) bool {
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
 
+	// Drain stdin in a goroutine; signal on the first newline. Run
+	// without raw-mode shenanigans — terminals are cooked by default,
+	// so pressing Enter delivers a single '\n' immediately. We don't
+	// kill the goroutine at the end: syscall.Exec replaces the
+	// process image and reaps it.
+	enterCh := make(chan struct{}, 1)
+	go func() {
+		buf := make([]byte, 1)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if err != nil || n == 0 {
+				return
+			}
+			if buf[0] == '\n' || buf[0] == '\r' {
+				select {
+				case enterCh <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}()
+
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
 
@@ -207,6 +231,9 @@ func warnAgentDown(cmdName string) bool {
 		case <-sigCh:
 			fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
 			return true
+		case <-enterCh:
+			fmt.Fprintln(os.Stderr)
+			return false
 		case <-tick.C:
 		}
 	}

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -150,11 +150,16 @@ func (m *mappingsListScreen) View() string {
 }
 
 func mappingLabel(mp config.Mapping) string {
-	if mp.Glob != "" {
+	switch {
+	case mp.Glob != "":
 		return mp.Glob
-	}
-	if mp.Path != "" {
+	case mp.Path != "":
 		return mp.Path
+	case mp.CwdGlob != "":
+		if len(mp.Commands) > 0 {
+			return "cwd:" + mp.CwdGlob + "  " + strings.Join(mp.Commands, ",")
+		}
+		return "cwd:" + mp.CwdGlob
 	}
 	return "(empty)"
 }
@@ -181,11 +186,32 @@ type mappingFormScreen struct {
 	root     *rootModel
 	idx      int
 	creating bool
-	cursor   int // 0 = kind, 1 = target, 2 = variables
+	cursor   int // 0 = kind, 1 = target, 2 = commands (cwd-only) / variables
+	// pendingKind tracks the picker selection while the mapping has no
+	// target field set yet. config.Mapping has no kind field of its
+	// own — it's inferred from which of Path/Glob/CwdGlob is non-empty
+	// — so without this the picker wouldn't appear to "stick" on a
+	// brand-new mapping until the user typed a target.
+	pendingKind string
 }
 
 func newMappingFormScreen(r *rootModel, idx int, creating bool) screen {
 	return &mappingFormScreen{root: r, idx: idx, creating: creating}
+}
+
+// effectiveKind returns the kind the form should display: the
+// mapping's stored kind if a target is set, otherwise the picker's
+// pending choice, defaulting to "path".
+func (s *mappingFormScreen) effectiveKind() string {
+	if mp := s.mp(); mp != nil {
+		if k := mp.Kind(); k != "" {
+			return k
+		}
+	}
+	if s.pendingKind != "" {
+		return s.pendingKind
+	}
+	return "path"
 }
 
 func (s *mappingFormScreen) Title() string {
@@ -229,7 +255,16 @@ func (s *mappingFormScreen) mp() *config.Mapping {
 
 func (s *mappingFormScreen) isEmpty() bool {
 	mp := s.mp()
-	return mp != nil && mp.Path == "" && mp.Glob == "" && len(mp.Vars) == 0
+	return mp != nil && mp.Path == "" && mp.Glob == "" && mp.CwdGlob == "" && len(mp.Vars) == 0
+}
+
+// maxCursor returns the highest valid cursor row. Cwd mappings get an
+// extra "commands" row above "variables".
+func (s *mappingFormScreen) maxCursor() int {
+	if s.effectiveKind() == "cwd" {
+		return 3
+	}
+	return 2
 }
 
 func (s *mappingFormScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
@@ -240,7 +275,7 @@ func (s *mappingFormScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				s.cursor--
 			}
 		case "down", "j":
-			if s.cursor < 2 {
+			if s.cursor < s.maxCursor() {
 				s.cursor++
 			}
 		case "enter":
@@ -262,6 +297,19 @@ func (s *mappingFormScreen) activate() tea.Cmd {
 	if s.mp() == nil {
 		return nil
 	}
+	if s.effectiveKind() == "cwd" {
+		switch s.cursor {
+		case 0:
+			return s.openKindMenu()
+		case 1:
+			return s.openTargetInput()
+		case 2:
+			return s.openCommandsInput()
+		case 3:
+			return s.openVarTree()
+		}
+		return nil
+	}
 	switch s.cursor {
 	case 0:
 		return s.openKindMenu()
@@ -280,21 +328,37 @@ func (s *mappingFormScreen) openKindMenu() tea.Cmd {
 			return emit(popMsg{})
 		}
 		switch choice {
-		case "path":
+		case "path", "glob", "cwd":
+			// Carry the previous target across kind changes.
+			prev := mp.Path
 			if mp.Glob != "" {
-				mp.Path = mp.Glob
-				mp.Glob = ""
+				prev = mp.Glob
+			} else if mp.CwdGlob != "" {
+				prev = mp.CwdGlob
 			}
-		case "glob":
-			if mp.Path != "" {
-				mp.Glob = mp.Path
-				mp.Path = ""
+			mp.Path, mp.Glob, mp.CwdGlob = "", "", ""
+			switch choice {
+			case "path":
+				mp.Path = prev
+			case "glob":
+				mp.Glob = prev
+			case "cwd":
+				mp.CwdGlob = prev
 			}
+			s.pendingKind = choice
+			if choice != "cwd" {
+				mp.Commands = nil
+			}
+			if s.cursor > s.maxCursor() {
+				s.cursor = s.maxCursor()
+			}
+			return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
 		}
-		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
+		// "Back" / unknown: leave both mp and pendingKind alone.
+		return emit(popMsg{})
 	}
 	return emit(pushMsg{s: newPopupMenuScreen(s.root,
-		"Mapping kind", cb, "path", "glob", "Back")})
+		"Mapping kind", cb, "path", "glob", "cwd", "Back")})
 }
 
 func (s *mappingFormScreen) openTargetInput() tea.Cmd {
@@ -302,15 +366,17 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 	if mp == nil {
 		return nil
 	}
-	title := "edit path"
-	prompt := "Absolute path to the file."
-	ph := "/home/me/scripts/deploy.sh"
-	init := mp.Path
-	if mp.Glob != "" {
-		title = "edit glob"
-		prompt = "Doublestar glob — matches multiple files."
-		ph = "/home/me/scripts/**/*.sh"
-		init = mp.Glob
+	kind := s.effectiveKind()
+	var title, prompt, ph, init string
+	switch kind {
+	case "glob":
+		title, prompt, ph, init = "edit glob", "Doublestar glob — matches multiple files.", "/home/me/scripts/**/*.sh", mp.Glob
+	case "cwd":
+		title, prompt, ph, init = "edit cwd glob",
+			"Match by current working directory. The pattern also covers any subdirectory of a match.",
+			"~/work/acme", mp.CwdGlob
+	default:
+		title, prompt, ph, init = "edit path", "Absolute path to the file.", "/home/me/scripts/deploy.sh", mp.Path
 	}
 	commit := func(val string) tea.Cmd {
 		v := strings.TrimSpace(val)
@@ -318,9 +384,13 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 		if m == nil {
 			return emit(popMsg{})
 		}
-		if m.Glob != "" {
+		m.Path, m.Glob, m.CwdGlob = "", "", ""
+		switch kind {
+		case "glob":
 			m.Glob = v
-		} else {
+		case "cwd":
+			m.CwdGlob = v
+		default:
 			m.Path = v
 		}
 		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
@@ -328,6 +398,40 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
 		Title: title, Prompt: prompt, Placeholder: ph, Initial: init,
 		SaveLabel: "OK", CancelLabel: "Cancel",
+	}, commit)})
+}
+
+// openCommandsInput edits the cwd-only commands list. The list is
+// stored as a comma-separated string in the input field; we trim and
+// split on commit. Empty list is invalid (config.Validate rejects),
+// but we let the user pass through here so they can fix it later
+// without losing other edits.
+func (s *mappingFormScreen) openCommandsInput() tea.Cmd {
+	mp := s.mp()
+	if mp == nil {
+		return nil
+	}
+	commit := func(val string) tea.Cmd {
+		m := s.mp()
+		if m == nil {
+			return emit(popMsg{})
+		}
+		m.Commands = m.Commands[:0]
+		for _, c := range strings.Split(val, ",") {
+			c = strings.TrimSpace(c)
+			if c != "" {
+				m.Commands = append(m.Commands, c)
+			}
+		}
+		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
+	}
+	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
+		Title:       "scope to commands",
+		Prompt:      "Comma-separated bare command names to wrap inside this cwd (e.g. npm, yarn).",
+		Placeholder: "npm, yarn",
+		Initial:     strings.Join(mp.Commands, ", "),
+		AllowBlank:  true,
+		SaveLabel:   "OK", CancelLabel: "Cancel",
 	}, commit)})
 }
 
@@ -342,13 +446,15 @@ func (s *mappingFormScreen) View() string {
 		return errorStyle.Render("(mapping vanished)")
 	}
 
-	kind := "path"
-	if mp.Glob != "" {
-		kind = "glob"
-	}
-	target := mp.Path
-	if mp.Glob != "" {
+	kind := s.effectiveKind()
+	var target string
+	switch kind {
+	case "glob":
 		target = mp.Glob
+	case "cwd":
+		target = mp.CwdGlob
+	default:
+		target = mp.Path
 	}
 	if target == "" {
 		target = dimText("(not set)")
@@ -359,8 +465,17 @@ func (s *mappingFormScreen) View() string {
 	}{
 		{"kind", kind},
 		{"target", target},
-		{"variables", fmt.Sprintf("%d selected", localVarCount(s.root, mp))},
 	}
+	if kind == "cwd" {
+		cmds := strings.Join(mp.Commands, ", ")
+		if cmds == "" {
+			cmds = dimText("(none — required)")
+		}
+		rows = append(rows, struct{ label, value string }{"commands", cmds})
+	}
+	rows = append(rows, struct{ label, value string }{
+		"variables", fmt.Sprintf("%d selected", localVarCount(s.root, mp)),
+	})
 
 	for i, r := range rows {
 		line := fmt.Sprintf("%-12s %s", r.label+":", r.value)


### PR DESCRIPTION
Implements the design from #33 / `docs/design/wrapper-hook.md`. Replaces the closed PR #31's all-DEBUG-trap approach.

## What's in it

A new `cwd_glob` mapping kind that applies env vars to commands the user runs inside a configured directory. The wiring is entirely outside the DEBUG trap:

```toml
[[mappings]]
cwd_glob = "~/work/acme"
commands = ["npm", "yarn"]   # required, explicit list — no wildcards
[[mappings.vars]]
name   = "ACME_API_TOKEN"
source = "local"
ref    = "acme"
key    = "API_TOKEN"
```

### How it works under the hood

- The shell hook prepends a per-shell wrapper dir (`\$XDG_RUNTIME_DIR/jitenv/shells/<pid>/bin`) to `\$PATH` once at hook load. Empty by default.
- A chpwd hook (zsh native, bash via `PROMPT_COMMAND` PWD-diff) calls `jitenv __chpwd <pid> <oldpwd> <newpwd>`. That subcommand asks the agent for the union of `commands` lists across cwd_glob mappings matching the new pwd, then reconciles the wrapper dir's symlinks: adds missing, removes extras.
- Each wrapper is a symlink to the jitenv binary itself. `cmd/jitenv/main.go` dispatches to `internal/shim` when `filepath.Base(os.Args[0]) != "jitenv"`. The shim reads `__JITENV_WRAP_DIR` (exported by the hook), resolves the real command via `\$PATH` minus that dir (so it doesn't loop back into itself), asks the agent for env vars keyed by `(cwd, command)`, and `syscall.Exec`s with merged env.
- Agent-down → shim runs the real command with parent env, silent. Same UX as the locked-agent path elsewhere.
- Stale wrapper dirs from crashed shells get GC'd by `agent.Listen` on next start (via `PidAlive`).

### Schema

`config.Mapping` gains `CwdGlob string` and `Commands []string`. `Validate` rejects multi-kind mappings, commands-without-cwd_glob, and cwd_glob-without-commands. Wildcard rejected by design — explicit list only.

### Agent protocol

Two new ops: `OpFetchEnvCwd` (shim → env vars) and `OpCwdCommands` (chpwd → wrapper command list). Resolver gains `FetchEnvCwd` / `CwdCommands`. Path-keyed `FetchEnv` / `Lookup` unchanged.

### TUI

Mapping form gains a third "cwd" kind in the picker plus a "commands" row (comma-separated input) that only appears for cwd mappings. Carries the `pendingKind` design from #31's late fix so brand-new mappings reflect the picker immediately.

## What's NOT included

- DEBUG-trap intercept of bare-PATH commands (the cwd_glob feature in PR #31). Removed entirely — this design replaces it.
- `has-cwd` sentinel file. No longer needed.
- Wildcard / "match any command" support. Rejected.
- Direnv coexistence verification (deferred per design).

## Test plan
- [x] `make test` — all green, including new `mapping_test.go` (8 cases) and `hook_wrapper_test.go` (2 e2e cases that build the binary, spawn the agent, source the hook, and confirm wrapping in-mapped vs. outside).
- [x] `golangci-lint run ./...` clean.
- [x] Reviewer (interactive bash): `jitenv unlock`, configure a cwd_glob mapping with `commands = ["npm"]`, `cd` into the mapped dir, `which npm` should show the wrapper symlink. Run the wrapped command and confirm env vars land. `cd` out, confirm `which npm` reverts to the system path.
- [x] Reviewer: `jitenv lock`, then run a wrapped command — confirm it runs silently with parent env (no warning, no countdown).
- [x] Reviewer (zsh): same flow.

Closes #27 (the underlying user need; PR #31's specific implementation is closed and superseded).