### PR TITLE
feat(tui): align Save/Back/Apply/Quit nav conventions across screens

### DIFF
--- a/internal/tui/arn_list_screen.go
+++ b/internal/tui/arn_list_screen.go
@@ -104,7 +104,7 @@ func (s *arnListScreen) openAddInput() tea.Cmd {
 		Title:       "add ARN",
 		Prompt:      "Paste a full AWS Secrets Manager ARN.",
 		Placeholder: "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/db-AbCdEf",
-		SaveLabel:   "Add", CancelLabel: "Cancel",
+		SaveLabel:   "Add", CancelLabel: "Back",
 	}, commit)})
 }
 
@@ -137,7 +137,7 @@ func (s *arnListScreen) openEntryMenu() tea.Cmd {
 			return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
 				Title: "edit ARN", Prompt: "Update the ARN.",
 				Initial:   current,
-				SaveLabel: "OK", CancelLabel: "Cancel",
+				SaveLabel: "Apply", CancelLabel: "Back",
 			}, editCommit)})
 		case "Delete":
 			confirmCb := func(c string) tea.Cmd {

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -26,8 +26,9 @@ func commonNavKeys() []helpEntry {
 	return []helpEntry{
 		{"↑/↓ or k/j", "move"},
 		{"Enter", "activate"},
-		{"Esc", "back / cancel"},
+		{"Esc", "back"},
 		{"Tab / Shift-Tab", "next / previous control"},
+		{"Ctrl-S", "save to disk (any screen)"},
 		{"Ctrl-C", "quit (prompts on unsaved changes)"},
 	}
 }
@@ -39,6 +40,7 @@ func renderHelpStatus() string {
 		[2]string{"↑/↓", "move"},
 		[2]string{"Enter", "activate"},
 		[2]string{"Esc", "back"},
+		[2]string{"Ctrl+S", "save"},
 		[2]string{"?", "help"},
 	)
 }

--- a/internal/tui/input_screen.go
+++ b/internal/tui/input_screen.go
@@ -7,10 +7,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// inputScreen asks the user to type a single value, with a [ Save ]
-// and [ Cancel ] button row beneath. The buttons are first-class
-// focusable widgets — Tab cycles between the input and the buttons,
-// and Enter on a focused button activates it.
+// inputScreen asks the user to type a single value, with a commit
+// button (default label "Apply") and a [ Back ] button row beneath.
+// The buttons are first-class focusable widgets — Tab cycles between
+// the input and the buttons, and Enter on a focused button activates
+// it.
 type inputScreen struct {
 	root      *rootModel
 	title     string
@@ -53,11 +54,11 @@ func newInputScreen(r *rootModel, opts inputOpts, onCommit func(string) tea.Cmd)
 
 	saveLabel := opts.SaveLabel
 	if saveLabel == "" {
-		saveLabel = "OK"
+		saveLabel = "Apply"
 	}
 	cancelLabel := opts.CancelLabel
 	if cancelLabel == "" {
-		cancelLabel = "Cancel"
+		cancelLabel = "Back"
 	}
 	btns := []button{newButton(saveLabel), newButton(cancelLabel)}
 	if opts.Masked {
@@ -149,7 +150,7 @@ func (s *inputScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				s.input.EchoMode = textinput.EchoPassword
 				s.buttons[s.btnFocus] = newButton("Reveal")
 				return s, nil
-			case "Cancel":
+			case "Back", "Cancel":
 				return s, emit(popMsg{})
 			default:
 				return s, s.commit()

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -397,7 +397,7 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 	}
 	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
 		Title: title, Prompt: prompt, Placeholder: ph, Initial: init,
-		SaveLabel: "OK", CancelLabel: "Cancel",
+		SaveLabel: "Apply", CancelLabel: "Back",
 	}, commit)})
 }
 
@@ -431,7 +431,7 @@ func (s *mappingFormScreen) openCommandsInput() tea.Cmd {
 		Placeholder: "npm, yarn",
 		Initial:     strings.Join(mp.Commands, ", "),
 		AllowBlank:  true,
-		SaveLabel:   "OK", CancelLabel: "Cancel",
+		SaveLabel:   "Apply", CancelLabel: "Back",
 	}, commit)})
 }
 

--- a/internal/tui/menu.go
+++ b/internal/tui/menu.go
@@ -66,8 +66,15 @@ func (m *menuScreen) HelpText() string {
 	return `jitenv config is the home for editing the encrypted configuration.
 Pick a section, drill in, edit. The ● indicator in the status bar
 shows whether the file has unsaved changes; Save (or Ctrl-S from any
-list page) writes them with envelope encryption and pings the running
+screen) writes them with envelope encryption and pings the running
 agent to reload.
+
+Navigation labels used throughout the TUI:
+  - Save     persist the in-memory cfg to disk (Ctrl-S anywhere).
+  - Apply    commit form values into the in-memory cfg and return.
+  - Back     return to the previous screen, keeping in-memory edits.
+  - Discard  return to the previous screen, dropping in-memory edits.
+  - Quit     leave the application (only on this screen).
 
 The Remote Sources page (AWS / GitHub) is hidden in this build — see
 issues #16 and #17 for the re-enable work.`
@@ -154,7 +161,7 @@ func (m *menuScreen) quitFlow() tea.Cmd {
 	}
 	return emit(pushMsg{s: newConfirmScreen(m.root,
 		"Unsaved changes — what do you want to do?",
-		cb, "Save & quit", "Discard", "Cancel")})
+		cb, "Save & quit", "Discard", "Back")})
 }
 
 func (m *menuScreen) View() string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -58,6 +58,12 @@ func (r *rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Type == tea.KeyCtrlC {
 			return r, tea.Quit
 		}
+		// Global Ctrl+S persists the in-memory cfg to disk from any
+		// screen. Per-screen Update funcs never see this key, so they
+		// don't need to special-case it.
+		if msg.Type == tea.KeyCtrlS {
+			return r, saveCmd(r)
+		}
 		if msg.String() == "?" && len(r.stack) > 0 {
 			if h, ok := r.top().(helpfulScreen); ok {
 				return r, helpOverlayCmd(r, h)

--- a/internal/tui/nav_conventions_test.go
+++ b/internal/tui/nav_conventions_test.go
@@ -1,0 +1,188 @@
+package tui
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+)
+
+// TestCtrlS_GlobalSave drives the rootModel.Update directly with a
+// Ctrl+S keypress and asserts that the global save flow runs end-to-end:
+// the on-disk config file is written and the dirty flag clears once the
+// resulting savedMsg is fed back through Update.
+func TestCtrlS_GlobalSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+	if err := config.DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	r := newRootModel(path, c, key)
+	// Pretend the user has an unsaved edit pending so we can verify
+	// the dirty flag clears after save.
+	r.dirty = true
+
+	// Simulate a Ctrl+S keypress at the root level.
+	_, cmd := r.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("Ctrl+S produced no command")
+	}
+
+	// Drain the save sequence: run each emitted msg back through Update
+	// so the savedMsg path mutates rootModel state.
+	runCmdRecursively(t, r, cmd, 0)
+
+	if r.dirty {
+		t.Fatalf("dirty flag should clear after Ctrl+S save")
+	}
+	if _, err := config.Load(path); err != nil {
+		t.Fatalf("config not written to disk: %v", err)
+	}
+}
+
+// runCmdRecursively executes a tea.Cmd, then walks any sequence/batch
+// messages it produces, feeding terminal messages through r.Update so
+// state-mutating msgs (savedMsg, popMsg, …) take effect.
+//
+// Bubble Tea's tea.Sequence returns a Cmd whose msg is an unexported
+// sequenceMsg ([]tea.Cmd). We unwrap it with reflection so the test
+// doesn't have to depend on internal types.
+func runCmdRecursively(t *testing.T, r *rootModel, cmd tea.Cmd, depth int) {
+	t.Helper()
+	if cmd == nil || depth > 32 {
+		return
+	}
+	msg := cmd()
+	if msg == nil {
+		return
+	}
+	if bm, ok := msg.(tea.BatchMsg); ok {
+		for _, sub := range bm {
+			runCmdRecursively(t, r, sub, depth+1)
+		}
+		return
+	}
+	if subs := unwrapSequence(msg); subs != nil {
+		for _, sub := range subs {
+			runCmdRecursively(t, r, sub, depth+1)
+		}
+		return
+	}
+	_, next := r.Update(msg)
+	runCmdRecursively(t, r, next, depth+1)
+}
+
+// unwrapSequence returns the underlying []tea.Cmd if msg is a Bubble
+// Tea sequence message (an unexported type defined as []tea.Cmd).
+func unwrapSequence(msg tea.Msg) []tea.Cmd {
+	v := reflect.ValueOf(msg)
+	if v.Kind() != reflect.Slice {
+		return nil
+	}
+	if v.Type().Elem() != reflect.TypeOf((*tea.Cmd)(nil)).Elem() {
+		return nil
+	}
+	out := make([]tea.Cmd, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		out[i], _ = v.Index(i).Interface().(tea.Cmd)
+	}
+	return out
+}
+
+// TestParamButtonsForType_UsesCanonicalLabels guards against accidental
+// regression where someone reintroduces "Save"/"Cancel" on the source
+// params form. Apply/Back is the convention; Save belongs to disk
+// persistence (Ctrl+S).
+func TestParamButtonsForType_UsesCanonicalLabels(t *testing.T) {
+	awsBtns := paramButtonsForType("aws")
+	if got := labelsOf(awsBtns); !contains(got, "Apply") || !contains(got, "Back") {
+		t.Errorf("aws buttons missing Apply/Back: %v", got)
+	}
+	if contains(labelsOf(awsBtns), "Save") {
+		t.Errorf("aws buttons must not use 'Save' (reserved for disk save): %v", labelsOf(awsBtns))
+	}
+	if contains(labelsOf(awsBtns), "Cancel") {
+		t.Errorf("aws buttons must use 'Back' not 'Cancel': %v", labelsOf(awsBtns))
+	}
+
+	dflt := paramButtonsForType("github")
+	if got := labelsOf(dflt); !contains(got, "Apply") || !contains(got, "Back") {
+		t.Errorf("default buttons missing Apply/Back: %v", got)
+	}
+	if contains(labelsOf(dflt), "Save") {
+		t.Errorf("default buttons must not use 'Save': %v", labelsOf(dflt))
+	}
+}
+
+// TestInputScreen_DefaultLabels verifies the default input-screen
+// commit/cancel labels match the Apply/Back convention.
+func TestInputScreen_DefaultLabels(t *testing.T) {
+	r := &rootModel{}
+	is := newInputScreen(r, inputOpts{Title: "x", Prompt: "y"}, nil)
+	got := labelsOf(is.buttons)
+	if !contains(got, "Apply") {
+		t.Errorf("input default commit label should be 'Apply', got %v", got)
+	}
+	if !contains(got, "Back") {
+		t.Errorf("input default cancel label should be 'Back', got %v", got)
+	}
+	if contains(got, "OK") {
+		t.Errorf("default input must not use legacy 'OK' label: %v", got)
+	}
+	if contains(got, "Cancel") {
+		t.Errorf("default input must not use legacy 'Cancel' label: %v", got)
+	}
+}
+
+// TestFooterHints_IncludeCtrlS sanity-checks the shared footer
+// renderers so every screen using them advertises Ctrl+S.
+func TestFooterHints_IncludeCtrlS(t *testing.T) {
+	checks := []struct {
+		name string
+		got  string
+	}{
+		{"renderHelpStatus", renderHelpStatus()},
+		{"defaultFormStatus", defaultFormStatus},
+	}
+	for _, tc := range checks {
+		if !strings.Contains(tc.got, "Ctrl+S") {
+			t.Errorf("%s missing Ctrl+S hint: %q", tc.name, tc.got)
+		}
+	}
+}
+
+func labelsOf(btns []button) []string {
+	out := make([]string, len(btns))
+	for i, b := range btns {
+		out[i] = b.label
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/popup_menu.go
+++ b/internal/tui/popup_menu.go
@@ -30,6 +30,7 @@ func (p *popupMenuScreen) Status() string {
 		[2]string{"↑/↓", "move"},
 		[2]string{"Enter", "select"},
 		[2]string{"Esc", "close"},
+		[2]string{"Ctrl+S", "save"},
 	)
 }
 func (p *popupMenuScreen) Init() tea.Cmd { return nil }

--- a/internal/tui/screens_stub.go
+++ b/internal/tui/screens_stub.go
@@ -17,9 +17,14 @@ func newStubScreen(r *rootModel, title, body string) *stubScreen {
 	return &stubScreen{root: r, title: title, body: body}
 }
 
-func (s *stubScreen) Title() string  { return s.title }
-func (s *stubScreen) Status() string { return renderHelpKeys([2]string{"Esc", "back"}) }
-func (s *stubScreen) Init() tea.Cmd  { return nil }
+func (s *stubScreen) Title() string { return s.title }
+func (s *stubScreen) Status() string {
+	return renderHelpKeys(
+		[2]string{"Esc", "back"},
+		[2]string{"Ctrl+S", "save"},
+	)
+}
+func (s *stubScreen) Init() tea.Cmd { return nil }
 func (s *stubScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if k, ok := msg.(tea.KeyMsg); ok {
 		switch k.String() {

--- a/internal/tui/secrets_screen.go
+++ b/internal/tui/secrets_screen.go
@@ -267,6 +267,7 @@ func (s *secretDetailScreen) Status() string {
 		[2]string{"Enter", "open"},
 		[2]string{"r", "reveal"},
 		[2]string{"Esc", "back"},
+		[2]string{"Ctrl+S", "save"},
 		[2]string{"?", "help"},
 	)
 }
@@ -418,7 +419,7 @@ func newKeyValueEditor(r *rootModel, bag, existingKey string) screen {
 		root: r, bag: bag, existingKey: existingKey,
 		keyIn: ki, valIn: vi,
 		btnFocus: -1,
-		buttons:  []button{newButton("Save"), newButton("Reveal"), newButton("Cancel")},
+		buttons:  []button{newButton("Apply"), newButton("Reveal"), newButton("Back")},
 	}
 	if existingKey != "" {
 		s.field = 1
@@ -487,7 +488,7 @@ func (s *kvEditScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 			}
 			label := s.buttons[s.btnFocus].label
 			switch label {
-			case "Save":
+			case "Apply":
 				return s, s.commit()
 			case "Reveal":
 				if s.valIn.EchoMode == textinput.EchoPassword {
@@ -502,7 +503,7 @@ func (s *kvEditScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				s.valIn.EchoMode = textinput.EchoPassword
 				s.buttons[s.btnFocus] = newButton("Reveal")
 				return s, nil
-			case "Cancel":
+			case "Back":
 				return s, emit(popMsg{})
 			}
 		}

--- a/internal/tui/settings_screen.go
+++ b/internal/tui/settings_screen.go
@@ -90,7 +90,7 @@ func (s *settingsScreen) openIdleInput() tea.Cmd {
 		Placeholder: "30m",
 		Initial:     s.root.cfg.Agent.IdleTimeout,
 		AllowBlank:  true,
-		SaveLabel:   "OK",
+		SaveLabel:   "Apply",
 	}, commit)})
 }
 

--- a/internal/tui/sources_screen.go
+++ b/internal/tui/sources_screen.go
@@ -54,6 +54,7 @@ func (s *sourcesListScreen) Status() string {
 		[2]string{"↑/↓", "move"},
 		[2]string{"Enter", "open"},
 		[2]string{"Esc", "back"},
+		[2]string{"Ctrl+S", "save"},
 	)
 }
 func (s *sourcesListScreen) Init() tea.Cmd { return nil }
@@ -196,7 +197,7 @@ func newSourceTypePickerScreen(r *rootModel) screen {
 		root:     r,
 		types:    remoteSourceTypes(),
 		btnFocus: -1,
-		buttons:  []button{newButton("Next"), newButton("Cancel")},
+		buttons:  []button{newButton("Next"), newButton("Back")},
 	}
 }
 
@@ -382,13 +383,15 @@ func newSourceParamsScreenForNew(r *rootModel, typeName, name string) screen {
 // paramButtonsForType returns the button row for a source params screen.
 // Source types that maintain a curated ID list (currently AWS Secrets
 // Manager and its `arns` list) get an extra "ARNs" button between
-// Test and Cancel.
+// Test and Back. The leading "Apply" button commits the form to the
+// in-memory config; "Save" (Ctrl+S) is the disk-persistence action and
+// is global, not per-screen.
 func paramButtonsForType(typeName string) []button {
 	switch typeName {
 	case "aws":
-		return []button{newButton("Save"), newButton("Test"), newButton("ARNs"), newButton("Cancel")}
+		return []button{newButton("Apply"), newButton("Test"), newButton("ARNs"), newButton("Back")}
 	default:
-		return []button{newButton("Save"), newButton("Test"), newButton("Cancel")}
+		return []button{newButton("Apply"), newButton("Test"), newButton("Back")}
 	}
 }
 
@@ -448,13 +451,13 @@ func (s *sourceParamsScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				return s, nil
 			}
 			switch s.buttons[s.btnFocus].label {
-			case "Save":
+			case "Apply":
 				return s, s.save()
 			case "Test":
 				return s, s.testConnection()
 			case "ARNs":
 				return s, s.openARNs()
-			case "Cancel":
+			case "Back":
 				return s, emit(popMsg{})
 			}
 		case "left":

--- a/internal/tui/var_tree_screen.go
+++ b/internal/tui/var_tree_screen.go
@@ -90,7 +90,8 @@ func (s *varTreeScreen) Status() string {
 	return renderHelpKeys(
 		[2]string{"↑/↓", "move"},
 		[2]string{"Space/Enter", "toggle"},
-		[2]string{"Esc", "done"},
+		[2]string{"Esc", "back"},
+		[2]string{"Ctrl+S", "save"},
 		[2]string{"?", "help"},
 	)
 }

--- a/internal/tui/var_wizard.go
+++ b/internal/tui/var_wizard.go
@@ -55,7 +55,7 @@ func newPickSourceStep(r *rootModel, ref config.VarRef, onComplete func(config.V
 	}
 	return &pickSourceStep{
 		root: r, names: names, cursor: cursor, btnFocus: -1,
-		buttons:    []button{newButton("Next"), newButton("Cancel")},
+		buttons:    []button{newButton("Next"), newButton("Back")},
 		ref:        ref,
 		onComplete: onComplete,
 	}

--- a/internal/tui/widgets.go
+++ b/internal/tui/widgets.go
@@ -68,10 +68,12 @@ var (
 		[2]string{"Tab", "buttons"},
 		[2]string{"Enter", "activate"},
 		[2]string{"Esc", "back"},
+		[2]string{"Ctrl+S", "save"},
 	)
 	defaultFormStatus = renderHelpKeys(
 		[2]string{"Tab", "next field"},
 		[2]string{"Enter", "activate"},
-		[2]string{"Esc", "cancel"},
+		[2]string{"Esc", "back"},
+		[2]string{"Ctrl+S", "save"},
 	)
 )


### PR DESCRIPTION
Closes #37 (the minimum coherent slice — see "out of scope" below).

## Summary

The TUI grew three+ conventions for "how do I leave this page" depending on the screen. This PR canonicalizes the navigation vocabulary, adds a global keybinding for disk save, and standardizes footer hints — without doing the bigger "every screen renders a [Save] [Back] button row" redesign.

### Canonical labels

| Label | Meaning | Where |
|---|---|---|
| **Save** | persist in-memory cfg to disk | Ctrl+S anywhere; main-menu button |
| **Apply** | commit form values into in-memory cfg, return | form screens |
| **Back** | return to previous screen, keep edits | Esc and the secondary button on every screen |
| **Discard** | return, drop edits | unsaved-changes confirm on Quit |
| **Quit** | leave the app | main menu only |

Side-effect buttons (`Test`, `ARNs`, `Reveal`/`Hide`, `Add`, `Rename`, `Create`, `Next`, `Done`) are intentionally untouched — they're action verbs, not navigation.

### Changes

- `internal/tui/model.go`: global `Ctrl+S` interceptor in `rootModel.Update` runs `saveCmd` from any screen.
- `internal/tui/widgets.go`, `help.go`: shared status helpers (`defaultListStatus`, `defaultFormStatus`, `renderHelpStatus`, `commonNavKeys`) advertise `Ctrl+S save` and use `Esc back`.
- `internal/tui/menu.go`: quit-confirm now offers `Save & quit / Discard / Back` (was `… / Cancel`).
- `internal/tui/input_screen.go`: defaults changed from `OK / Cancel` to `Apply / Back` (Cancel still recognised for caller compat).
- `internal/tui/sources_screen.go`: source params row is `[Apply] [Test] (ARNs) [Back]`. Type-picker is `[Next] [Back]`.
- `internal/tui/secrets_screen.go`: kvEditScreen is `[Apply] [Reveal] [Back]`.
- Various screens (`mappings_screen`, `arn_list_screen`, `settings_screen`, `var_tree_screen`, `popup_menu`, `screens_stub`, `var_wizard`): footer hints add Ctrl+S; rename `done` → `back` where applicable.

### Tests

`internal/tui/nav_conventions_test.go`:
- `TestCtrlS_GlobalSave` — drives `rootModel.Update` with synthetic Ctrl+S, drains the resulting `tea.Sequence` via reflection (sequenceMsg is unexported), verifies the dirty flag clears and the file lands on disk.
- `TestParamButtonsForType_UsesCanonicalLabels` — guards source-params button rows against future Save/Cancel regressions.
- `TestInputScreen_DefaultLabels` — pins inputScreen defaults to Apply/Back.
- `TestFooterHints_IncludeCtrlS` — sanity-check on the shared status helpers.

## Out of scope (deferred)

- The visible `[Save] [Back]` button row on every screen (issue's proposal #1) — bigger redesign, follow-up issue.
- Popup-menu and confirm-dialog button labels (`Yes`/`No`, `Install`/`Not now` etc.) — left alone per the issue's explicit list.

## Test plan
- [x] `make fmt vet tidy` clean.
- [x] `go test ./...` green.
- [x] `make build` succeeds.
- [ ] Reviewer (interactive TTY): walk the main flows — Mappings → create → Ctrl+S, Local secrets → edit → Esc → confirm in-memory edit preserved, confirm `●` unsaved indicator behavior, confirm footer hints render on every screen.