### PR TITLE
feat(e2e): containerised harness with two distros + LocalStack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /dist/
 *.test
 *.out
+
+# e2e harness artefacts
+/e2e/harness/bin/
+/e2e/runs/*
+!/e2e/runs/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ GO ?= go
 BIN := jitenv
 PREFIX ?= $(HOME)/.local
 
-.PHONY: build install test fmt vet tidy lint release-snapshot clean
+.PHONY: build install test fmt vet tidy lint release-snapshot clean \
+	e2e-up e2e-down e2e-down-hard e2e-build e2e-run e2e-runner-build e2e-shell
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -39,3 +40,37 @@ lint:
 
 release-snapshot:
 	goreleaser release --snapshot --clean --skip=publish,sign
+
+# ---- e2e ---------------------------------------------------------------
+# The harness lives under e2e/ as a separate Go module so it can pull in
+# yaml deps without polluting the main module. See e2e/README.md.
+
+E2E_COMPOSE := e2e/docker-compose.yml
+E2E_PROJECT := jitenv-e2e
+E2E_RUNNER  := e2e/harness/bin/runner
+
+e2e-build:
+	docker compose -f $(E2E_COMPOSE) -p $(E2E_PROJECT) build
+
+e2e-up: e2e-build
+	docker compose -f $(E2E_COMPOSE) -p $(E2E_PROJECT) up -d --wait
+
+e2e-down:
+	docker compose -f $(E2E_COMPOSE) -p $(E2E_PROJECT) down
+
+e2e-down-hard:
+	docker compose -f $(E2E_COMPOSE) -p $(E2E_PROJECT) down -v --remove-orphans
+
+e2e-runner-build:
+	cd e2e/harness && $(GO) build -o ../../$(E2E_RUNNER) ./cmd/runner
+
+# Run a single scenario by filename in e2e/scenarios/.
+#   make e2e-run SCENARIO=unlock-and-run-local.yaml
+e2e-run: e2e-runner-build
+	@test -n "$(SCENARIO)" || (echo "usage: make e2e-run SCENARIO=<file.yaml>"; exit 2)
+	$(E2E_RUNNER) -scenario e2e/scenarios/$(SCENARIO) -compose-file $(E2E_COMPOSE) -project $(E2E_PROJECT)
+
+# Drop into a shell in the named distro service (debian | alpine).
+#   make e2e-shell DISTRO=alpine
+e2e-shell:
+	docker compose -f $(E2E_COMPOSE) -p $(E2E_PROJECT) exec --user jitenv $(or $(DISTRO),debian) bash

--- a/e2e/Dockerfile.alpine
+++ b/e2e/Dockerfile.alpine
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+#
+# Alpine (musl) jitenv test image. Building jitenv against musl is
+# the point — SO_PEERCRED, Setsid double-fork, syscall.Exec all need
+# to round-trip a non-glibc libc. CGO is off so we don't drag in
+# musl-dev unnecessarily.
+
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+RUN apk add --no-cache git
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv ./cmd/jitenv \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+
+FROM alpine:3.20 AS runtime
+RUN apk add --no-cache bash zsh ca-certificates curl tini coreutils procps shadow util-linux && \
+    useradd --create-home --shell /bin/bash --uid 1000 jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/.config/jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts
+
+COPY --from=build /out/jitenv /usr/local/bin/jitenv
+COPY --from=build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
+COPY --from=build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+
+ENTRYPOINT ["/sbin/tini", "--"]
+USER jitenv
+WORKDIR /home/jitenv
+HEALTHCHECK --interval=5s --timeout=2s --start-period=2s --retries=3 \
+    CMD jitenv version || exit 1
+CMD ["sleep", "infinity"]

--- a/e2e/Dockerfile.debian
+++ b/e2e/Dockerfile.debian
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+#
+# Debian-flavoured jitenv test image. The build stage compiles jitenv
+# and the seed helper inside the image (rather than mounting the host
+# binary) so the same Dockerfile works in CI without artefact handoff.
+#
+# Run as user `jitenv` (uid 1000). XDG_RUNTIME_DIR is left unset so
+# agent.DefaultPaths() falls back to /tmp/jitenv-<uid>, which works
+# without systemd. If you want to exercise the XDG branch instead,
+# set XDG_RUNTIME_DIR=/run/user/1000 in the compose file.
+
+FROM golang:1.25-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv ./cmd/jitenv \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+
+FROM debian:bookworm-slim AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        bash zsh ca-certificates curl tini coreutils procps && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd --create-home --shell /bin/bash --uid 1000 jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/.config/jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts
+
+COPY --from=build /out/jitenv /usr/local/bin/jitenv
+COPY --from=build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
+COPY --from=build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+
+# Tini reaps the agent if a scenario forgets to lock; this matters
+# because the daemon double-forks and would otherwise leak as a
+# container-level zombie on `docker compose down`.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# `sleep infinity` keeps the container alive so scenarios can `docker
+# compose exec` into it. The healthcheck looks for the binary, so a
+# broken build fails the stack early instead of after the first scenario.
+USER jitenv
+WORKDIR /home/jitenv
+HEALTHCHECK --interval=5s --timeout=2s --start-period=2s --retries=3 \
+    CMD jitenv version || exit 1
+CMD ["sleep", "infinity"]

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,204 @@
+# jitenv e2e harness
+
+Containerised end-to-end stack and scenario runner for jitenv. The
+harness exists so an AI coding agent (Claude) — or a human — can
+reproduce the unlock → hook → run → fetch loop against real source
+backends and surface failures from rich on-disk diagnostics.
+
+## Quick start
+
+```sh
+make e2e-up                                  # build images, start stack, wait for healthchecks
+make e2e-run SCENARIO=unlock-and-run-local.yaml
+make e2e-run SCENARIO=localstack-fetch.yaml
+make e2e-down                                # tear stack down (keeps volumes)
+make e2e-down-hard                           # tear stack down + drop volumes
+```
+
+Failed runs leave a self-contained artefact directory under
+`e2e/runs/<scenario>-<timestamp>/`. That directory IS the bug report
+— the harness never holds in-memory state past `summary.json`.
+
+## Stack layout
+
+`e2e/docker-compose.yml` runs:
+
+| service       | role                                                                         |
+| ------------- | ---------------------------------------------------------------------------- |
+| `debian`      | Debian bookworm-slim (glibc) test container; bash + zsh + non-root user      |
+| `alpine`      | Alpine 3.20 (musl) test container; same setup, exercises the non-glibc path  |
+| `localstack`  | LocalStack 3.x with Secrets Manager, seeded with one JSON secret             |
+
+Each distro container has:
+
+- A non-root `jitenv` user (uid 1000) with a writable home and `~/.config/jitenv/`.
+- `/tmp` mounted tmpfs, owned by the test user — `agent.DefaultPaths()`
+  falls back to `/tmp/jitenv-1000/` so this is the agent's runtime dir.
+- `bash`, `zsh`, `ca-certificates`, `curl`, `tini`, `coreutils`, `procps`.
+- `/usr/local/bin/jitenv-e2e-seed` — fixture-config generator.
+- `/usr/local/bin/jitenv-e2e-unlock` — non-interactive replacement for
+  `jitenv unlock` (see "Driving unlock" below).
+
+## Run-dir layout
+
+Every scenario produces `e2e/runs/<name>-<UTC-timestamp>/`:
+
+```
+meta.json                  scenario, service, verdict, started/ended timestamps
+summary.json               full per-step report (kind, status, exit, duration, error)
+steps/
+  000-<step-name>/cmd      what was executed (or the assertion meta)
+                  stdout   captured stdout (exec steps only)
+                  stderr   captured stderr (exec steps only)
+                  exit     exit code as a single integer
+  001-<step-name>/...
+teardown/
+  agent.log                tail of /tmp/jitenv-1000/agent.log inside the service
+  config.toml              encrypted config state at scenario end
+  compose-ps.txt           docker compose ps snapshot
+  ps-aux.txt               in-container process listing at teardown time
+```
+
+Acceptance criteria in scenarios reference paths in this layout — do
+not rename or restructure without updating callers.
+
+## Scenario format
+
+Scenarios live under `e2e/scenarios/<name>.yaml`. The shape is
+deliberately small: top-level scenario metadata + a flat list of
+steps. Exactly one action per step.
+
+```yaml
+name: my-scenario
+service: debian          # docker-compose service to exec into
+user: jitenv             # default user for every step (override per-step with `user:`)
+steps:
+  - name: do-thing
+    exec: echo hello
+  - name: assert-ok
+    assert_exit_code: 0
+  - name: assert-out
+    assert_stdout_contains: "hello"
+  - name: wait-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 10s
+```
+
+### Step actions (one per step)
+
+| field                         | semantics                                                       |
+| ----------------------------- | --------------------------------------------------------------- |
+| `exec`                        | run a `bash -c` command inside the service                      |
+| `wait_for_file`               | poll `test -e <path>` inside the service until present          |
+| `assert_exit_code: <int>`     | the previous exec step exited with this code                    |
+| `assert_stdout_contains`      | substring match against stdout                                  |
+| `assert_stdout_equals`        | exact match (trailing `\n` trimmed)                             |
+| `assert_stdout_not_contains`  | negative substring match (used for "no leak" assertions)        |
+| `assert_stderr_contains`      | substring match against stderr                                  |
+
+### Step modifiers
+
+| field            | semantics                                                                  |
+| ---------------- | -------------------------------------------------------------------------- |
+| `target`         | name of an earlier exec step to assert against (default: last exec)        |
+| `service`        | override the scenario service for this step                                |
+| `user`           | override the scenario user for this step                                   |
+| `env`            | extra `-e KEY=VAL` for the docker exec                                     |
+| `stdin`          | string fed to the command's stdin                                          |
+| `timeout`        | per-step timeout (Go duration syntax: `30s`, `5m`, …)                      |
+
+### Why `target`
+
+`jitenv run` exits with the inner script's exit code, which can be
+nonzero for legitimate reasons. `assert_exit_code` against the most
+recent exec is the common case; `target: <step-name>` lets a later
+assertion refer back to an earlier step explicitly.
+
+## Adding a new distro
+
+1. Create `e2e/Dockerfile.<distro>` using the existing two as a
+   template. Multi-stage build: copy `cmd/jitenv` and `e2e/seed` from
+   the build stage into the runtime stage.
+2. The runtime image MUST install:
+   - `bash`, `zsh`, `ca-certificates`, `curl`, `tini`, `coreutils`,
+     `procps`
+   - `script(1)` — bsdutils on Debian, util-linux on Alpine
+3. Provision a non-root `jitenv` user (uid 1000) with `~/.config/jitenv/`
+   and `~/scripts/` pre-created (mode 0700).
+4. Add a `<distro>:` service to `e2e/docker-compose.yml`. Mount
+   `/tmp` as tmpfs owned by uid 1000 so `agent.DefaultPaths()` lands
+   somewhere fresh per `make e2e-up`.
+5. The new service's healthcheck should run `jitenv version` — that
+   way a broken cross-compile fails the stack startup, not the
+   first scenario.
+6. Bump `service:` in any new scenarios to point at it.
+
+## Adding a new source backend
+
+The fixture generator is `e2e/seed/seed.go`. Today it knows two
+variants (`local`, `localstack`). To add another:
+
+1. Add a new `apply<Source>` function that mirrors the TUI's save
+   shape for that source — see `applyLocalstack` for the
+   encrypted-params pattern (use `crypto.EncryptField` for any
+   `Sensitive` schema field).
+2. Add a case in the `switch *variant` block.
+3. If the source needs a backing service (Vault, mock GitHub, …):
+   - add it to `docker-compose.yml` with a healthcheck;
+   - put init scripts under `e2e/seed/<service>-init/`;
+   - add the service as a `depends_on: condition: service_healthy`
+     for the distro services that need it.
+4. Add a scenario under `e2e/scenarios/` that drives unlock + run
+   against a mapped script using the new source.
+
+## Driving `jitenv unlock` non-interactively
+
+`jitenv unlock` reads its passphrase from `/dev/tty`, which
+`docker exec -T` does not provide. The first attempt was a `script(1)`
+PTY wrapper, but golang.org/x/term's `ReadPassword` doesn't reliably
+consume input piped through a subprocess-allocated PTY (the canonical
+line buffer hand-off has timing issues we won't fix in the harness).
+
+Instead the image ships `jitenv-e2e-unlock`, a tiny Go helper that
+takes the passphrase as a flag (or on stdin) and otherwise calls the
+exact same code path as production unlock — `config.Load`,
+`config.DeriveKeyFromMeta`, `agent.SpawnDaemon`. The only thing it
+skips is `crypto.PromptPassphrase`. This means scenarios exercise the
+KDF (passphrase verification), salt unmarshalling, daemon double-fork,
+and key handover via fd 3 — i.e. everything below `unlock` in the
+production stack.
+
+```sh
+jitenv-e2e-unlock -passphrase e2e-test-pass
+# or
+printf '%s\n' "$pw" | jitenv-e2e-unlock -passphrase-stdin
+```
+
+We deliberately do NOT add a `--passphrase-fd` flag to the real
+`jitenv unlock`; the e2e harness is the only consumer that needs
+this and it owns its own helper.
+
+## Common failure-mode reads
+
+When a scenario fails, look at these files in order:
+
+1. `summary.json` — which step failed and why (the `error` field).
+2. `steps/<failed-step>/{stdout,stderr}` — what the command emitted.
+3. `teardown/agent.log` — the agent's own log, captured at scenario
+   end. Empty file means the agent never started.
+4. `teardown/config.toml` — the on-disk encrypted state. The
+   scenario harness does NOT decrypt; if you need to inspect, use
+   `jitenv config show` against the file with the e2e passphrase
+   `e2e-test-pass`.
+5. `teardown/ps-aux.txt` — useful when checking whether the daemon
+   is still alive after a `lock` step.
+
+## Out of scope (deferred to follow-ups)
+
+- Vault, mock GitHub, OIDC services
+- Fedora / Arch distros
+- CI workflow integration (`.github/workflows/e2e.yml`)
+- Scenarios for: locked-agent UX, glob mappings, mid-session
+  `pingAgentReload`
+- zsh hook scenarios (the snippets are installed but no scenario
+  exercises them yet)

--- a/e2e/cmd/unlock/main.go
+++ b/e2e/cmd/unlock/main.go
@@ -1,0 +1,163 @@
+// Command jitenv-e2e-unlock is a test-only replacement for `jitenv
+// unlock` that takes the passphrase non-interactively. It exists
+// because `jitenv unlock` reads from /dev/tty and we cannot reliably
+// drive a PTY from `docker exec -T` without dragging expect/socat
+// into every distro image.
+//
+// The implementation is identical to the production unlock path: load
+// the config, derive the key via DeriveKeyFromMeta (which still
+// validates the passphrase via the verify sentinel), then spawn the
+// agent daemon with the key on fd 3.
+//
+// Note: `agent.SpawnDaemon` re-execs `os.Executable()`, which here is
+// `jitenv-e2e-unlock`, not `jitenv`. The helper would then re-enter
+// itself with `__agent ...` flags and crash. So this command does the
+// daemon spawn inline against the path of the real `jitenv` binary
+// (configurable via -jitenv-bin, default /usr/local/bin/jitenv). The
+// rest — pipe handover, Setsid double-fork, socket-presence wait —
+// is copied from SpawnDaemon.
+//
+// We deliberately do NOT add a `--passphrase-fd` flag to the real
+// `jitenv unlock` to avoid weakening its UX contract; the e2e harness
+// is the only consumer that needs this shape.
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+func main() {
+	var (
+		passphrase = flag.String("passphrase", "", "passphrase (or use -passphrase-stdin)")
+		stdinPW    = flag.Bool("passphrase-stdin", false, "read passphrase from stdin (newline-terminated)")
+		idle       = flag.String("idle", "30m", "agent idle timeout")
+		jitenvBin  = flag.String("jitenv-bin", "/usr/local/bin/jitenv", "path to the jitenv binary to spawn as the daemon")
+	)
+	flag.Parse()
+
+	pw := []byte(*passphrase)
+	if *stdinPW {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			die("read stdin: %v", err)
+		}
+		if n := len(b); n > 0 && b[n-1] == '\n' {
+			b = b[:n-1]
+		}
+		pw = b
+	}
+	if len(pw) == 0 {
+		die("passphrase required (use -passphrase or -passphrase-stdin)")
+	}
+	defer zero(pw)
+
+	cfgPath, err := config.Resolve("")
+	if err != nil {
+		die("resolve config: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		die("load config: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		die("derive key: %v", err)
+	}
+	defer zero(key)
+
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		die("agent paths: %v", err)
+	}
+	d, err := time.ParseDuration(*idle)
+	if err != nil {
+		die("parse idle: %v", err)
+	}
+	if err := spawn(paths, cfgPath, *jitenvBin, d, key); err != nil {
+		die("spawn agent: %v", err)
+	}
+	fmt.Fprintf(os.Stdout, "agent started (socket: %s)\n", paths.Socket)
+}
+
+// spawn mirrors agent.SpawnDaemon but uses an explicit binary path
+// rather than os.Executable(), so jitenv-e2e-unlock can hand off to
+// the real `jitenv` binary's hidden `__agent` subcommand.
+func spawn(paths agent.Paths, cfgFile, exe string, idle time.Duration, key []byte) error {
+	if existing, _ := agent.ReadPidFile(paths.PidFile); existing > 0 && agent.PidAlive(existing) {
+		return fmt.Errorf("agent already running (pid %d)", existing)
+	}
+	if len(key) != int(crypto.KeyLen) {
+		return errors.New("invalid key length")
+	}
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer pw.Close()
+
+	logF, err := os.OpenFile(paths.LogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	defer logF.Close()
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer devNull.Close()
+
+	cmd := exec.Command(exe, "__agent", "--key-fd=3", "--config="+cfgFile, "--idle="+idle.String())
+	cmd.Stdin = devNull
+	cmd.Stdout = logF
+	cmd.Stderr = logF
+	cmd.ExtraFiles = []*os.File{pr}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := cmd.Start(); err != nil {
+		pr.Close()
+		return err
+	}
+	pr.Close()
+
+	if _, err := pw.Write(key); err != nil {
+		return fmt.Errorf("write key to child: %w", err)
+	}
+	pw.Close()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(paths.Socket); err == nil {
+			_ = cmd.Process.Release()
+			return nil
+		}
+		if cmd.ProcessState != nil {
+			return fmt.Errorf("agent exited early: %s", cmd.ProcessState)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = cmd.Process.Kill()
+	return errors.New("agent did not start within 5s; check the agent.log under the runtime dir")
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "jitenv-e2e-unlock: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,68 @@
+# jitenv e2e stack. Bring up with `make e2e-up`.
+#
+# Two distros (debian-glibc, alpine-musl) sit alongside a LocalStack
+# instance for the AWS Secrets Manager source. The harness runs on
+# the host and shells into a chosen service via `docker compose exec`.
+#
+# All services are unprivileged. The runtime dir for jitenv falls back
+# to /tmp/jitenv-<uid> automatically (see internal/agent/paths.go).
+
+services:
+  debian:
+    build:
+      # Build context is the repo root so the Dockerfile can `COPY .`
+      # without a subtree-mount; this keeps the e2e image self-contained
+      # and means CI reproduction needs nothing more than `docker compose build`.
+      context: ..
+      dockerfile: e2e/Dockerfile.debian
+    image: jitenv-e2e-debian
+    container_name: jitenv-e2e-debian
+    init: true
+    # Fresh tmpfs at /tmp keeps each `make e2e-up` cycle deterministic:
+    # the agent socket / pidfile / log all land here.
+    tmpfs:
+      - /tmp:exec,uid=1000,gid=1000
+    depends_on:
+      localstack:
+        condition: service_healthy
+    environment:
+      JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
+      LOCALSTACK_HOSTNAME: localstack
+
+  alpine:
+    build:
+      context: ..
+      dockerfile: e2e/Dockerfile.alpine
+    image: jitenv-e2e-alpine
+    container_name: jitenv-e2e-alpine
+    init: true
+    tmpfs:
+      - /tmp:exec,uid=1000,gid=1000
+    depends_on:
+      localstack:
+        condition: service_healthy
+    environment:
+      JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
+      LOCALSTACK_HOSTNAME: localstack
+
+  localstack:
+    image: localstack/localstack:3.8
+    container_name: jitenv-e2e-localstack
+    environment:
+      SERVICES: secretsmanager
+      DEBUG: "0"
+      LS_LOG: warn
+      AWS_DEFAULT_REGION: us-east-1
+      # Skip pro features and dashboard so cold-start is faster.
+      EAGER_SERVICE_LOADING: "1"
+    healthcheck:
+      # /_localstack/health returns 200 when listed services are running.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:4566/_localstack/health | grep -q '\"secretsmanager\": \"available\"\\|\"secretsmanager\": \"running\"' || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+    volumes:
+      # Init scripts run on first boot. /etc/localstack/init/ready.d
+      # fires after services are listening.
+      - ./seed/localstack-init:/etc/localstack/init/ready.d:ro

--- a/e2e/harness/cmd/runner/main.go
+++ b/e2e/harness/cmd/runner/main.go
@@ -1,0 +1,75 @@
+// Command runner executes jitenv e2e scenarios. Each scenario is a
+// YAML file that picks a docker-compose service to run inside, then
+// drives a sequence of steps via `docker compose exec`. Output is
+// captured per step into a run directory and a summary.json is
+// produced at the end so a calling agent can inspect results without
+// re-running anything.
+//
+// The harness DOES NOT bring the stack up or down — that's `make e2e-up`
+// / `make e2e-down`. It DOES NOT interpret success based on heuristics
+// — explicit assert_* steps are the only verdict surface.
+//
+// Usage:
+//
+//	runner -scenario e2e/scenarios/foo.yaml -compose-file e2e/docker-compose.yml -runs-dir e2e/runs
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gv/jitenv/e2e/harness/internal/runner"
+)
+
+func main() {
+	var (
+		scenarioPath = flag.String("scenario", "", "path to scenario YAML (required)")
+		composeFile  = flag.String("compose-file", "e2e/docker-compose.yml", "path to docker-compose.yml")
+		runsDir      = flag.String("runs-dir", "e2e/runs", "where to drop run artifacts")
+		project      = flag.String("project", "jitenv-e2e", "compose project name")
+	)
+	flag.Parse()
+
+	if *scenarioPath == "" {
+		fmt.Fprintln(os.Stderr, "runner: -scenario is required")
+		os.Exit(2)
+	}
+
+	abs, err := filepath.Abs(*scenarioPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runner: %v\n", err)
+		os.Exit(2)
+	}
+	scn, err := runner.LoadScenario(abs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "runner: load scenario: %v\n", err)
+		os.Exit(2)
+	}
+
+	runDir := filepath.Join(*runsDir, fmt.Sprintf("%s-%s", scn.Name, time.Now().UTC().Format("20060102-150405")))
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "runner: mkdir run-dir: %v\n", err)
+		os.Exit(2)
+	}
+
+	r := &runner.Runner{
+		Scenario:     scn,
+		ScenarioPath: abs,
+		RunDir:       runDir,
+		ComposeFile:  *composeFile,
+		Project:      *project,
+		Out:          os.Stdout,
+	}
+	rep := r.Run()
+	if err := rep.Write(runDir); err != nil {
+		fmt.Fprintf(os.Stderr, "runner: write report: %v\n", err)
+		os.Exit(2)
+	}
+	fmt.Fprintf(os.Stdout, "\nrun dir: %s\n", runDir)
+	if rep.Verdict != "pass" {
+		os.Exit(1)
+	}
+}

--- a/e2e/harness/go.mod
+++ b/e2e/harness/go.mod
@@ -1,0 +1,5 @@
+module github.com/gv/jitenv/e2e/harness
+
+go 1.25.6
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/e2e/harness/go.sum
+++ b/e2e/harness/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/e2e/harness/internal/runner/run.go
+++ b/e2e/harness/internal/runner/run.go
@@ -1,0 +1,529 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Runner executes a Scenario against a docker-compose stack.
+type Runner struct {
+	Scenario     *Scenario
+	ScenarioPath string
+	RunDir       string
+	ComposeFile  string
+	Project      string
+	Out          io.Writer
+
+	// DefaultTimeout is the per-step timeout when the step does not
+	// set its own. Eight minutes is enough for `go build` from cold
+	// inside an alpine container; trim later if it bites.
+	DefaultTimeout time.Duration
+
+	// lastExec is the index of the most recent exec step. assert_*
+	// steps without an explicit Target refer to this one.
+	lastExec int
+	// stepDirs maps step name → run-dir subpath, so a Target lookup
+	// can read back stdout/stderr/exit.
+	stepDirs map[string]string
+}
+
+// Report is what the runner writes to <run>/summary.json. Everything
+// the calling agent needs to triage a failure should be referenced here
+// or live alongside it in the run dir.
+type Report struct {
+	Scenario  string       `json:"scenario"`
+	Service   string       `json:"service"`
+	Verdict   string       `json:"verdict"` // "pass" | "fail"
+	StartedAt time.Time    `json:"started_at"`
+	EndedAt   time.Time    `json:"ended_at"`
+	Steps     []StepReport `json:"steps"`
+	Failure   string       `json:"failure,omitempty"`
+}
+
+// StepReport is one entry in Report.Steps. The Dir field is the
+// per-step subdirectory (relative to the run dir); the harness writes
+// cmd / stdout / stderr / exit there.
+type StepReport struct {
+	Index    int           `json:"index"`
+	Name     string        `json:"name"`
+	Kind     string        `json:"kind"` // "exec" | "wait_for_file" | "assert_*"
+	Dir      string        `json:"dir"`
+	ExitCode int           `json:"exit_code"`
+	Duration time.Duration `json:"duration_ns"`
+	Error    string        `json:"error,omitempty"`
+	Status   string        `json:"status"` // "ok" | "fail" | "skipped"
+}
+
+// Run executes every step and returns a Report. The runner does not
+// stop on the first failure: subsequent steps still run so the run dir
+// captures as much state as possible. Verdict is "fail" if any step
+// failed.
+func (r *Runner) Run() *Report {
+	if r.DefaultTimeout == 0 {
+		r.DefaultTimeout = 8 * time.Minute
+	}
+	r.stepDirs = map[string]string{}
+	r.lastExec = -1
+
+	rep := &Report{
+		Scenario:  r.Scenario.Name,
+		Service:   r.Scenario.Service,
+		StartedAt: time.Now().UTC(),
+	}
+	r.logf("=== scenario %s on service %s ===\n", r.Scenario.Name, r.Scenario.Service)
+
+	for i, st := range r.Scenario.Steps {
+		sr := r.runStep(i, &st)
+		rep.Steps = append(rep.Steps, sr)
+		r.logf("[%02d] %s (%s) → %s\n", sr.Index, sr.Name, sr.Kind, sr.Status)
+		if sr.Status == "fail" && rep.Failure == "" {
+			rep.Failure = fmt.Sprintf("step %d (%s): %s", sr.Index, sr.Name, sr.Error)
+		}
+	}
+
+	rep.EndedAt = time.Now().UTC()
+	rep.Verdict = "pass"
+	for _, s := range rep.Steps {
+		if s.Status == "fail" {
+			rep.Verdict = "fail"
+			break
+		}
+	}
+	r.captureTeardown()
+	r.logf("=== verdict: %s ===\n", rep.Verdict)
+	return rep
+}
+
+// runStep dispatches one step. The step writes its own per-step
+// directory (the only files the harness writes per step are cmd,
+// stdout, stderr, exit, plus a meta.json for non-exec steps).
+func (r *Runner) runStep(i int, st *Step) StepReport {
+	stepDirName := fmt.Sprintf("%03d-%s", i, sanitize(st.Name))
+	dirAbs := filepath.Join(r.RunDir, "steps", stepDirName)
+	if err := os.MkdirAll(dirAbs, 0755); err != nil {
+		return StepReport{Index: i, Name: st.Name, Kind: "unknown", Status: "fail", Error: err.Error()}
+	}
+	r.stepDirs[st.Name] = dirAbs
+
+	start := time.Now()
+	sr := StepReport{Index: i, Name: st.Name, Dir: filepath.Join("steps", stepDirName)}
+
+	switch {
+	case st.Exec != "":
+		sr.Kind = "exec"
+		r.lastExec = i
+		ec, err := r.doExec(st, dirAbs)
+		sr.ExitCode = ec
+		if err != nil {
+			sr.Status = "fail"
+			sr.Error = err.Error()
+		} else {
+			sr.Status = "ok"
+		}
+	case st.WaitForFile != "":
+		sr.Kind = "wait_for_file"
+		err := r.doWaitForFile(st, dirAbs)
+		if err != nil {
+			sr.Status = "fail"
+			sr.Error = err.Error()
+		} else {
+			sr.Status = "ok"
+		}
+	case st.AssertExitCode != nil:
+		sr.Kind = "assert_exit_code"
+		err := r.doAssertExit(*st.AssertExitCode, st.Target, dirAbs)
+		if err != nil {
+			sr.Status = "fail"
+			sr.Error = err.Error()
+		} else {
+			sr.Status = "ok"
+		}
+	case st.AssertStdoutContains != "":
+		sr.Kind = "assert_stdout_contains"
+		err := r.doAssertStream("stdout", st.AssertStdoutContains, st.Target, dirAbs, contains)
+		if err != nil {
+			sr.Status = "fail"
+			sr.Error = err.Error()
+		} else {
+			sr.Status = "ok"
+		}
+	case st.AssertStdoutEquals != "":
+		sr.Kind = "assert_stdout_equals"
+		err := r.doAssertStream("stdout", st.AssertStdoutEquals, st.Target, dirAbs, equals)
+		if err != nil {
+			sr.Status = "fail"
+			sr.Error = err.Error()
+		} else {
+			sr.Status = "ok"
+		}
+	case st.AssertStderrContains != "":
+		sr.Kind = "assert_stderr_contains"
+		err := r.doAssertStream("stderr", st.AssertStderrContains, st.Target, dirAbs, contains)
+		if err != nil {
+			sr.Status = "fail"
+			sr.Error = err.Error()
+		} else {
+			sr.Status = "ok"
+		}
+	case st.AssertStdoutNotContain != "":
+		sr.Kind = "assert_stdout_not_contains"
+		err := r.doAssertStream("stdout", st.AssertStdoutNotContain, st.Target, dirAbs, notContains)
+		if err != nil {
+			sr.Status = "fail"
+			sr.Error = err.Error()
+		} else {
+			sr.Status = "ok"
+		}
+	default:
+		sr.Kind = "unknown"
+		sr.Status = "fail"
+		sr.Error = "no action"
+	}
+
+	sr.Duration = time.Since(start)
+	return sr
+}
+
+// doExec runs an `exec` step: docker compose exec --user <u> <svc> bash -c <cmd>.
+// stdout/stderr are tee'd into the per-step dir AND the runner's Out.
+func (r *Runner) doExec(st *Step, dirAbs string) (int, error) {
+	user := r.Scenario.User
+	if st.User != "" {
+		user = st.User
+	}
+	service := r.Scenario.Service
+	if st.Service != "" {
+		service = st.Service
+	}
+
+	composeArgs := []string{"compose", "-f", r.ComposeFile, "-p", r.Project, "exec", "-T", "--user", user}
+	for k, v := range st.Env {
+		composeArgs = append(composeArgs, "-e", k+"="+v)
+	}
+	composeArgs = append(composeArgs, service, "bash", "-c", st.Exec)
+
+	if err := os.WriteFile(filepath.Join(dirAbs, "cmd"), []byte(st.Exec+"\n"), 0644); err != nil {
+		return -1, err
+	}
+
+	timeout := r.DefaultTimeout
+	if st.Timeout != "" {
+		if d, err := time.ParseDuration(st.Timeout); err == nil {
+			timeout = d
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", composeArgs...)
+	if st.Stdin != "" {
+		cmd.Stdin = strings.NewReader(st.Stdin)
+	}
+
+	stdoutF, err := os.Create(filepath.Join(dirAbs, "stdout"))
+	if err != nil {
+		return -1, err
+	}
+	defer stdoutF.Close()
+	stderrF, err := os.Create(filepath.Join(dirAbs, "stderr"))
+	if err != nil {
+		return -1, err
+	}
+	defer stderrF.Close()
+
+	// Tee through the runner's Out so a human running this manually can
+	// follow along; the per-step files are the source of truth for
+	// later assertions.
+	cmd.Stdout = io.MultiWriter(stdoutF, prefixWriter{w: r.Out, prefix: "    | "})
+	cmd.Stderr = io.MultiWriter(stderrF, prefixWriter{w: r.Out, prefix: "    ! "})
+
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			exitCode = ee.ExitCode()
+			err = nil // exit codes aren't runner failures
+		} else if ctx.Err() == context.DeadlineExceeded {
+			exitCode = -1
+			err = fmt.Errorf("timeout after %s", timeout)
+		} else {
+			exitCode = -1
+		}
+	}
+	if writeErr := os.WriteFile(filepath.Join(dirAbs, "exit"), []byte(fmt.Sprintf("%d\n", exitCode)), 0644); writeErr != nil && err == nil {
+		err = writeErr
+	}
+	return exitCode, err
+}
+
+// doWaitForFile polls inside the service until the file exists. It
+// uses bash inside the container so we don't need a host-side mount.
+func (r *Runner) doWaitForFile(st *Step, dirAbs string) error {
+	timeout := 30 * time.Second
+	if st.Timeout != "" {
+		if d, err := time.ParseDuration(st.Timeout); err == nil {
+			timeout = d
+		}
+	}
+	deadline := time.Now().Add(timeout)
+	user := r.Scenario.User
+	service := r.Scenario.Service
+
+	if err := os.WriteFile(filepath.Join(dirAbs, "cmd"), []byte("wait_for_file: "+st.WaitForFile+"\n"), 0644); err != nil {
+		return err
+	}
+
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cmd := exec.CommandContext(ctx, "docker", "compose", "-f", r.ComposeFile, "-p", r.Project,
+			"exec", "-T", "--user", user, service, "test", "-e", st.WaitForFile)
+		err := cmd.Run()
+		cancel()
+		if err == nil {
+			_ = os.WriteFile(filepath.Join(dirAbs, "exit"), []byte("0\n"), 0644)
+			return nil
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	_ = os.WriteFile(filepath.Join(dirAbs, "exit"), []byte("1\n"), 0644)
+	return fmt.Errorf("file %q did not appear within %s", st.WaitForFile, timeout)
+}
+
+// doAssertExit reads the exit file of a previous exec step and checks
+// it against want.
+func (r *Runner) doAssertExit(want int, target, dirAbs string) error {
+	t, err := r.targetExitCode(target)
+	if err != nil {
+		return err
+	}
+	r.writeAssertMeta(dirAbs, fmt.Sprintf("want_exit=%d got_exit=%d target=%s", want, t, r.targetName(target)))
+	if t != want {
+		return fmt.Errorf("expected exit %d, got %d (target=%s)", want, t, r.targetName(target))
+	}
+	return nil
+}
+
+type matchFn func(haystack, needle string) (bool, string)
+
+func contains(h, n string) (bool, string) {
+	if strings.Contains(h, n) {
+		return true, ""
+	}
+	return false, fmt.Sprintf("expected to contain %q", n)
+}
+
+func equals(h, n string) (bool, string) {
+	h = strings.TrimRight(h, "\n")
+	if h == n {
+		return true, ""
+	}
+	return false, fmt.Sprintf("expected %q, got %q", n, h)
+}
+
+func notContains(h, n string) (bool, string) {
+	if !strings.Contains(h, n) {
+		return true, ""
+	}
+	return false, fmt.Sprintf("expected NOT to contain %q (but it did)", n)
+}
+
+func (r *Runner) doAssertStream(stream, want, target, dirAbs string, fn matchFn) error {
+	body, err := r.targetStream(target, stream)
+	if err != nil {
+		return err
+	}
+	r.writeAssertMeta(dirAbs, fmt.Sprintf("stream=%s want=%q target=%s", stream, want, r.targetName(target)))
+	ok, msg := fn(body, want)
+	if !ok {
+		return fmt.Errorf("%s (target=%s, stream=%s); have: %q",
+			msg, r.targetName(target), stream, truncate(body, 240))
+	}
+	return nil
+}
+
+// targetExitCode resolves the step name (or last exec) and reads its
+// exit file from the run dir.
+func (r *Runner) targetExitCode(name string) (int, error) {
+	dir, err := r.targetDir(name)
+	if err != nil {
+		return 0, err
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "exit"))
+	if err != nil {
+		return 0, fmt.Errorf("read exit: %w", err)
+	}
+	var n int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(b)), "%d", &n); err != nil {
+		return 0, fmt.Errorf("parse exit %q: %w", string(b), err)
+	}
+	return n, nil
+}
+
+func (r *Runner) targetStream(name, stream string) (string, error) {
+	dir, err := r.targetDir(name)
+	if err != nil {
+		return "", err
+	}
+	b, err := os.ReadFile(filepath.Join(dir, stream))
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", stream, err)
+	}
+	return string(b), nil
+}
+
+func (r *Runner) targetDir(name string) (string, error) {
+	if name != "" {
+		d, ok := r.stepDirs[name]
+		if !ok {
+			return "", fmt.Errorf("target step %q not found", name)
+		}
+		return d, nil
+	}
+	if r.lastExec < 0 {
+		return "", fmt.Errorf("assert_* with no target and no preceding exec")
+	}
+	last := r.Scenario.Steps[r.lastExec]
+	d, ok := r.stepDirs[last.Name]
+	if !ok {
+		return "", fmt.Errorf("internal: last exec dir not registered")
+	}
+	return d, nil
+}
+
+func (r *Runner) targetName(name string) string {
+	if name != "" {
+		return name
+	}
+	if r.lastExec < 0 {
+		return "(none)"
+	}
+	return r.Scenario.Steps[r.lastExec].Name
+}
+
+func (r *Runner) writeAssertMeta(dirAbs, line string) {
+	_ = os.WriteFile(filepath.Join(dirAbs, "cmd"), []byte(line+"\n"), 0644)
+}
+
+// captureTeardown collects post-run state into the run dir: a tail of
+// the agent log, the current config.toml (encrypted), and a compose
+// ps snapshot. Each is best-effort; failures are noted in a per-file
+// .err but don't fail the run.
+func (r *Runner) captureTeardown() {
+	tdDir := filepath.Join(r.RunDir, "teardown")
+	_ = os.MkdirAll(tdDir, 0755)
+
+	r.collect(tdDir, "compose-ps.txt",
+		"docker", "compose", "-f", r.ComposeFile, "-p", r.Project, "ps")
+	// Best-effort grab of jitenv runtime state. The container's runtime
+	// dir is /run/user/1000/jitenv (XDG) or /tmp/jitenv-<uid>; we try
+	// both via shell.
+	r.collect(tdDir, "agent.log",
+		"docker", "compose", "-f", r.ComposeFile, "-p", r.Project,
+		"exec", "-T", "--user", r.Scenario.User, r.Scenario.Service,
+		"bash", "-c", `cat "$XDG_RUNTIME_DIR/jitenv/agent.log" 2>/dev/null || cat "/tmp/jitenv-$UID/agent.log" 2>/dev/null || echo "(no agent.log)"`)
+	r.collect(tdDir, "config.toml",
+		"docker", "compose", "-f", r.ComposeFile, "-p", r.Project,
+		"exec", "-T", "--user", r.Scenario.User, r.Scenario.Service,
+		"bash", "-c", `cat "${JITENV_CONFIG:-$HOME/.config/jitenv/config.toml}" 2>/dev/null || echo "(no config.toml)"`)
+	r.collect(tdDir, "ps-aux.txt",
+		"docker", "compose", "-f", r.ComposeFile, "-p", r.Project,
+		"exec", "-T", "--user", r.Scenario.User, r.Scenario.Service,
+		"bash", "-c", "ps -ef")
+}
+
+func (r *Runner) collect(dir, name string, args ...string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	out, err := cmd.CombinedOutput()
+	dst := filepath.Join(dir, name)
+	if writeErr := os.WriteFile(dst, out, 0644); writeErr != nil {
+		_ = os.WriteFile(dst+".err", []byte(writeErr.Error()), 0644)
+	}
+	if err != nil {
+		_ = os.WriteFile(dst+".err", []byte(err.Error()+"\n"), 0644)
+	}
+}
+
+// Write serialises the report to summary.json + meta.json. Keep them
+// separate so a calling agent can read meta without parsing all step
+// detail.
+func (rep *Report) Write(runDir string) error {
+	full, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "summary.json"), full, 0644); err != nil {
+		return err
+	}
+	meta := map[string]any{
+		"scenario":   rep.Scenario,
+		"service":    rep.Service,
+		"verdict":    rep.Verdict,
+		"started_at": rep.StartedAt,
+		"ended_at":   rep.EndedAt,
+		"failure":    rep.Failure,
+	}
+	mb, _ := json.MarshalIndent(meta, "", "  ")
+	return os.WriteFile(filepath.Join(runDir, "meta.json"), mb, 0644)
+}
+
+func (r *Runner) logf(format string, args ...any) {
+	if r.Out == nil {
+		return
+	}
+	fmt.Fprintf(r.Out, format, args...)
+}
+
+// sanitize strips characters that shouldn't appear in directory names.
+// We don't need to be exhaustive — scenario authors choose step names.
+func sanitize(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-', c == '_':
+			out = append(out, c)
+		case c == ' ':
+			out = append(out, '-')
+		}
+	}
+	if len(out) == 0 {
+		return "step"
+	}
+	return string(out)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+type prefixWriter struct {
+	w      io.Writer
+	prefix string
+}
+
+func (p prefixWriter) Write(b []byte) (int, error) {
+	if p.w == nil {
+		return len(b), nil
+	}
+	for _, line := range strings.SplitAfter(string(b), "\n") {
+		if line == "" {
+			continue
+		}
+		if _, err := io.WriteString(p.w, p.prefix+line); err != nil {
+			return 0, err
+		}
+	}
+	return len(b), nil
+}

--- a/e2e/harness/internal/runner/scenario.go
+++ b/e2e/harness/internal/runner/scenario.go
@@ -1,0 +1,149 @@
+// Package runner loads, executes, and reports on jitenv e2e scenarios.
+//
+// Design tenets, in order of importance:
+//
+//  1. The agent is the runner. The harness is a capture surface — it
+//     does not branch behaviour on heuristics. Every verdict comes
+//     from an explicit assert_* step in the YAML.
+//  2. Run-dir layout is rigid. Acceptance criteria in scenarios refer
+//     to paths in this layout (e.g. steps/<n>-<name>/exit), so the
+//     layout is the contract; do not parameterise it.
+//  3. Failures are diagnosable from the run dir alone. Every step
+//     records cmd / stdout / stderr / exit. The teardown captures
+//     agent.log, the config.toml state, and a docker-compose ps
+//     snapshot.
+package runner
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Scenario is the on-disk YAML shape. Keep this small — adding a new
+// step type is easier than reasoning about a control-flow grammar.
+type Scenario struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	// Service is the docker-compose service to exec into for every step
+	// that doesn't override it.
+	Service string `yaml:"service"`
+	// User defaults to "jitenv" — the non-root user every distro
+	// container provisions. Override per-scenario if you need root.
+	User  string `yaml:"user,omitempty"`
+	Steps []Step `yaml:"steps"`
+}
+
+// Step is one entry in a scenario's `steps:` list. Exactly one of the
+// action fields (Exec, AssertExitCode, …) is set per step; the loader
+// validates that.
+type Step struct {
+	Name string `yaml:"name"`
+
+	// Exec runs a shell command inside the service. Recorded as one
+	// step in the run dir; subsequent assert_* steps refer to it via
+	// `target` (default: most recent exec). The command is executed
+	// with `bash -c` so users can pipe / redirect freely.
+	Exec string `yaml:"exec,omitempty"`
+
+	// User overrides the scenario default for this step (e.g. run a
+	// helper as root before dropping back to the test user).
+	User string `yaml:"user,omitempty"`
+
+	// Service overrides the scenario default for this step.
+	Service string `yaml:"service,omitempty"`
+
+	// Env adds environment variables for this exec step. Inherited by
+	// the container shell only; the harness never reads them.
+	Env map[string]string `yaml:"env,omitempty"`
+
+	// Stdin is fed to the command via docker exec -i.
+	Stdin string `yaml:"stdin,omitempty"`
+
+	// Timeout overrides the global per-step timeout for this step.
+	Timeout string `yaml:"timeout,omitempty"`
+
+	// Target picks an earlier step by name to assert against. When
+	// empty, assert_* steps run against the most recent exec step.
+	Target string `yaml:"target,omitempty"`
+
+	// Assertion fields. A step has exactly one of these set when it
+	// isn't an exec step.
+	AssertExitCode         *int   `yaml:"assert_exit_code,omitempty"`
+	AssertStdoutContains   string `yaml:"assert_stdout_contains,omitempty"`
+	AssertStdoutEquals     string `yaml:"assert_stdout_equals,omitempty"`
+	AssertStderrContains   string `yaml:"assert_stderr_contains,omitempty"`
+	AssertStdoutNotContain string `yaml:"assert_stdout_not_contains,omitempty"`
+
+	// WaitForFile polls inside the service until the named file exists
+	// or the per-step timeout elapses. Useful for the agent socket.
+	WaitForFile string `yaml:"wait_for_file,omitempty"`
+}
+
+// LoadScenario reads and validates a scenario file. It does not run it.
+func LoadScenario(path string) (*Scenario, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var s Scenario
+	if err := yaml.Unmarshal(b, &s); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if s.Name == "" {
+		return nil, fmt.Errorf("%s: scenario name is required", path)
+	}
+	if s.Service == "" {
+		return nil, fmt.Errorf("%s: scenario service is required", path)
+	}
+	if s.User == "" {
+		s.User = "jitenv"
+	}
+	if len(s.Steps) == 0 {
+		return nil, fmt.Errorf("%s: scenario has no steps", path)
+	}
+	for i, st := range s.Steps {
+		if st.Name == "" {
+			return nil, fmt.Errorf("%s: step[%d] is missing a name", path, i)
+		}
+		if err := validateStep(&st); err != nil {
+			return nil, fmt.Errorf("%s: step[%d] (%s): %w", path, i, st.Name, err)
+		}
+	}
+	return &s, nil
+}
+
+// validateStep enforces the "exactly one action" rule. Adding a new
+// step type means adding a clause here and a handler in run.go.
+func validateStep(st *Step) error {
+	actions := 0
+	if st.Exec != "" {
+		actions++
+	}
+	if st.WaitForFile != "" {
+		actions++
+	}
+	if st.AssertExitCode != nil {
+		actions++
+	}
+	if st.AssertStdoutContains != "" {
+		actions++
+	}
+	if st.AssertStdoutEquals != "" {
+		actions++
+	}
+	if st.AssertStderrContains != "" {
+		actions++
+	}
+	if st.AssertStdoutNotContain != "" {
+		actions++
+	}
+	if actions == 0 {
+		return fmt.Errorf("step has no action (set one of: exec, wait_for_file, assert_*)")
+	}
+	if actions > 1 {
+		return fmt.Errorf("step has %d actions; only one per step is allowed", actions)
+	}
+	return nil
+}

--- a/e2e/scenarios/localstack-fetch.yaml
+++ b/e2e/scenarios/localstack-fetch.yaml
@@ -1,0 +1,57 @@
+name: localstack-fetch
+description: |
+  Same shape as unlock-and-run-local but the env var is fetched from
+  AWS Secrets Manager via LocalStack. Exercises the aws source's
+  endpoint_override + static-credentials path; localstack-init seeds
+  the secret with FOO/BAR JSON, and the mapping picks key=FOO.
+
+service: debian
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed \
+        -out "$JITENV_CONFIG" \
+        -variant localstack \
+        -script /home/jitenv/scripts/show.sh \
+        -sm-endpoint http://localstack:4566
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/show.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      EOF
+      chmod +x /home/jitenv/scripts/show.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  - name: run-via-jitenv
+    exec: jitenv run /home/jitenv/scripts/show.sh
+    timeout: 30s
+  - name: assert-aws-foo
+    assert_stdout_contains: "FOO=value-from-aws-foo"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/scenarios/unlock-and-run-local.yaml
+++ b/e2e/scenarios/unlock-and-run-local.yaml
@@ -1,0 +1,85 @@
+name: unlock-and-run-local
+description: |
+  Seed an encrypted config with a local-bag source, unlock the agent,
+  and verify `jitenv run` injects the bag's keys (FOO, BAR) into the
+  child process while leaving the parent shell's env clean.
+
+service: debian
+user: jitenv
+
+steps:
+  # Per-scenario reset. Without this, a prior run leaves an agent
+  # running and unlock fails with "already running". Each scenario
+  # is responsible for its own cleanup; the harness does not.
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed -out "$JITENV_CONFIG" -variant local -script /home/jitenv/scripts/show.sh
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: validate-config
+    exec: jitenv config validate
+  - name: assert-validate-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/show.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      EOF
+      chmod +x /home/jitenv/scripts/show.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  - name: agent-status
+    exec: jitenv status
+  - name: assert-status-ok
+    assert_exit_code: 0
+
+  - name: is-mapped-target
+    exec: jitenv is-mapped /home/jitenv/scripts/show.sh
+  - name: assert-mapped
+    assert_exit_code: 0
+
+  # Run the script through `jitenv run` and confirm the local bag's
+  # values land in the child process. Parent shell ($FOO etc.) was
+  # never set, so this is the only place these values exist.
+  - name: run-via-jitenv
+    exec: jitenv run /home/jitenv/scripts/show.sh
+  - name: assert-run-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+  - name: assert-run-bar
+    assert_stdout_contains: "BAR=value-from-local-bar"
+
+  # Bare execution (no jitenv run) should NOT see the bag values —
+  # the local source only injects via the agent path.
+  - name: run-bare
+    exec: /home/jitenv/scripts/show.sh
+  - name: assert-bare-foo-empty
+    assert_stdout_contains: "FOO="
+  - name: assert-bare-no-leak
+    target: run-bare
+    assert_stdout_not_contains: "value-from-local-foo"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/seed/localstack-init/01-secrets.sh
+++ b/e2e/seed/localstack-init/01-secrets.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Seed AWS Secrets Manager with a fixture secret used by the
+# localstack scenarios. The awscli is preinstalled in the LocalStack
+# image, and `awslocal` wraps it with the right endpoint.
+#
+# We create one secret with a JSON body so scenarios can exercise both
+# the "fetch one key" path (ref.Key="FOO") and the "expand all keys"
+# path (empty Name + empty Key) without re-seeding.
+set -euo pipefail
+
+SECRET_ARN="arn:aws:secretsmanager:us-east-1:000000000000:secret:jitenv/demo"
+
+echo "[seed] creating jitenv/demo secret"
+awslocal secretsmanager create-secret \
+    --name jitenv/demo \
+    --secret-string '{"FOO":"value-from-aws-foo","BAR":"value-from-aws-bar"}' \
+    >/dev/null 2>&1 || awslocal secretsmanager put-secret-value \
+        --secret-id jitenv/demo \
+        --secret-string '{"FOO":"value-from-aws-foo","BAR":"value-from-aws-bar"}' \
+        >/dev/null
+
+# Re-emit the canonical ARN so the harness can grep for it in logs
+# when something goes wrong.
+echo "[seed] secret_arn=$SECRET_ARN"

--- a/e2e/seed/seed.go
+++ b/e2e/seed/seed.go
@@ -1,0 +1,162 @@
+// Command seed generates encrypted jitenv config.toml fixtures for the
+// e2e harness. It is intended to run inside the test container as the
+// non-root user, so the resulting file lives at the path the agent
+// will later resolve via $JITENV_CONFIG.
+//
+// We can't shell out to `jitenv config init` here: the CLI prompts for
+// a passphrase via /dev/tty, which doesn't work non-interactively. So
+// we drive the same internal APIs the TUI uses (config.InitNew +
+// crypto.EncryptField) and write the file directly.
+//
+// Fixture variants are selected with -variant:
+//
+//   - local        a local-bag-only fixture: sources.vault (local) +
+//     secrets.demo containing FOO/BAR; mapping on
+//     /home/jitenv/scripts/show.sh expands the bag.
+//   - localstack   an aws-source fixture pointing at LocalStack with
+//     static dummy creds; mapping on .../show.sh fetches
+//     one key from the seeded SM secret.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+func main() {
+	var (
+		out        = flag.String("out", "", "output path for config.toml (required)")
+		passphrase = flag.String("passphrase", "e2e-test-pass", "passphrase for the encrypted config")
+		variant    = flag.String("variant", "local", "fixture variant: local | localstack")
+		scriptPath = flag.String("script", "/home/jitenv/scripts/show.sh", "absolute path used in the mapping")
+		smARN      = flag.String("sm-arn", "arn:aws:secretsmanager:us-east-1:000000000000:secret:jitenv/demo", "SM secret ARN (localstack variant)")
+		smEndpoint = flag.String("sm-endpoint", "http://localstack:4566", "SM endpoint URL (localstack variant)")
+	)
+	flag.Parse()
+
+	if *out == "" {
+		fmt.Fprintln(os.Stderr, "seed: -out is required")
+		os.Exit(2)
+	}
+	if err := run(*out, []byte(*passphrase), *variant, *scriptPath, *smARN, *smEndpoint); err != nil {
+		fmt.Fprintf(os.Stderr, "seed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "wrote %s (variant=%s)\n", *out, *variant)
+}
+
+func run(out string, pw []byte, variant, scriptPath, smARN, smEndpoint string) error {
+	if err := os.MkdirAll(dirOf(out), 0700); err != nil {
+		return fmt.Errorf("mkdir parent: %w", err)
+	}
+	if err := config.InitNew(out, pw); err != nil {
+		return fmt.Errorf("init config: %w", err)
+	}
+	cfg, err := config.Load(out)
+	if err != nil {
+		return fmt.Errorf("reload config: %w", err)
+	}
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		return fmt.Errorf("derive key: %w", err)
+	}
+	defer zero(key)
+
+	switch variant {
+	case "local":
+		if err := applyLocal(cfg, key, scriptPath); err != nil {
+			return err
+		}
+	case "localstack":
+		if err := applyLocalstack(cfg, key, scriptPath, smARN, smEndpoint); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown variant %q (want: local | localstack)", variant)
+	}
+
+	return config.AtomicSave(out, cfg)
+}
+
+// applyLocal mirrors what the TUI emits for a local-bag-only setup:
+// one source of type "local", one secrets table, one mapping that
+// expands the bag.
+func applyLocal(cfg *config.Config, key []byte, scriptPath string) error {
+	foo, err := crypto.EncryptField(key, "value-from-local-foo")
+	if err != nil {
+		return err
+	}
+	bar, err := crypto.EncryptField(key, "value-from-local-bar")
+	if err != nil {
+		return err
+	}
+	cfg.Sources = map[string]config.SourceConfig{
+		"vault": {Type: "local"},
+	}
+	cfg.Secrets = map[string]map[string]string{
+		"demo": {"FOO": foo, "BAR": bar},
+	}
+	cfg.Mappings = []config.Mapping{
+		{
+			Path: scriptPath,
+			Vars: []config.VarRef{
+				// Empty Name + empty Key = expand all keys in the bag.
+				{Source: "vault", Ref: "demo"},
+			},
+		},
+	}
+	return nil
+}
+
+// applyLocalstack wires an aws Secrets Manager source at the LocalStack
+// endpoint. Static creds are used because LocalStack accepts any string.
+// We only fetch a single JSON key (FOO) to also exercise that path.
+func applyLocalstack(cfg *config.Config, key []byte, scriptPath, smARN, smEndpoint string) error {
+	akid, err := crypto.EncryptField(key, "test")
+	if err != nil {
+		return err
+	}
+	sak, err := crypto.EncryptField(key, "test")
+	if err != nil {
+		return err
+	}
+	cfg.Sources = map[string]config.SourceConfig{
+		"awssm": {
+			Type: "aws",
+			Params: map[string]any{
+				"region":            "us-east-1",
+				"access_key_id":     akid,
+				"secret_access_key": sak,
+				"endpoint_override": smEndpoint,
+			},
+		},
+	}
+	cfg.Mappings = []config.Mapping{
+		{
+			Path: scriptPath,
+			Vars: []config.VarRef{
+				{Name: "FOO", Source: "awssm", Ref: smARN, Key: "FOO"},
+			},
+		},
+	}
+	return nil
+}
+
+func dirOf(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			return p[:i]
+		}
+	}
+	return "."
+}
+
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}


### PR DESCRIPTION
Phase 1 of #41. Lands the foundation; the remaining scope (Vault, mock GitHub, CI workflow, Fedora/Arch, the other 3 scenarios) is deferred and noted at the bottom.

## Summary

Stand up a reproducible E2E testing stack that exercises jitenv against real source backends across multiple Linux distros, plus an agent-friendly scenario harness that produces machine-readable artefacts on failure.

## What's in it

### Stack lifecycle (`e2e/docker-compose.yml`)

Three services:
- `debian` (bookworm-slim, glibc) and `alpine` (3.20, musl) — both build jitenv inside the container, run as non-root uid 1000, use a tmpfs `/tmp` so each `make e2e-up` starts from a clean runtime dir. Agent falls back to `/tmp/jitenv-1000/` (no privileged mounts needed).
- `localstack:3.8` — Secrets Manager only, seeded by `e2e/seed/localstack-init/01-secrets.sh`. Healthcheck-gated `depends_on` ensures ordering.

### Capture surface (`e2e/harness/`, separate Go module)

- `cmd/runner/main.go` + `internal/runner/{scenario.go,run.go}`. Depends only on `gopkg.in/yaml.v3` — keeps the main jitenv binary's dep graph untouched.
- Scenario YAML format: flat `steps:` list, one action per step (`exec`, `wait_for_file`, `assert_exit_code`, `assert_stdout_{contains,equals,not_contains}`, `assert_stderr_contains`); modifiers `target`, `service`, `user`, `env`, `stdin`, `timeout`.
- Rigid run-dir layout: `meta.json`, `summary.json`, `steps/NNN-name/{cmd,stdout,stderr,exit}`, `teardown/{agent.log,config.toml,compose-ps.txt,ps-aux.txt}`.
- Failures don't short-circuit — every step still runs so the artefact dir captures as much state as possible. Failed-step error fields reference target step + stream + actual content.

### Test-only helpers (in main module so they can use `internal/config` + `internal/crypto`)

- `e2e/seed/seed.go` (`jitenv-e2e-seed`) — generates encrypted `config.toml` for two variants: `local` (bag) and `localstack` (aws source).
- `e2e/cmd/unlock/main.go` (`jitenv-e2e-unlock`) — non-interactive unlock. Same code path as `jitenv unlock` minus the `/dev/tty` passphrase prompt, then `Setsid`-double-forks `jitenv __agent` with the key on fd 3. Avoids the `script -qefc` PTY rabbit hole; production unlock untouched.

### Two scenarios (both passing)

- `e2e/scenarios/unlock-and-run-local.yaml` — full flow asserting local-bag values land in the child but NOT in the parent shell.
- `e2e/scenarios/localstack-fetch.yaml` — same flow with the value resolving through AWS SM via LocalStack's `endpoint_override`.

### Makefile targets

`e2e-build`, `e2e-up` (waits for healthchecks), `e2e-down`, `e2e-down-hard`, `e2e-runner-build`, `e2e-run SCENARIO=...`, `e2e-shell DISTRO=...`.

### Documentation

`e2e/README.md` covers run-dir layout, scenario step grammar, how to add a new distro or source backend, and the rationale for the unlock-helper detour.

## Verification

- `docker compose -f e2e/docker-compose.yml config` parses cleanly.
- `docker compose build` — both images built (multi-stage, CGO off, tiny runtime layers).
- `make e2e-up` — full stack reaches healthy.
- Both scenarios pass on `debian`. `unlock-and-run-local.yaml` also passes on `alpine` (verified by patching `service:`).
- A deliberate-failure probe: `summary.json` errors include target step, stream, and actual output — diagnosable from artefacts alone.
- `go test ./...` (main module) green.
- `e2e/harness` module builds.

## Decisions worth flagging

- **Harness as a separate Go module** — keeps `gopkg.in/yaml.v3` out of the main binary's dep graph.
- **No PTY wrapper for `jitenv unlock`** — the helper duplicates ~30 lines of the `__agent` exec path; production code stays untouched.
- **Each scenario owns its reset** — first step is a `reset-state` that locks any prior agent and clears `/tmp/jitenv-1000` + the config file. The harness deliberately doesn't run cross-cutting setup/teardown.

## Out of scope (deferred follow-ups)

- Vault, mock GitHub, OIDC services.
- CI workflow integration (`.github/workflows/e2e.yml`).
- Fedora/Arch distros.
- The remaining 3 scenarios from #41: locked-agent UX (exit code 2), glob mapping + bag expansion, mid-session `pingAgentReload`.
- zsh hook scenarios (zsh is installed in both images, no scenario exercises it yet).

## Test plan
- [x] `docker compose -f e2e/docker-compose.yml config` parses.
- [x] `docker compose build` succeeds for both distros.
- [x] `make e2e-up` brings the stack up healthy.
- [x] Both scenarios pass via the harness.
- [x] `go test ./...` (main module) still green.
- [ ] Reviewer: `make e2e-up && make e2e-run SCENARIO=unlock-and-run-local.yaml` then inspect `e2e/runs/<latest>/` and confirm the artefact layout is what you'd want when triaging a failure.