### PR TITLE
feat(tui): switch cwd_glob commands editor to a list page

### DIFF
--- a/internal/tui/commands_list_screen.go
+++ b/internal/tui/commands_list_screen.go
@@ -1,0 +1,249 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// commandsListScreen edits the per-mapping cwd_glob commands list.
+//
+// Storage: cfg.Mappings[idx].Commands is a []string of bare command
+// names. UX mirrors arnListScreen: a "< Add command >" sentinel at the
+// top, existing commands underneath; Enter on an existing row opens an
+// Edit/Delete popup.
+type commandsListScreen struct {
+	root   *rootModel
+	idx    int
+	cursor int
+}
+
+func newCommandsListScreen(r *rootModel, idx int) screen {
+	s := &commandsListScreen{root: r, idx: idx}
+	s.refresh()
+	return s
+}
+
+func (s *commandsListScreen) refresh() {
+	if s.cursor < 0 {
+		s.cursor = 0
+	}
+	mp := s.mp()
+	if mp == nil {
+		s.cursor = 0
+		return
+	}
+	if max := len(mp.Commands); s.cursor > max {
+		s.cursor = max
+	}
+}
+
+func (s *commandsListScreen) mp() *config.Mapping {
+	if s.idx < 0 || s.idx >= len(s.root.cfg.Mappings) {
+		return nil
+	}
+	return &s.root.cfg.Mappings[s.idx]
+}
+
+func (s *commandsListScreen) Title() string {
+	mp := s.mp()
+	if mp == nil || mp.CwdGlob == "" {
+		return "commands"
+	}
+	return "commands: " + mp.CwdGlob
+}
+func (s *commandsListScreen) Status() string { return renderHelpStatus() }
+func (s *commandsListScreen) Init() tea.Cmd  { return nil }
+
+func (s *commandsListScreen) HelpKeys() []helpEntry { return commonNavKeys() }
+func (s *commandsListScreen) HelpText() string {
+	return `Bare command names to wrap inside this cwd. The shell hook creates
+a per-shell symlink for each one when you cd into a matching
+directory, so running e.g. "npm" from the cwd routes through
+"jitenv run" with this mapping's env vars in scope.
+
+Pick "< Add command >" to append a new entry; selecting an existing
+row opens Edit / Delete. Empty names are rejected and duplicates
+are flagged. The list must be non-empty for a cwd_glob mapping —
+saving an empty list will fail validation.`
+}
+
+func (s *commandsListScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	if _, ok := msg.(commandsChangedMsg); ok {
+		s.refresh()
+		return s, nil
+	}
+	mp := s.mp()
+	if mp == nil {
+		return s, nil
+	}
+	if k, ok := msg.(tea.KeyMsg); ok {
+		total := len(mp.Commands) + 1 // sentinel + entries
+		switch k.String() {
+		case "up", "k":
+			if s.cursor > 0 {
+				s.cursor--
+			}
+		case "down", "j":
+			if s.cursor < total-1 {
+				s.cursor++
+			}
+		case "enter":
+			if s.cursor == 0 {
+				return s, s.openAddInput()
+			}
+			return s, s.openEntryMenu()
+		case "esc":
+			return s, emit(popMsg{})
+		}
+	}
+	return s, nil
+}
+
+func (s *commandsListScreen) openAddInput() tea.Cmd {
+	commit := func(val string) tea.Cmd {
+		v := strings.TrimSpace(val)
+		if v == "" {
+			return emit(errorMsg("command name required"))
+		}
+		mp := s.mp()
+		if mp == nil {
+			return emit(popMsg{})
+		}
+		if hasCommand(mp.Commands, v) {
+			return emit(errorMsg(fmt.Sprintf("%q is already in the list", v)))
+		}
+		mp.Commands = append(mp.Commands, v)
+		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}),
+			emit(commandsChangedMsg{}), emit(statusMsg("command added")))
+	}
+	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
+		Title:       "add command",
+		Prompt:      "Bare command name to wrap inside this cwd (e.g. npm).",
+		Placeholder: "npm",
+		SaveLabel:   "Add", CancelLabel: "Back",
+	}, commit)})
+}
+
+func (s *commandsListScreen) openEntryMenu() tea.Cmd {
+	mp := s.mp()
+	if mp == nil {
+		return nil
+	}
+	idx := s.cursor - 1
+	if idx < 0 || idx >= len(mp.Commands) {
+		return nil
+	}
+	current := mp.Commands[idx]
+	cb := func(choice string) tea.Cmd {
+		switch choice {
+		case "Edit":
+			editCommit := func(val string) tea.Cmd {
+				v := strings.TrimSpace(val)
+				if v == "" {
+					return emit(errorMsg("command name required"))
+				}
+				m := s.mp()
+				if m == nil {
+					return emit(popMsg{})
+				}
+				if idx >= len(m.Commands) {
+					return emit(popMsg{})
+				}
+				if v == m.Commands[idx] {
+					return tea.Sequence(emit(popMsg{}), emit(popMsg{}))
+				}
+				if hasCommand(m.Commands, v) {
+					return emit(errorMsg(fmt.Sprintf("%q is already in the list", v)))
+				}
+				m.Commands[idx] = v
+				return tea.Sequence(emit(popMsg{}), emit(popMsg{}),
+					emit(dirtyMsg{}), emit(commandsChangedMsg{}),
+					emit(statusMsg("command updated")))
+			}
+			return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
+				Title: "edit command", Prompt: "Update the command name.",
+				Initial:   current,
+				SaveLabel: "Apply", CancelLabel: "Back",
+			}, editCommit)})
+		case "Delete":
+			confirmCb := func(c string) tea.Cmd {
+				if c != "Yes" {
+					return emit(popMsg{})
+				}
+				m := s.mp()
+				if m == nil {
+					return emit(popMsg{})
+				}
+				if idx < len(m.Commands) {
+					m.Commands = append(m.Commands[:idx], m.Commands[idx+1:]...)
+				}
+				return tea.Sequence(emit(popMsg{}), emit(popMsg{}),
+					emit(dirtyMsg{}), emit(commandsChangedMsg{}),
+					emit(statusMsg("command removed")))
+			}
+			return emit(pushMsg{s: newConfirmScreen(s.root,
+				fmt.Sprintf("Remove %q?", current), confirmCb,
+				"Yes", "No")})
+		}
+		return emit(popMsg{})
+	}
+	return emit(pushMsg{s: newPopupMenuScreen(s.root,
+		"Command: "+current, cb,
+		"Edit", "Delete", "Back",
+	)})
+}
+
+func (s *commandsListScreen) View() string {
+	var b strings.Builder
+	mp := s.mp()
+	if mp == nil {
+		return errorStyle.Render("(mapping vanished)")
+	}
+	heading := "Commands"
+	if mp.CwdGlob != "" {
+		heading = "Commands (cwd_glob: " + mp.CwdGlob + ")"
+	}
+	b.WriteString(labelStyle.Render(heading) + "\n\n")
+
+	sentinel := "< Add command >"
+	if s.cursor == 0 {
+		b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(sentinel) + "\n")
+	} else {
+		b.WriteString("   " + listItemStyle.Render(sentinel) + "\n")
+	}
+
+	if len(mp.Commands) == 0 {
+		b.WriteString("\n" + dimText("No commands yet. Pick the row above to add one.") + "\n")
+		b.WriteString(dimText("Each command is wrapped by a per-shell symlink while you're") + "\n")
+		b.WriteString(dimText("inside the matching cwd; running it routes through jitenv run.") + "\n")
+		return b.String()
+	}
+
+	for i, c := range mp.Commands {
+		row := truncate(c, 60)
+		if i+1 == s.cursor {
+			b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(row) + "\n")
+		} else {
+			b.WriteString("   " + listItemStyle.Render(row) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// hasCommand reports whether name is already in cmds (exact match).
+func hasCommand(cmds []string, name string) bool {
+	for _, c := range cmds {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ----- messages ----------------------------------------------------
+
+type commandsChangedMsg struct{}

--- a/internal/tui/commands_list_screen_test.go
+++ b/internal/tui/commands_list_screen_test.go
@@ -1,0 +1,517 @@
+package tui
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+)
+
+// commandsFixture builds a minimal in-memory config with one cwd_glob
+// mapping the screen tests can mutate directly.
+func commandsFixture() *config.Config {
+	return &config.Config{
+		Sources: map[string]config.SourceConfig{
+			"local": {Type: "local"},
+		},
+		Mappings: []config.Mapping{
+			{
+				CwdGlob:  "~/work/acme",
+				Commands: []string{"npm"},
+				Vars: []config.VarRef{
+					{Source: "local", Ref: "stripe"},
+				},
+			},
+		},
+	}
+}
+
+// drainCmd recursively unwraps Bubble Tea command trees (BatchMsg /
+// internal sequenceMsg) and returns the terminal messages they produce.
+// The caller can then feed those terminal messages back through a
+// screen's Update if it wants to verify state propagation. We keep this
+// local so the test doesn't depend on internal/private tea types.
+func drainCmd(cmd tea.Cmd) []tea.Msg {
+	var out []tea.Msg
+	var walk func(c tea.Cmd, depth int)
+	walk = func(c tea.Cmd, depth int) {
+		if c == nil || depth > 32 {
+			return
+		}
+		msg := c()
+		if msg == nil {
+			return
+		}
+		if bm, ok := msg.(tea.BatchMsg); ok {
+			for _, sub := range bm {
+				walk(sub, depth+1)
+			}
+			return
+		}
+		if subs := unwrapSeq(msg); subs != nil {
+			for _, sub := range subs {
+				walk(sub, depth+1)
+			}
+			return
+		}
+		out = append(out, msg)
+	}
+	walk(cmd, 0)
+	return out
+}
+
+// unwrapSeq mirrors unwrapSequence in nav_conventions_test.go but lives
+// here so this test file is self-contained when run alone.
+func unwrapSeq(msg tea.Msg) []tea.Cmd {
+	v := reflect.ValueOf(msg)
+	if v.Kind() != reflect.Slice {
+		return nil
+	}
+	if v.Type().Elem() != reflect.TypeOf((*tea.Cmd)(nil)).Elem() {
+		return nil
+	}
+	out := make([]tea.Cmd, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		out[i], _ = v.Index(i).Interface().(tea.Cmd)
+	}
+	return out
+}
+
+// findInputScreen pulls the most recently pushed inputScreen out of a
+// drained command stream so tests can drive its commit callback.
+func findInputScreen(msgs []tea.Msg) *inputScreen {
+	for _, m := range msgs {
+		if pm, ok := m.(pushMsg); ok {
+			if is, ok := pm.s.(*inputScreen); ok {
+				return is
+			}
+		}
+	}
+	return nil
+}
+
+// findPopupMenu pulls the most recently pushed popupMenuScreen out of a
+// drained command stream.
+func findPopupMenu(msgs []tea.Msg) *popupMenuScreen {
+	for _, m := range msgs {
+		if pm, ok := m.(pushMsg); ok {
+			if ms, ok := pm.s.(*popupMenuScreen); ok {
+				return ms
+			}
+		}
+	}
+	return nil
+}
+
+// findConfirm pulls the most recently pushed confirmScreen out of a
+// drained command stream.
+func findConfirm(msgs []tea.Msg) *confirmScreen {
+	for _, m := range msgs {
+		if pm, ok := m.(pushMsg); ok {
+			if cs, ok := pm.s.(*confirmScreen); ok {
+				return cs
+			}
+		}
+	}
+	return nil
+}
+
+func TestCommandsList_Add(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	// Sentinel row is selected by default.
+	if scr.cursor != 0 {
+		t.Fatalf("expected cursor 0, got %d", scr.cursor)
+	}
+
+	// Enter on the sentinel pushes an inputScreen for "add command".
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	is := findInputScreen(drainCmd(cmd))
+	if is == nil {
+		t.Fatal("Enter on sentinel should push an inputScreen")
+	}
+	if is.title != "add command" {
+		t.Errorf("input title = %q, want add command", is.title)
+	}
+
+	// Drive its commit with "yarn".
+	is.input.SetValue("yarn")
+	commitCmd := is.commit()
+	msgs := drainCmd(commitCmd)
+
+	mp := &r.cfg.Mappings[0]
+	if got := mp.Commands; !reflect.DeepEqual(got, []string{"npm", "yarn"}) {
+		t.Fatalf("Commands = %v, want [npm yarn]", got)
+	}
+
+	// dirtyMsg + commandsChangedMsg should fire.
+	if !hasMsgType(msgs, dirtyMsg{}) {
+		t.Errorf("expected dirtyMsg in stream: %#v", msgs)
+	}
+	if !hasMsgType(msgs, commandsChangedMsg{}) {
+		t.Errorf("expected commandsChangedMsg in stream: %#v", msgs)
+	}
+}
+
+func TestCommandsList_Add_RejectsEmpty(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	is := findInputScreen(drainCmd(cmd))
+	if is == nil {
+		t.Fatal("expected input screen")
+	}
+	// The inputScreen is configured AllowBlank=false (default), so an
+	// empty/whitespace value is short-circuited there with the standard
+	// "value required" error and our commit callback is never invoked.
+	is.input.SetValue("   ")
+	msgs := drainCmd(is.commit())
+
+	if !hasErrorMsg(msgs, "value required") {
+		t.Fatalf("expected value-required error, got: %#v", msgs)
+	}
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"npm"}) {
+		t.Errorf("Commands mutated on empty input: %v", got)
+	}
+}
+
+// TestCommandsList_AddCommitDirectRejectsEmpty exercises the screen's
+// own commit-callback empty check: the inputScreen normally short-
+// circuits empty input, but the callback also defends against it so
+// the contract holds even if AllowBlank is later flipped on.
+func TestCommandsList_AddCommitDirectRejectsEmpty(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	cmd := scr.openAddInput()
+	is := findInputScreen(drainCmd(cmd))
+	if is == nil {
+		t.Fatal("expected input screen")
+	}
+	// Drive the screen's onCommit directly with whitespace.
+	msgs := drainCmd(is.onCommit("   "))
+	if !hasErrorMsg(msgs, "command name required") {
+		t.Fatalf("expected command-name-required error, got: %#v", msgs)
+	}
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"npm"}) {
+		t.Errorf("Commands mutated on empty commit: %v", got)
+	}
+}
+
+func TestCommandsList_Add_RejectsDuplicate(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	is := findInputScreen(drainCmd(cmd))
+	if is == nil {
+		t.Fatal("expected input screen")
+	}
+	is.input.SetValue("npm")
+	msgs := drainCmd(is.commit())
+
+	if !hasErrorMsgPrefix(msgs, `"npm" is already`) {
+		t.Fatalf("expected duplicate error msg, got: %#v", msgs)
+	}
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"npm"}) {
+		t.Errorf("Commands mutated on duplicate: %v", got)
+	}
+}
+
+func TestCommandsList_Edit(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	// Move cursor onto the second entry (yarn).
+	scr.Update(tea.KeyMsg{Type: tea.KeyDown})
+	scr.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if scr.cursor != 2 {
+		t.Fatalf("cursor: %d, want 2", scr.cursor)
+	}
+
+	// Enter opens the popup menu.
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm := findPopupMenu(drainCmd(cmd))
+	if pm == nil {
+		t.Fatal("expected popup menu push")
+	}
+
+	// Choose "Edit" → it should push an inputScreen pre-filled with "yarn".
+	editMsgs := drainCmd(pm.onChoose("Edit"))
+	is := findInputScreen(editMsgs)
+	if is == nil {
+		t.Fatal("Edit choice should push inputScreen")
+	}
+	if is.input.Value() != "yarn" {
+		t.Errorf("inputScreen initial value = %q, want yarn", is.input.Value())
+	}
+
+	is.input.SetValue("pnpm")
+	msgs := drainCmd(is.commit())
+
+	mp := &r.cfg.Mappings[0]
+	if !reflect.DeepEqual(mp.Commands, []string{"npm", "pnpm"}) {
+		t.Fatalf("Commands = %v, want [npm pnpm]", mp.Commands)
+	}
+	if !hasMsgType(msgs, dirtyMsg{}) {
+		t.Errorf("expected dirtyMsg in edit stream: %#v", msgs)
+	}
+}
+
+func TestCommandsList_Edit_RejectsDuplicate(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+	scr.cursor = 2 // yarn
+
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm := findPopupMenu(drainCmd(cmd))
+	if pm == nil {
+		t.Fatal("expected popup menu")
+	}
+	is := findInputScreen(drainCmd(pm.onChoose("Edit")))
+	if is == nil {
+		t.Fatal("expected inputScreen for edit")
+	}
+	is.input.SetValue("npm") // collide with the other entry
+	msgs := drainCmd(is.commit())
+
+	if !hasErrorMsgPrefix(msgs, `"npm" is already`) {
+		t.Fatalf("expected duplicate error: %#v", msgs)
+	}
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"npm", "yarn"}) {
+		t.Errorf("Commands mutated on dup edit: %v", got)
+	}
+}
+
+func TestCommandsList_Delete(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+	scr.cursor = 1 // npm
+
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm := findPopupMenu(drainCmd(cmd))
+	if pm == nil {
+		t.Fatal("expected popup menu")
+	}
+	cs := findConfirm(drainCmd(pm.onChoose("Delete")))
+	if cs == nil {
+		t.Fatal("Delete should push a confirmScreen")
+	}
+
+	msgs := drainCmd(cs.onChoose("Yes"))
+
+	mp := &r.cfg.Mappings[0]
+	if !reflect.DeepEqual(mp.Commands, []string{"yarn"}) {
+		t.Fatalf("Commands = %v, want [yarn]", mp.Commands)
+	}
+	if !hasMsgType(msgs, dirtyMsg{}) {
+		t.Errorf("expected dirtyMsg in delete stream: %#v", msgs)
+	}
+}
+
+func TestCommandsList_Delete_NoConfirmKeepsList(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+	scr.cursor = 1
+
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm := findPopupMenu(drainCmd(cmd))
+	cs := findConfirm(drainCmd(pm.onChoose("Delete")))
+	if cs == nil {
+		t.Fatal("expected confirm")
+	}
+	drainCmd(cs.onChoose("No"))
+
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"npm", "yarn"}) {
+		t.Errorf("Commands mutated after No: %v", got)
+	}
+}
+
+// TestCommandsList_TomlRoundTrip drives the list editor end-to-end and
+// then runs the same encrypt+save+reload pipeline the TUI uses to make
+// sure the mutated []string round-trips through encrypted TOML.
+func TestCommandsList_TomlRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+	if err := config.DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	c.Sources = map[string]config.SourceConfig{"local": {Type: "local"}}
+	c.Secrets = map[string]map[string]string{"stripe": {"PK": "pk_live"}}
+	c.Mappings = []config.Mapping{
+		{
+			CwdGlob:  "~/work/acme",
+			Commands: []string{"npm"},
+			Vars:     []config.VarRef{{Source: "local", Ref: "stripe"}},
+		},
+	}
+
+	r := makeRoot(c)
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	// Add: yarn.
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	is := findInputScreen(drainCmd(cmd))
+	if is == nil {
+		t.Fatal("add: no input screen")
+	}
+	is.input.SetValue("yarn")
+	drainCmd(is.commit())
+
+	// Add: python3.
+	scr.cursor = 0
+	_, cmd = scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	is = findInputScreen(drainCmd(cmd))
+	is.input.SetValue("python3")
+	drainCmd(is.commit())
+
+	if got := c.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"npm", "yarn", "python3"}) {
+		t.Fatalf("after add: %v", got)
+	}
+
+	// Edit "yarn" → "pnpm".
+	scr.cursor = 2
+	_, cmd = scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm := findPopupMenu(drainCmd(cmd))
+	is = findInputScreen(drainCmd(pm.onChoose("Edit")))
+	is.input.SetValue("pnpm")
+	drainCmd(is.commit())
+
+	// Delete "npm".
+	scr.cursor = 1
+	_, cmd = scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm = findPopupMenu(drainCmd(cmd))
+	cs := findConfirm(drainCmd(pm.onChoose("Delete")))
+	drainCmd(cs.onChoose("Yes"))
+
+	if got := c.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"pnpm", "python3"}) {
+		t.Fatalf("after edit+delete: %v", got)
+	}
+
+	// Save + validate + reload, mirroring saveCmd.
+	out := cloneForSave(c)
+	if err := encryptForSave(out, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := out.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := config.AtomicSave(path, out); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	reloaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := config.DecryptInPlace(reloaded, key); err != nil {
+		t.Fatalf("decrypt reload: %v", err)
+	}
+	if got := reloaded.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"pnpm", "python3"}) {
+		t.Fatalf("reloaded commands = %v, want [pnpm python3]", got)
+	}
+	if reloaded.Mappings[0].CwdGlob != "~/work/acme" {
+		t.Errorf("CwdGlob round-trip broken: %q", reloaded.Mappings[0].CwdGlob)
+	}
+}
+
+// TestCommandsList_EmptyListStillRejectedByValidate guards the
+// acceptance criterion that an empty Commands list is still rejected
+// at validate time (the new screen lets users transit through empty
+// without prompting, matching the old input's AllowBlank behaviour).
+func TestCommandsList_EmptyListStillRejectedByValidate(t *testing.T) {
+	c := commandsFixture()
+	c.Version = config.Version
+	r := makeRoot(c)
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+	scr.cursor = 1 // the only entry
+
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	pm := findPopupMenu(drainCmd(cmd))
+	if pm == nil {
+		t.Fatal("expected popup menu")
+	}
+	cs := findConfirm(drainCmd(pm.onChoose("Delete")))
+	drainCmd(cs.onChoose("Yes"))
+
+	if got := c.Mappings[0].Commands; len(got) != 0 {
+		t.Fatalf("expected empty Commands, got %v", got)
+	}
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("Validate should reject cwd_glob mapping with empty commands")
+	}
+	if !strings.Contains(err.Error(), "non-empty commands") {
+		t.Errorf("unexpected validate error: %v", err)
+	}
+}
+
+// TestCommandsList_FooterAdvertisesCtrlS keeps the new screen aligned
+// with the post-PR-43 footer convention.
+func TestCommandsList_FooterAdvertisesCtrlS(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0)
+	if !strings.Contains(scr.Status(), "Ctrl+S") {
+		t.Errorf("Status missing Ctrl+S hint: %q", scr.Status())
+	}
+	if !strings.Contains(scr.Status(), "Esc") {
+		t.Errorf("Status missing Esc hint: %q", scr.Status())
+	}
+	if !strings.Contains(scr.Status(), "?") {
+		t.Errorf("Status missing ? hint: %q", scr.Status())
+	}
+}
+
+// hasMsgType reports whether msgs contains an exact type match for want.
+func hasMsgType(msgs []tea.Msg, want tea.Msg) bool {
+	wantT := reflect.TypeOf(want)
+	for _, m := range msgs {
+		if reflect.TypeOf(m) == wantT {
+			return true
+		}
+	}
+	return false
+}
+
+func hasErrorMsg(msgs []tea.Msg, want string) bool {
+	for _, m := range msgs {
+		if em, ok := m.(errorMsg); ok && string(em) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasErrorMsgPrefix(msgs []tea.Msg, prefix string) bool {
+	for _, m := range msgs {
+		if em, ok := m.(errorMsg); ok && strings.HasPrefix(string(em), prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -304,7 +304,7 @@ func (s *mappingFormScreen) activate() tea.Cmd {
 		case 1:
 			return s.openTargetInput()
 		case 2:
-			return s.openCommandsInput()
+			return s.openCommandsList()
 		case 3:
 			return s.openVarTree()
 		}
@@ -401,38 +401,14 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 	}, commit)})
 }
 
-// openCommandsInput edits the cwd-only commands list. The list is
-// stored as a comma-separated string in the input field; we trim and
-// split on commit. Empty list is invalid (config.Validate rejects),
-// but we let the user pass through here so they can fix it later
-// without losing other edits.
-func (s *mappingFormScreen) openCommandsInput() tea.Cmd {
-	mp := s.mp()
-	if mp == nil {
+// openCommandsList drills into the per-mapping commands editor. Each
+// entry is added/edited/deleted on its own row; the underlying
+// []string storage is unchanged.
+func (s *mappingFormScreen) openCommandsList() tea.Cmd {
+	if s.mp() == nil {
 		return nil
 	}
-	commit := func(val string) tea.Cmd {
-		m := s.mp()
-		if m == nil {
-			return emit(popMsg{})
-		}
-		m.Commands = m.Commands[:0]
-		for _, c := range strings.Split(val, ",") {
-			c = strings.TrimSpace(c)
-			if c != "" {
-				m.Commands = append(m.Commands, c)
-			}
-		}
-		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
-	}
-	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
-		Title:       "scope to commands",
-		Prompt:      "Comma-separated bare command names to wrap inside this cwd (e.g. npm, yarn).",
-		Placeholder: "npm, yarn",
-		Initial:     strings.Join(mp.Commands, ", "),
-		AllowBlank:  true,
-		SaveLabel:   "Apply", CancelLabel: "Back",
-	}, commit)})
+	return emit(pushMsg{s: newCommandsListScreen(s.root, s.idx)})
 }
 
 func (s *mappingFormScreen) openVarTree() tea.Cmd {
@@ -467,11 +443,14 @@ func (s *mappingFormScreen) View() string {
 		{"target", target},
 	}
 	if kind == "cwd" {
-		cmds := strings.Join(mp.Commands, ", ")
-		if cmds == "" {
-			cmds = dimText("(none — required)")
+		var value string
+		if len(mp.Commands) == 0 {
+			value = dimText("(none — required)")
+		} else {
+			preview := truncate(strings.Join(mp.Commands, ", "), 48)
+			value = fmt.Sprintf("%s  %s", preview, dimText(fmt.Sprintf("(%d)", len(mp.Commands))))
 		}
-		rows = append(rows, struct{ label, value string }{"commands", cmds})
+		rows = append(rows, struct{ label, value string }{"commands", value})
 	}
 	rows = append(rows, struct{ label, value string }{
 		"variables", fmt.Sprintf("%d selected", localVarCount(s.root, mp)),


### PR DESCRIPTION
Closes #38.

## Summary

Replaces the comma-separated text input for cwd_glob \`commands\` with a dedicated list screen modeled directly on \`arnListScreen\`. Same shape as every other list-style page in the TUI: \`< Add command >\` sentinel at the top, Edit/Delete popup per row.

## Changes

- **New** \`internal/tui/commands_list_screen.go\` — \`commandsListScreen\` mirroring \`arnListScreen\`. Implements \`helpfulScreen\` with \`HelpKeys\`/\`HelpText\`. Reads/writes \`cfg.Mappings[idx].Commands\` directly via an \`mp()\` accessor.
- \`internal/tui/mappings_screen.go\` — replaced \`openCommandsInput\` with \`openCommandsList\`. The collapsed preview row now reads \`npm, yarn, python3  (3)\` (truncated to 48 chars + count tag).
- **New** \`internal/tui/commands_list_screen_test.go\` — 10 cases, all green:
  - Add: success, rejects empty (via \`inputScreen\`), rejects empty (commit-callback direct), rejects duplicate.
  - Edit: success, rejects duplicate.
  - Delete: success, \"No\" keeps list intact.
  - TOML round-trip: drives Add/Add/Edit/Delete via the screen, then \`cloneForSave\`+\`encryptForSave\`+\`Validate\`+\`AtomicSave\`+\`Load\`+\`DecryptInPlace\` and asserts \`Commands\` survives.
  - \`Config.Validate\` still rejects empty \`Commands\` after deleting the last entry (no regression).
  - Footer hint includes \`Ctrl+S\`, \`Esc\`, \`?\`.

## Screen flow

\`\`\`
Commands (cwd_glob: ~/work/acme)

▶ < Add command >
  npm
  yarn
  python3
\`\`\`

- \`< Add command >\` → \`inputScreen\` (\`Add\`/\`Back\`).
- Existing row → \`popupMenuScreen\` (\`Edit\` / \`Delete\` / \`Back\`).
- \`Edit\` → pre-filled \`inputScreen\` (\`Apply\`/\`Back\`).
- \`Delete\` → \`confirmScreen\` (\`Yes\`/\`No\`).

Per-entry validation: empty → \`command name required\`; duplicate → \`%q is already in the list\`.

## Out of scope

- \`$PATH\` existence check at edit time (could land later).
- Other mapping-form rows.

## Test plan

- [x] \`make fmt vet tidy\` clean.
- [x] \`go test ./...\` green (full suite, including the existing \`TestVarTree_*\`, \`TestCtrlS_GlobalSave\`, \`TestFooterHints_IncludeCtrlS\`).
- [x] \`make build\` clean.
- [x] Reviewer: \`jitenv config\` interactively — create a cwd_glob mapping, drill into commands, exercise Add/Edit/Delete, save, reopen, confirm round-trip.