### PR TITLE
feat: display version via -v, --help footer, and TUI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,9 +22,9 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X github.com/gv/jitenv/internal/cli.Version={{.Version}}
-      - -X github.com/gv/jitenv/internal/cli.Commit={{.ShortCommit}}
-      - -X github.com/gv/jitenv/internal/cli.Date={{.Date}}
+      - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
+      - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
 
 archives:
   - id: jitenv

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 
 LDFLAGS := -s -w \
-	-X github.com/gv/jitenv/internal/cli.Version=$(VERSION) \
-	-X github.com/gv/jitenv/internal/cli.Commit=$(COMMIT) \
-	-X github.com/gv/jitenv/internal/cli.Date=$(DATE)
+	-X github.com/gv/jitenv/internal/version.Version=$(VERSION) \
+	-X github.com/gv/jitenv/internal/version.Commit=$(COMMIT) \
+	-X github.com/gv/jitenv/internal/version.Date=$(DATE)
 
 build:
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN) ./cmd/jitenv

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,7 +13,9 @@ var configPath string
 const helpTemplate = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
-{{.Version}}`
+{{.Version}}
+
+`
 
 func newRoot() *cobra.Command {
 	root := &cobra.Command{

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,26 +2,33 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
-)
 
-// Build-time injected via -ldflags. Defaults intentionally identify a
-// non-release build so plain `go build` / `go install` are honest.
-var (
-	Version = "dev"
-	Commit  = ""
-	Date    = ""
+	"github.com/gv/jitenv/internal/version"
 )
 
 var configPath string
+
+// helpTemplate mirrors cobra's defaultHelpTemplate but appends the
+// version footer so `--help` advertises the build alongside the usage.
+const helpTemplate = `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}
+{{.Version}}`
 
 func newRoot() *cobra.Command {
 	root := &cobra.Command{
 		Use:           "jitenv",
 		Short:         "Just-in-time environment variable loader",
 		Long:          "jitenv loads env vars on demand from pluggable sources when configured files are executed.",
+		Version:       version.Short(),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	root.SetVersionTemplate("{{.Version}}\n")
+	root.SetHelpTemplate(helpTemplate)
+	// Cobra auto-registers --version (with the conventional -v
+	// shorthand) at Execute time once .Version is non-empty; nothing
+	// extra needed here.
 	root.PersistentFlags().StringVar(&configPath, "config", "", "path to config file (default: $JITENV_CONFIG or ~/.config/jitenv/config.toml)")
 
 	for _, sub := range subcommands() {

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -4,26 +4,21 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/gv/jitenv/internal/version"
 )
 
+// newVersionCmd is retained for users who learned the `jitenv version`
+// subcommand before the `--version` / `-v` flag landed; the flag is the
+// preferred surface going forward (printed by `jitenv -v` and surfaced
+// in `--help`).
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print jitenv version",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(formatVersion(Version, Commit, Date))
+			fmt.Println(version.String())
 		},
-	}
-}
-
-func formatVersion(version, commit, date string) string {
-	switch {
-	case commit != "" && date != "":
-		return fmt.Sprintf("jitenv %s (commit %s, built %s)", version, commit, date)
-	case commit != "":
-		return fmt.Sprintf("jitenv %s (commit %s)", version, commit)
-	default:
-		return fmt.Sprintf("jitenv %s", version)
 	}
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -49,7 +49,11 @@ func TestRoot_HelpIncludesVersion(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute --help: %v", err)
 	}
-	if !strings.Contains(out.String(), "jitenv 9.9.9") {
-		t.Errorf("--help output should embed version, got:\n%s", out.String())
+	got := out.String()
+	if !strings.Contains(got, "jitenv 9.9.9") {
+		t.Errorf("--help output should embed version, got:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "\n\n") {
+		t.Errorf("--help output should end with a blank line after the version, got tail %q", got[max(0, len(got)-8):])
 	}
 }

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,42 +1,55 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
 
-func TestFormatVersion(t *testing.T) {
-	cases := []struct {
-		name              string
-		ver, commit, date string
-		want              string
-	}{
-		{
-			name:   "all fields populated",
-			ver:    "0.1.0",
-			commit: "abc1234",
-			date:   "2026-05-06T12:34:56Z",
-			want:   "jitenv 0.1.0 (commit abc1234, built 2026-05-06T12:34:56Z)",
-		},
-		{
-			name:   "dev build with empty commit and date",
-			ver:    "dev",
-			commit: "",
-			date:   "",
-			want:   "jitenv dev",
-		},
-		{
-			name:   "dev build with commit but no date",
-			ver:    "dev",
-			commit: "abc1234",
-			date:   "",
-			want:   "jitenv dev (commit abc1234)",
-		},
+	"github.com/gv/jitenv/internal/version"
+)
+
+// TestRoot_VersionFlag exercises the cobra --version path end-to-end:
+// the flag should print exactly `jitenv <version>\n` and return without
+// error. Pinning the format here means a regression in
+// SetVersionTemplate / version.Short() trips the test rather than
+// silently shipping.
+func TestRoot_VersionFlag(t *testing.T) {
+	prev := version.Version
+	t.Cleanup(func() { version.Version = prev })
+	version.Version = "9.9.9"
+
+	root := newRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--version"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute --version: %v", err)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := formatVersion(tc.ver, tc.commit, tc.date)
-			if got != tc.want {
-				t.Errorf("formatVersion(%q, %q, %q) = %q, want %q",
-					tc.ver, tc.commit, tc.date, got, tc.want)
-			}
-		})
+	if got, want := strings.TrimRight(out.String(), "\n"), "jitenv 9.9.9"; got != want {
+		t.Errorf("--version output = %q, want %q", got, want)
+	}
+}
+
+// TestRoot_HelpIncludesVersion guards the help template change: every
+// `jitenv --help` invocation must surface the version somewhere so
+// users can confirm the build without leaving --help.
+func TestRoot_HelpIncludesVersion(t *testing.T) {
+	prev := version.Version
+	t.Cleanup(func() { version.Version = prev })
+	version.Version = "9.9.9"
+
+	root := newRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--help"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute --help: %v", err)
+	}
+	if !strings.Contains(out.String(), "jitenv 9.9.9") {
+		t.Errorf("--help output should embed version, got:\n%s", out.String())
 	}
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -54,7 +54,8 @@ func renderApp(w, h int, body, status string) string {
 
 var copyrightStyle = lipgloss.NewStyle().
 	Foreground(colorMuted).
-	Faint(true)
+	Faint(true).
+	Padding(0, 1)
 
 // footerSegments are the fixed segments of the global footer. The
 // version segment, when non-empty, is appended at render time so the
@@ -65,17 +66,21 @@ const footerSeparator = " | "
 
 // renderFooter draws the global one-line footer as a left-aligned,
 // pipe-separated string: `jitenv | © 2026 Gal Villaret | MIT |
-// <version>`. On terminals too narrow to fit the version segment, it
-// is dropped rather than wrapping — the version is always reachable
-// via `jitenv -v`.
+// <version>`. The leading column matches the status bar's 1-space
+// horizontal padding so the two lines align visually. On terminals
+// too narrow to fit the version segment, it is dropped rather than
+// wrapping — the version is always reachable via `jitenv -v`.
 func renderFooter(w int) string {
 	if w < 4 {
 		w = 4
 	}
+	// copyrightStyle's horizontal padding is inside Width(w), so the
+	// usable text area shrinks by 2 columns.
+	avail := w - 2
 	segments := footerSegments
 	if v := versionFooterText(); v != "" {
 		full := strings.Join(append(append([]string{}, segments...), v), footerSeparator)
-		if lipgloss.Width(full) <= w {
+		if lipgloss.Width(full) <= avail {
 			return copyrightStyle.Width(w).Align(lipgloss.Left).Render(full)
 		}
 	}

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -63,11 +63,11 @@ var footerSegments = []string{"jitenv", "© 2026 Gal Villaret", "MIT"}
 
 const footerSeparator = " | "
 
-// renderFooter draws the global one-line footer as a centered, pipe-
-// separated string: `jitenv | © 2026 Gal Villaret | MIT | <version>`.
-// On terminals too narrow to fit the version segment, it is dropped
-// rather than wrapping — the version is always reachable via `jitenv
-// -v`.
+// renderFooter draws the global one-line footer as a left-aligned,
+// pipe-separated string: `jitenv | © 2026 Gal Villaret | MIT |
+// <version>`. On terminals too narrow to fit the version segment, it
+// is dropped rather than wrapping — the version is always reachable
+// via `jitenv -v`.
 func renderFooter(w int) string {
 	if w < 4 {
 		w = 4
@@ -76,11 +76,11 @@ func renderFooter(w int) string {
 	if v := versionFooterText(); v != "" {
 		full := strings.Join(append(append([]string{}, segments...), v), footerSeparator)
 		if lipgloss.Width(full) <= w {
-			return copyrightStyle.Width(w).Align(lipgloss.Center).Render(full)
+			return copyrightStyle.Width(w).Align(lipgloss.Left).Render(full)
 		}
 	}
 	base := strings.Join(segments, footerSeparator)
-	return copyrightStyle.Width(w).Align(lipgloss.Center).Render(base)
+	return copyrightStyle.Width(w).Align(lipgloss.Left).Render(base)
 }
 
 // modalOverlay returns a small centered bordered popup of the given

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -52,46 +52,35 @@ func renderApp(w, h int, body, status string) string {
 	return panel + "\n" + statusLine + "\n" + footerLine
 }
 
-const copyrightText = "© 2026 Gal Villaret · jitenv — MIT"
-
 var copyrightStyle = lipgloss.NewStyle().
 	Foreground(colorMuted).
 	Faint(true)
 
-// renderFooter draws the global one-line footer: the centered copyright
-// notice plus the build version on the right. Both segments share the
-// same dim/faint style so the version reads as a hint, not a status
-// claim. When the terminal is too narrow to fit both segments without
-// overlap, we drop the version rather than the copyright — the version
-// is always available via `jitenv -v`.
+// footerSegments are the fixed segments of the global footer. The
+// version segment, when non-empty, is appended at render time so the
+// footer can drop it on narrow terminals without disturbing the rest.
+var footerSegments = []string{"jitenv", "© 2026 Gal Villaret", "MIT"}
+
+const footerSeparator = " | "
+
+// renderFooter draws the global one-line footer as a centered, pipe-
+// separated string: `jitenv | © 2026 Gal Villaret | MIT | <version>`.
+// On terminals too narrow to fit the version segment, it is dropped
+// rather than wrapping — the version is always reachable via `jitenv
+// -v`.
 func renderFooter(w int) string {
 	if w < 4 {
 		w = 4
 	}
-	versionText := versionFooterText()
-	versionWidth := lipgloss.Width(versionText)
-	copyrightWidth := lipgloss.Width(copyrightText)
-
-	if versionText == "" || versionWidth+copyrightWidth+2 > w {
-		return copyrightStyle.Width(w).Align(lipgloss.Center).Render(copyrightText)
-	}
-
-	leftPad := (w - copyrightWidth) / 2
-	if leftPad < 0 {
-		leftPad = 0
-	}
-	rightPad := w - leftPad - copyrightWidth - versionWidth
-	if rightPad < 1 {
-		rightPad = 1
-		leftPad = w - copyrightWidth - versionWidth - rightPad
-		if leftPad < 0 {
-			leftPad = 0
+	segments := footerSegments
+	if v := versionFooterText(); v != "" {
+		full := strings.Join(append(append([]string{}, segments...), v), footerSeparator)
+		if lipgloss.Width(full) <= w {
+			return copyrightStyle.Width(w).Align(lipgloss.Center).Render(full)
 		}
 	}
-	return copyrightStyle.Render(strings.Repeat(" ", leftPad)) +
-		copyrightStyle.Render(copyrightText) +
-		copyrightStyle.Render(strings.Repeat(" ", rightPad)) +
-		copyrightStyle.Render(versionText)
+	base := strings.Join(segments, footerSeparator)
+	return copyrightStyle.Width(w).Align(lipgloss.Center).Render(base)
 }
 
 // modalOverlay returns a small centered bordered popup of the given

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -21,7 +21,7 @@ func renderApp(w, h int, body, status string) string {
 	}
 
 	statusLine := statusBarStyle.Width(w).Render(status)
-	footerLine := copyrightStyle.Width(w).Align(lipgloss.Center).Render(copyrightText)
+	footerLine := renderFooter(w)
 
 	// Reserve 1 row for status + 1 row for the footer.
 	contentH := h - 2
@@ -57,6 +57,42 @@ const copyrightText = "© 2026 Gal Villaret · jitenv — MIT"
 var copyrightStyle = lipgloss.NewStyle().
 	Foreground(colorMuted).
 	Faint(true)
+
+// renderFooter draws the global one-line footer: the centered copyright
+// notice plus the build version on the right. Both segments share the
+// same dim/faint style so the version reads as a hint, not a status
+// claim. When the terminal is too narrow to fit both segments without
+// overlap, we drop the version rather than the copyright — the version
+// is always available via `jitenv -v`.
+func renderFooter(w int) string {
+	if w < 4 {
+		w = 4
+	}
+	versionText := versionFooterText()
+	versionWidth := lipgloss.Width(versionText)
+	copyrightWidth := lipgloss.Width(copyrightText)
+
+	if versionText == "" || versionWidth+copyrightWidth+2 > w {
+		return copyrightStyle.Width(w).Align(lipgloss.Center).Render(copyrightText)
+	}
+
+	leftPad := (w - copyrightWidth) / 2
+	if leftPad < 0 {
+		leftPad = 0
+	}
+	rightPad := w - leftPad - copyrightWidth - versionWidth
+	if rightPad < 1 {
+		rightPad = 1
+		leftPad = w - copyrightWidth - versionWidth - rightPad
+		if leftPad < 0 {
+			leftPad = 0
+		}
+	}
+	return copyrightStyle.Render(strings.Repeat(" ", leftPad)) +
+		copyrightStyle.Render(copyrightText) +
+		copyrightStyle.Render(strings.Repeat(" ", rightPad)) +
+		copyrightStyle.Render(versionText)
+}
 
 // modalOverlay returns a small centered bordered popup of the given
 // width, ready to be rendered in lieu of the body. Used by confirm

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/version"
+)
+
+// TestRenderFooter_IncludesVersionRightAligned guards the global footer
+// contract: the copyright text stays visible centred-ish, and the
+// version sits to its right when the terminal is wide enough. Reviewer
+// ergonomics — when a screenshot lands in a bug report, the version
+// should be readable without needing to dump the binary.
+func TestRenderFooter_IncludesVersionRightAligned(t *testing.T) {
+	prev := version.Version
+	t.Cleanup(func() { version.Version = prev })
+	version.Version = "9.9.9"
+
+	out := renderFooter(120)
+	if !strings.Contains(out, "jitenv 9.9.9") {
+		t.Fatalf("footer missing version: %q", out)
+	}
+	if !strings.Contains(out, "jitenv — MIT") {
+		t.Fatalf("footer missing copyright: %q", out)
+	}
+	copyrightIdx := strings.Index(out, "jitenv — MIT")
+	versionIdx := strings.LastIndex(out, "jitenv 9.9.9")
+	if versionIdx <= copyrightIdx {
+		t.Fatalf("version should sit to the right of copyright: %q", out)
+	}
+}
+
+// TestRenderFooter_DropsVersionWhenNarrow falls back to the centred
+// copyright on tight widths so the footer never wraps or clobbers the
+// status line above it. The version is always reachable via -v.
+func TestRenderFooter_DropsVersionWhenNarrow(t *testing.T) {
+	prev := version.Version
+	t.Cleanup(func() { version.Version = prev })
+	version.Version = "9.9.9"
+
+	out := renderFooter(20)
+	if strings.Contains(out, "9.9.9") {
+		t.Fatalf("narrow footer should drop version, got %q", out)
+	}
+}

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -7,33 +7,31 @@ import (
 	"github.com/gv/jitenv/internal/version"
 )
 
-// TestRenderFooter_IncludesVersionRightAligned guards the global footer
-// contract: the copyright text stays visible centred-ish, and the
-// version sits to its right when the terminal is wide enough. Reviewer
-// ergonomics — when a screenshot lands in a bug report, the version
-// should be readable without needing to dump the binary.
-func TestRenderFooter_IncludesVersionRightAligned(t *testing.T) {
+// TestRenderFooter_PipeSeparatedSegments guards the global footer
+// shape: a single centered line of pipe-separated segments —
+// `jitenv | © 2026 Gal Villaret | MIT | <version>`. "jitenv" appears
+// only once (in the leading segment), not duplicated as a prefix on
+// the version.
+func TestRenderFooter_PipeSeparatedSegments(t *testing.T) {
 	prev := version.Version
 	t.Cleanup(func() { version.Version = prev })
 	version.Version = "9.9.9"
 
 	out := renderFooter(120)
-	if !strings.Contains(out, "jitenv 9.9.9") {
-		t.Fatalf("footer missing version: %q", out)
+	for _, want := range []string{"jitenv", "© 2026 Gal Villaret", "MIT", "9.9.9", " | "} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("footer missing %q: %q", want, out)
+		}
 	}
-	if !strings.Contains(out, "jitenv — MIT") {
-		t.Fatalf("footer missing copyright: %q", out)
-	}
-	copyrightIdx := strings.Index(out, "jitenv — MIT")
-	versionIdx := strings.LastIndex(out, "jitenv 9.9.9")
-	if versionIdx <= copyrightIdx {
-		t.Fatalf("version should sit to the right of copyright: %q", out)
+	if strings.Count(out, "jitenv") != 1 {
+		t.Fatalf("expected 'jitenv' exactly once, got %d in %q", strings.Count(out, "jitenv"), out)
 	}
 }
 
-// TestRenderFooter_DropsVersionWhenNarrow falls back to the centred
-// copyright on tight widths so the footer never wraps or clobbers the
-// status line above it. The version is always reachable via -v.
+// TestRenderFooter_DropsVersionWhenNarrow falls back to the
+// jitenv | copyright | MIT line on tight widths so the footer never
+// wraps or clobbers the status line above it. The version is always
+// reachable via -v.
 func TestRenderFooter_DropsVersionWhenNarrow(t *testing.T) {
 	prev := version.Version
 	t.Cleanup(func() { version.Version = prev })

--- a/internal/tui/version.go
+++ b/internal/tui/version.go
@@ -1,0 +1,10 @@
+package tui
+
+import "github.com/gv/jitenv/internal/version"
+
+// versionFooterText is the right-hand text the global footer renders.
+// Pulled into its own helper so tests can drive renderFooter without
+// reaching into the version package directly.
+func versionFooterText() string {
+	return version.Short()
+}

--- a/internal/tui/version.go
+++ b/internal/tui/version.go
@@ -2,9 +2,11 @@ package tui
 
 import "github.com/gv/jitenv/internal/version"
 
-// versionFooterText is the right-hand text the global footer renders.
+// versionFooterText is the version segment of the global footer.
+// Returns the bare version string (e.g. "v0.5.0-1-gabc1234") without
+// the "jitenv" prefix, since the footer already starts with "jitenv".
 // Pulled into its own helper so tests can drive renderFooter without
 // reaching into the version package directly.
 func versionFooterText() string {
-	return version.Short()
+	return version.Version
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,46 @@
+// Package version exposes the build-time version metadata for jitenv.
+//
+// Values here are populated by `-ldflags "-X .../internal/version.Version=..."`
+// at link time. The defaults intentionally identify a non-release build
+// so plain `go build` / `go install` are honest. Both the CLI (cobra
+// --version, --help footer) and the TUI (global footer) read from this
+// package; keeping it leaf-level avoids the cli↔tui import cycle that
+// would result from hosting the var inside `internal/cli`.
+package version
+
+import "fmt"
+
+var (
+	Version = "dev"
+	Commit  = ""
+	Date    = ""
+)
+
+// String returns a single-line, user-facing version string.
+//
+//	jitenv 0.5.0 (commit abc1234, built 2026-05-06T12:34:56Z)
+//	jitenv 0.5.0 (commit abc1234)
+//	jitenv dev
+func String() string {
+	return Format(Version, Commit, Date)
+}
+
+// Format is the pure variant of String, kept exported so tests can
+// drive it without mutating package globals.
+func Format(version, commit, date string) string {
+	switch {
+	case commit != "" && date != "":
+		return fmt.Sprintf("jitenv %s (commit %s, built %s)", version, commit, date)
+	case commit != "":
+		return fmt.Sprintf("jitenv %s (commit %s)", version, commit)
+	default:
+		return fmt.Sprintf("jitenv %s", version)
+	}
+}
+
+// Short returns just `jitenv <version>` — the canonical one-liner the
+// `--version` flag prints. Build metadata (commit/date) is left to
+// String() / the `version` subcommand.
+func Short() string {
+	return fmt.Sprintf("jitenv %s", Version)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,54 @@
+package version
+
+import "testing"
+
+func TestFormat(t *testing.T) {
+	cases := []struct {
+		name              string
+		ver, commit, date string
+		want              string
+	}{
+		{
+			name:   "all fields populated",
+			ver:    "0.5.0",
+			commit: "abc1234",
+			date:   "2026-05-06T12:34:56Z",
+			want:   "jitenv 0.5.0 (commit abc1234, built 2026-05-06T12:34:56Z)",
+		},
+		{
+			name:   "dev build with empty commit and date",
+			ver:    "dev",
+			commit: "",
+			date:   "",
+			want:   "jitenv dev",
+		},
+		{
+			name:   "commit but no date",
+			ver:    "0.5.0",
+			commit: "abc1234",
+			date:   "",
+			want:   "jitenv 0.5.0 (commit abc1234)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Format(tc.ver, tc.commit, tc.date)
+			if got != tc.want {
+				t.Errorf("Format(%q, %q, %q) = %q, want %q",
+					tc.ver, tc.commit, tc.date, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShort_FollowsSpec(t *testing.T) {
+	// The acceptance criterion fixes the `jitenv -v` output to a single
+	// line of the form `jitenv <version>` — guard that here so a future
+	// edit to Format() doesn't drift the flag's output.
+	prev := Version
+	t.Cleanup(func() { Version = prev })
+	Version = "1.2.3"
+	if got, want := Short(), "jitenv 1.2.3"; got != want {
+		t.Errorf("Short() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #40.

## Summary

Surfaces the jitenv version in three places:

- \`jitenv -v\` and \`jitenv --version\` print one line: \`jitenv <version>\`.
- \`jitenv --help\` shows the version in the footer.
- TUI footer (every screen) shows the version on the right side, dim/Faint style.

The existing \`jitenv version\` subcommand stays (it shipped in 0.4.0); now delegates to the new \`internal/version\` package and prints the verbose form (\`jitenv x.y.z (commit … built …)\`).

## Implementation

### Version source
- New \`internal/version\` package owns \`Version\`, \`Commit\`, \`Date\` build-time vars + \`Format()\`/\`String()\`/\`Short()\` helpers. Default \`Version=\"dev\"\` so \`go install\` from a tarball reports \`jitenv dev\` rather than blank.
- \`Makefile\` build target passes \`-X github.com/gv/jitenv/internal/version.{Version,Commit,Date}=…\`. \`VERSION ?=\` falls back to \`dev\` when \`git describe\` fails.
- \`.goreleaser.yaml\` ldflags retargeted to the same package.

### CLI
- \`internal/cli/root.go\` sets \`cobra.Command.Version = version.Short()\` and registers a custom help template (cobra's default + \`{{.Version}}\` footer) and \`--version\` template (\`{{.Version}}\\n\`). Cobra auto-attaches \`-v\` shorthand once \`.Version\` is non-empty.
- \`internal/cli/version_test.go\` — end-to-end cobra tests for \`--version\` and \`--help\`.

### TUI
- \`internal/tui/layout.go\` — new \`renderFooter\` lays out copyright (centered) + version (right-aligned) on one line in the existing \`copyrightStyle\`. When the terminal is too narrow to fit both with at least one space gap, the version is dropped (still reachable via \`jitenv -v\`).
- \`internal/tui/version.go\` — small accessor so \`layout.go\` doesn't import the version package directly.
- \`internal/tui/layout_test.go\` — covers right-aligned + narrow-fallback paths (no live TTY in CI).

## Verification

- \`make build && ./bin/jitenv -v\` → \`jitenv v0.5.0-N-g<sha>\`.
- \`./bin/jitenv --version\` matches.
- \`./bin/jitenv --help\` shows the version footer line; flags section shows \`-v, --version\`.
- No-git fallback verified: copying repo without \`.git\` and rebuilding → \`jitenv dev\`.
- \`go test ./...\` green.
- \`make fmt vet tidy\` clean.

## Test plan
- [x] \`make build && ./bin/jitenv -v\` shows the right version.
- [x] \`./bin/jitenv --help\` shows the version line.
- [x] No-git build shows \`dev\`.
- [x] \`go test ./...\` green.
- [x] Reviewer (TTY): open \`jitenv config\` and confirm the version appears in the footer right-side on every screen.