### PR TITLE
fix(hook): strip trailing slash from XDG_RUNTIME_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /e2e/harness/bin/
 /e2e/runs/*
 !/e2e/runs/.gitkeep
+.claude/

--- a/internal/shell/hook_path_normalization_test.go
+++ b/internal/shell/hook_path_normalization_test.go
@@ -1,0 +1,70 @@
+package shell_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestHookSnippetStripsTrailingSlash regresses the bash + zsh hook
+// snippets against double-slash leakage when XDG_RUNTIME_DIR happens
+// to end in a trailing slash. The snippets do raw string concat for
+// the wrapper-symlink directory, so an unstripped trailing slash
+// pollutes $PATH with `…//jitenv/shells/<pid>/bin`.
+func TestHookSnippetStripsTrailingSlash(t *testing.T) {
+	cases := []struct {
+		name      string
+		shell     string
+		hookCmd   string
+		runtime   string
+		wantPath  string
+		shellArgs []string
+	}{
+		{
+			name:     "bash trailing slash",
+			shell:    "bash",
+			hookCmd:  "bash",
+			runtime:  "/run/user/1000/",
+			wantPath: "/run/user/1000/jitenv/shells/",
+		},
+		{
+			name:     "bash no trailing slash",
+			shell:    "bash",
+			hookCmd:  "bash",
+			runtime:  "/run/user/1000",
+			wantPath: "/run/user/1000/jitenv/shells/",
+		},
+		{
+			name:     "zsh trailing slash",
+			shell:    "zsh",
+			hookCmd:  "zsh",
+			runtime:  "/run/user/1000/",
+			wantPath: "/run/user/1000/jitenv/shells/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := exec.LookPath(tc.shell); err != nil {
+				t.Skipf("%s not available", tc.shell)
+			}
+			bin := buildBinary(t)
+			binDir := strings.TrimSuffix(bin, "/jitenv")
+
+			script := `eval "$(` + binDir + `/jitenv hook ` + tc.hookCmd + `)"; printf '%s\n' "$__JITENV_WRAP_DIR"`
+			cmd := exec.Command(tc.shell, "-c", script)
+			cmd.Env = append([]string{"PATH=/usr/bin:/bin", "HOME=/tmp", "XDG_RUNTIME_DIR=" + tc.runtime}, "TMPDIR=/tmp")
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s: %v\noutput=%s", tc.shell, err, out)
+			}
+			got := strings.TrimSpace(string(out))
+			if !strings.HasPrefix(got, tc.wantPath) {
+				t.Fatalf("expected wrap dir to start with %q (no leading double-slash); got %q", tc.wantPath, got)
+			}
+			if strings.Contains(got, "//") {
+				t.Fatalf("wrap dir contains double slash: %q", got)
+			}
+		})
+	}
+}

--- a/internal/shell/hook_path_normalization_test.go
+++ b/internal/shell/hook_path_normalization_test.go
@@ -51,19 +51,38 @@ func TestHookSnippetStripsTrailingSlash(t *testing.T) {
 			bin := buildBinary(t)
 			binDir := strings.TrimSuffix(bin, "/jitenv")
 
-			script := `eval "$(` + binDir + `/jitenv hook ` + tc.hookCmd + `)"; printf '%s\n' "$__JITENV_WRAP_DIR"`
+			// The hook calls `jitenv __chpwd` once at load time via a
+			// bare name lookup, so binDir must be on $PATH in addition
+			// to the test's restricted defaults — otherwise we get a
+			// `command not found` line ahead of the wrap-dir output.
+			// HOME is set to the temp dir so the chpwd helper's config
+			// lookup ($XDG_CONFIG_HOME default) doesn't touch the
+			// developer's real config.
+			script := `eval "$(jitenv hook ` + tc.hookCmd + `)"; printf '%s\n' "$__JITENV_WRAP_DIR"`
 			cmd := exec.Command(tc.shell, "-c", script)
-			cmd.Env = append([]string{"PATH=/usr/bin:/bin", "HOME=/tmp", "XDG_RUNTIME_DIR=" + tc.runtime}, "TMPDIR=/tmp")
+			cmd.Env = []string{
+				"PATH=" + binDir + ":/usr/bin:/bin",
+				"HOME=" + t.TempDir(),
+				"XDG_RUNTIME_DIR=" + tc.runtime,
+				"TMPDIR=/tmp",
+			}
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("%s: %v\noutput=%s", tc.shell, err, out)
 			}
+			// Take the last line — diagnostic output from the hook's
+			// load-time chpwd may print before the wrap-dir line we
+			// care about.
 			got := strings.TrimSpace(string(out))
-			if !strings.HasPrefix(got, tc.wantPath) {
-				t.Fatalf("expected wrap dir to start with %q (no leading double-slash); got %q", tc.wantPath, got)
+			lastLine := got
+			if i := strings.LastIndex(got, "\n"); i >= 0 {
+				lastLine = got[i+1:]
 			}
-			if strings.Contains(got, "//") {
-				t.Fatalf("wrap dir contains double slash: %q", got)
+			if !strings.HasPrefix(lastLine, tc.wantPath) {
+				t.Fatalf("expected wrap dir to start with %q (no leading double-slash); got %q\nfull output: %q", tc.wantPath, lastLine, got)
+			}
+			if strings.Contains(lastLine, "//") {
+				t.Fatalf("wrap dir contains double slash: %q", lastLine)
 			}
 		})
 	}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -12,9 +12,14 @@ __JITENV_LOADED=1
 # silent fall-through. We pre-create it and prepend to $PATH once,
 # right here, so PATH stays stable for the rest of the shell's life.
 if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
-    __JITENV_RUNTIME_DIR="$XDG_RUNTIME_DIR/jitenv"
+    # Strip a trailing slash so the concat doesn't yield "//jitenv"
+    # for users whose XDG_RUNTIME_DIR happens to end in /. The Go
+    # side normalises with filepath.Join; the shell needs to do it
+    # by hand or the wrapper dir lands in $PATH with double slashes.
+    __JITENV_RUNTIME_DIR="${XDG_RUNTIME_DIR%/}/jitenv"
 else
-    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}/jitenv-$UID"
+    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}"
+    __JITENV_RUNTIME_DIR="${__JITENV_RUNTIME_DIR%/}/jitenv-$UID"
 fi
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -9,9 +9,10 @@ __JITENV_LOADED=1
 # Per-shell wrapper-symlink dir for cwd_glob mappings (mirrors
 # bash.sh).
 if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
-    __JITENV_RUNTIME_DIR="$XDG_RUNTIME_DIR/jitenv"
+    __JITENV_RUNTIME_DIR="${XDG_RUNTIME_DIR%/}/jitenv"
 else
-    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}/jitenv-$UID"
+    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}"
+    __JITENV_RUNTIME_DIR="${__JITENV_RUNTIME_DIR%/}/jitenv-$UID"
 fi
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null


### PR DESCRIPTION
## Summary

The bash and zsh hook snippets did raw string concat for the wrapper-symlink directory, so users whose \`XDG_RUNTIME_DIR\` ends in a trailing slash (e.g. \`/run/user/1000/\`) ended up with a \`//jitenv/shells/<pid>/bin\` entry in \`\$PATH\`. Linux file syscalls collapse \`//\` → \`/\`, so the wrappers still ran — but the path looked broken in \`echo \$PATH\` and string-equality checks against the path could mismatch.

The Go side already normalises via \`filepath.Join\`. This PR adds the same normalisation to the snippets via \`\${var%/}\`, plus the same on the \`TMPDIR\` fallback for symmetry.

## Reported

\`\`\`
$ echo \$PATH
/home/gv/.local/bin:/run/user/1000//jitenv/shells/2743202/bin:…
                                  ^^
\`\`\`

## Changes

- \`internal/shell/snippets/bash.sh\` — strip trailing slash from \`XDG_RUNTIME_DIR\` and (fallback branch) \`TMPDIR\` before concat.
- \`internal/shell/snippets/zsh.sh\` — same.
- \`internal/shell/hook_path_normalization_test.go\` — new test that sources each snippet under bash/zsh with a synthetic \`XDG_RUNTIME_DIR\` and asserts \`\$__JITENV_WRAP_DIR\` contains no \`//\`. Bash cases run in CI; zsh case skips when zsh isn't installed.

## Out of band cleanup

The first push of this branch accidentally committed worktree directories from parallel-agent runs (\`.claude/worktrees/...\`) as gitlinks. The follow-up commit removes them from the index and adds \`.claude/\` to \`.gitignore\` so future \`git add -A\` doesn't repeat the mistake.

## Test plan

- [x] \`go test ./...\` green.
- [x] New \`TestHookSnippetStripsTrailingSlash\` passes for bash with both trailing-slash and no-slash inputs.
- [ ] Reviewer (zsh installed): re-run that test locally and confirm the zsh case passes.