### PR TITLE
feat(site): add jitenv.com landing page served from /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ exposure to the one process that actually needs the value:
 - Pluggable sources: `local` (encrypted bags in `config.toml`) and
   AWS Secrets Manager.
 
+## Website
+
+[jitenv.com](https://jitenv.com) — project landing page with overview,
+download links, and contact info. Served via GitHub Pages from the
+[`/docs`](docs/) folder on `main`; edits land through normal pull
+requests.
+
 ## Documentation
 
 - [Quickstart](docs/quickstart.md) — install → unlock → mapping → run.

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+jitenv.com

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# jitenv website source
+
+This folder is the source for [jitenv.com](https://jitenv.com), served
+directly by GitHub Pages from `/docs` on the `main` branch &mdash; there
+is no `gh-pages` branch and no build step. Updates land via normal pull
+requests that touch `index.html`, `style.css`, `CNAME`, or any other
+file in this directory; once merged, GitHub Pages redeploys
+automatically.
+
+The Markdown files in this folder (`quickstart.md`, `concepts.md`,
+etc.) are the project's reference documentation, intended to be read on
+GitHub. They are not rendered by the website.

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#1e6fd9"/>
+  <text x="32" y="44" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="36" font-weight="700" fill="#ffffff" text-anchor="middle">j</text>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="jitenv: just-in-time environment variable loader. Encrypted secrets injected into a single process tree, never the parent shell.">
+<title>jitenv &middot; just-in-time environment variables</title>
+<link rel="icon" type="image/svg+xml" href="favicon.svg">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header class="site-header">
+  <div class="container">
+    <h1 class="brand">jitenv</h1>
+    <p class="tagline">Just-in-time environment variables for the paranoid.</p>
+  </div>
+</header>
+
+<main class="container">
+
+  <section id="overview">
+    <h2>Overview</h2>
+    <p>
+      <strong>jitenv</strong> holds your secrets in an encrypted on-disk
+      config and injects them only into the process tree of the file you
+      actually want to run &mdash; never into the parent shell. A
+      per-user agent keeps the master key in memory; a shell hook
+      intercepts mapped commands and re-execs them through
+      <code>jitenv run</code>.
+    </p>
+
+    <pre><code>jitenv unlock
+./scripts/deploy.sh        # mapped &mdash; env vars appear inside the script
+echo "$DATABASE_URL"       # empty in your shell &mdash; it never saw the value</code></pre>
+
+    <h3>Features</h3>
+    <ul class="features">
+      <li>Per-file env injection via shell hooks (bash + zsh).</li>
+      <li>Encrypted at rest with XChaCha20-Poly1305 + Argon2id.</li>
+      <li>Long-lived per-user agent; secrets stay out of the parent shell.</li>
+      <li>Pluggable source backends: <code>local</code> (encrypted bags) and AWS Secrets Manager.</li>
+      <li>Exact-path and glob mappings, with whole-bag expansion.</li>
+      <li>TUI for managing config without hand-editing TOML.</li>
+      <li>Linux and macOS support.</li>
+    </ul>
+  </section>
+
+  <section id="downloads">
+    <h2>Download</h2>
+
+    <h3>Pre-built binaries</h3>
+    <p>
+      Available on the
+      <a href="https://github.com/Galvill/jitenv/releases/latest">GitHub Releases page</a>
+      for:
+    </p>
+    <ul>
+      <li><code>linux/amd64</code> &mdash; <code>.tar.gz</code>, <code>.deb</code>, <code>.rpm</code></li>
+      <li><code>linux/arm64</code> &mdash; <code>.tar.gz</code>, <code>.deb</code>, <code>.rpm</code></li>
+    </ul>
+    <p>
+      macOS (darwin/amd64 and darwin/arm64) is supported in code; binary
+      releases are not yet published, so install via <code>go install</code>
+      or build from source (below). After installing, activate the shell
+      hook once:
+    </p>
+    <pre><code>jitenv hook install
+exec $SHELL</code></pre>
+
+    <h3>Install with <code>go install</code></h3>
+    <pre><code>go install github.com/gv/jitenv/cmd/jitenv@latest</code></pre>
+
+    <h3>Build from source</h3>
+    <pre><code>git clone https://github.com/Galvill/jitenv
+cd jitenv
+make install</code></pre>
+    <p>
+      Requires Go 1.22 or later. <code>make install</code> places the
+      binary in <code>$PREFIX/bin</code> (default
+      <code>~/.local/bin</code>).
+    </p>
+  </section>
+
+  <section id="contact">
+    <h2>Contact</h2>
+    <ul class="contact">
+      <li>Repository: <a href="https://github.com/Galvill/jitenv">github.com/Galvill/jitenv</a></li>
+      <li>Issues &amp; bug reports: <a href="https://github.com/Galvill/jitenv/issues">github.com/Galvill/jitenv/issues</a></li>
+      <li>Maintainer: <a href="https://github.com/Galvill">@Galvill</a></li>
+    </ul>
+  </section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container">
+    <p>
+      <a href="https://github.com/Galvill/jitenv/blob/main/LICENSE">MIT licensed</a>.
+      Source for this site lives in
+      <a href="https://github.com/Galvill/jitenv/tree/main/docs"><code>/docs</code></a>.
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,163 @@
+:root {
+  --bg: #ffffff;
+  --fg: #1a1d23;
+  --fg-muted: #5a6270;
+  --accent: #1e6fd9;
+  --accent-hover: #0f5ab8;
+  --code-bg: #f4f6f9;
+  --code-fg: #1a1d23;
+  --border: #e2e6ec;
+  --header-bg: #f9fafc;
+  --footer-fg: #6b7280;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1218;
+    --fg: #e8ecf2;
+    --fg-muted: #9aa3b2;
+    --accent: #5fafff;
+    --accent-hover: #8cc4ff;
+    --code-bg: #181c25;
+    --code-fg: #e8ecf2;
+    --border: #232834;
+    --header-bg: #131720;
+    --footer-fg: #8a93a3;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--fg);
+  background: var(--bg);
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+.site-header {
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--border);
+  padding: 2.5rem 0 2rem;
+  margin-bottom: 2rem;
+}
+
+.brand {
+  font-size: 2.5rem;
+  margin: 0 0 0.25rem;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 1.05rem;
+}
+
+main section {
+  margin-bottom: 2.75rem;
+}
+
+h2 {
+  font-size: 1.6rem;
+  margin: 0 0 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--accent);
+}
+
+h3 {
+  font-size: 1.15rem;
+  margin: 1.5rem 0 0.5rem;
+  color: var(--fg);
+}
+
+p {
+  margin: 0.5rem 0 1rem;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s ease;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-hover);
+  border-bottom-color: currentColor;
+}
+
+ul {
+  padding-left: 1.4rem;
+  margin: 0.5rem 0 1rem;
+}
+
+li {
+  margin: 0.25rem 0;
+}
+
+ul.features li,
+ul.contact li {
+  margin: 0.4rem 0;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.92em;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+pre {
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.9rem 1rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  overflow-x: auto;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+strong {
+  color: var(--fg);
+}
+
+.site-footer {
+  margin-top: 3rem;
+  padding: 1.5rem 0 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--footer-fg);
+  font-size: 0.9rem;
+}
+
+.site-footer p {
+  margin: 0;
+}


### PR DESCRIPTION
Closes #54.

## Summary

Adds a single-page static site for **jitenv.com** under \`/docs/\`, ready to be served via GitHub Pages. No build step, no dependencies, no analytics.

## Stack decision

Plain HTML/CSS/SVG — no Jekyll/Hugo/Astro. Reasoning:
- Three sections (intro, downloads, contact) doesn't need a generator.
- GitHub Pages serves \`/docs/index.html\` directly with zero config.
- Easy to swap later if the site grows.

## Files added

- \`docs/index.html\` — semantic single-page (header / main with three \`<section>\`s / footer).
- \`docs/style.css\` — system font stack, ~800 px container, CSS custom properties for theme. Light + dark mode via \`prefers-color-scheme\`.
- \`docs/CNAME\` — \`jitenv.com\\n\`.
- \`docs/robots.txt\` — allow-all.
- \`docs/favicon.svg\` — minimal inline SVG mark.
- \`docs/README.md\` — explains the folder's purpose: PR to \`/docs/\` on \`main\`, no \`gh-pages\` branch.

## Files modified

- Root \`README.md\` — new \"Website\" section pointing at https://jitenv.com.

## Honest deviations from the spec

- **Downloads list does not advertise darwin binaries.** The latest release (v0.4.0) only ships \`linux/amd64\` and \`linux/arm64\` artefacts. PR #25 added the darwin code path but no release with darwin assets has cut yet. macOS users get the \`go install\` / source-build path. Worth revisiting after the next release.
- **\`docs/\` now contains both website assets and the project's reference markdown** (\`quickstart.md\`, \`security.md\`, etc.). GitHub Pages will serve them at e.g. \`https://jitenv.com/quickstart.md\` as raw text. They're already public on GitHub so no leak, but it's ugly. If you'd rather hide them, move the website into \`docs/site/\` and configure Pages to serve from that subfolder. Left as-is to keep this PR small; happy to follow up.

## Manual setup the user must do

1. **GitHub Pages**: repo Settings → Pages → Source = \"Deploy from a branch\", Branch = \`main\`, Folder = \`/docs\`. Save.
2. **DNS at registrar** for the apex \`jitenv.com\`:
   - A: \`185.199.108.153\`, \`185.199.109.153\`, \`185.199.110.153\`, \`185.199.111.153\`
   - AAAA: \`2606:50c0:8000::153\`, \`2606:50c0:8001::153\`, \`2606:50c0:8002::153\`, \`2606:50c0:8003::153\`
3. **DNS for \`www.jitenv.com\`** (optional): \`CNAME www → galvill.github.io\`.
4. **HTTPS**: once DNS propagates (up to ~24 h), tick \"Enforce HTTPS\" in Pages settings — GitHub provisions a Let's Encrypt cert automatically.

## Test plan
- [x] HTML parses (Python's \`html.parser\`; no \`xmllint\` available).
- [x] \`docs/CNAME\` is exactly \`jitenv.com\\n\`.
- [x] No external resources requested by the page (offline-friendly).
- [x] \`go test ./...\` still green (no Go touched).
- [x] Reviewer: open \`docs/index.html\` in a browser locally — confirm light/dark switch via OS preference and that the layout reads cleanly at 800 px.