### PR TITLE
fix(shim): only inject env vars for direct shell invocations (#52)

### DIFF
--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -576,3 +576,137 @@ ls $__JITENV_WRAP_DIR
 		t.Errorf("after edit: expected both firstcmd and secondcmd; got:\n%s", after)
 	}
 }
+
+// TestBashWrapperNoLeakIntoChildProcesses is the regression for
+// issue #52: in a cwd_glob-mapped folder where `fakecmd` is mapped,
+// running an unmapped `fakeparent` that internally invokes `fakecmd`
+// must NOT inject env vars into the inner fakecmd. The wrapper dir
+// is on $PATH for the whole shell tree, so without a guard the
+// inner fakecmd lookup hits the wrapper symlink → shim → injection.
+//
+// Two assertions in the same shell:
+//
+//  1. Direct invocation of fakecmd (typed at the prompt) DOES inject —
+//     the desired behaviour and a guard against an over-zealous fix.
+//  2. Indirect invocation via fakeparent (the npm → node case from
+//     the issue) does NOT inject.
+func TestBashWrapperNoLeakIntoChildProcesses(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmdPath := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(cmdPath, []byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"${FOO:-MISSING}\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Stand-in for npm: an unmapped script that runs fakecmd. The
+	// wrapper dir sits at the head of $PATH, so the bare `fakecmd`
+	// lookup inside this script lands on the symlink → shim. We
+	// capture fakecmd's output via $(...) so the surrounding shell
+	// has to fork+wait — matching how npm/yarn/pnpm actually run
+	// node (they keep running to capture child output rather than
+	// `exec`-ing into it).
+	parentPath := filepath.Join(fakeBin, "fakeparent")
+	if err := os.WriteFile(parentPath, []byte("#!/bin/bash\nout=$(fakecmd)\nprintf '%s\\n' \"$out\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-noleak")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	key, _ := config.DeriveKeyFromMeta(cfg, pw)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "from-cwd"}},
+	}
+	cfg.Mappings = []config.Mapping{{
+		CwdGlob:  projectDir,
+		Commands: []string{"fakecmd"},
+		Vars:     []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+	}}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	cli := agent.NewClient(paths.Socket)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	binDir := filepath.Dir(bin)
+	// Trailing `:` after each invocation defeats bash's
+	// exec-into-the-last-command optimisation, which would otherwise
+	// collapse the whole chain into a single PID and make the test
+	// lie about who fakecmd's parent is.
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook bash)"
+cd %q
+__jitenv_chpwd
+echo '--- direct ---'
+fakecmd
+:
+echo '--- indirect ---'
+fakeparent
+:
+`, binDir, fakeBin, cfgPath, binDir, projectDir,
+	))
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+	t.Logf("bash output:\n%s", got)
+
+	direct := sectionBetween(got, "--- direct ---", "--- indirect ---")
+	indirect := sectionBetween(got, "--- indirect ---", "")
+	if !strings.Contains(direct, "FOO=from-cwd") {
+		t.Errorf("direct: expected FOO=from-cwd; got:\n%s", direct)
+	}
+	if !strings.Contains(indirect, "FOO=MISSING") {
+		t.Errorf("indirect: expected FOO=MISSING (no leak into child of unmapped command); got:\n%s", indirect)
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -22,6 +22,10 @@ else
     __JITENV_RUNTIME_DIR="${__JITENV_RUNTIME_DIR%/}/jitenv-$UID"
 fi
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
+# Recorded so the shim can tell "this shell typed the command" from
+# "an unmapped descendant spawned the wrapped binary"; only the former
+# should pull in mapped env vars (issue #52).
+export __JITENV_SHELL_PID=$$
 mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null
 case ":$PATH:" in
     *":$__JITENV_WRAP_DIR:"*) : ;;

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -15,6 +15,9 @@ else
     __JITENV_RUNTIME_DIR="${__JITENV_RUNTIME_DIR%/}/jitenv-$UID"
 fi
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
+# See bash.sh — gates env injection in the shim so vars don't leak
+# into children of unmapped commands (issue #52).
+export __JITENV_SHELL_PID=$$
 mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null
 case ":$PATH:" in
     *":$__JITENV_WRAP_DIR:"*) : ;;

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -67,22 +68,24 @@ func run(invokedAs string, args []string) error {
 
 	env := os.Environ()
 	injected := 0
-	extra, fetchErr := fetchEnv(invokedAs)
-	switch {
-	case errors.Is(fetchErr, errAgentDown):
-		if agentwarn.WarnAndWait(invokedAs) {
-			return errors.New("aborted")
+	if shouldInject() {
+		extra, fetchErr := fetchEnv(invokedAs)
+		switch {
+		case errors.Is(fetchErr, errAgentDown):
+			if agentwarn.WarnAndWait(invokedAs) {
+				return errors.New("aborted")
+			}
+		case fetchErr != nil:
+			// Other error (config parse, fetch failure). Surface to
+			// stderr but don't block — the user explicitly invoked the
+			// command.
+			fmt.Fprintf(os.Stderr, "jitenv shim: %s: %v\n", invokedAs, fetchErr)
+		default:
+			for k, v := range extra {
+				env = append(env, k+"="+v)
+			}
+			injected = len(extra)
 		}
-	case fetchErr != nil:
-		// Other error (config parse, fetch failure). Surface to
-		// stderr but don't block — the user explicitly invoked the
-		// command.
-		fmt.Fprintf(os.Stderr, "jitenv shim: %s: %v\n", invokedAs, fetchErr)
-	default:
-		for k, v := range extra {
-			env = append(env, k+"="+v)
-		}
-		injected = len(extra)
 	}
 
 	if injected > 0 && runnotice.Enabled() {
@@ -97,6 +100,29 @@ func run(invokedAs string, args []string) error {
 		return fmt.Errorf("exec %s: %w", realPath, execErr)
 	}
 	return nil
+}
+
+// shouldInject decides whether the shim should pull in mapped env
+// vars. The shell hook exports __JITENV_SHELL_PID=$$ when sourced;
+// the shim only injects when the typing shell is its direct parent —
+// either bash/zsh forked then exec'd us (Getppid matches) or, for a
+// trailing-single-command script, the shell exec'd into us in place
+// and we now wear its PID (Getpid matches). A wrapped command run as
+// a child of an unmapped command (e.g. npm spawning node) shares
+// neither identity, so it transparently execs the real binary with
+// the parent env (issue #52). When the marker is unset (no hook
+// loaded) we fall back to injecting, matching pre-fix behaviour for
+// hand-invoked wrappers.
+func shouldInject() bool {
+	raw := os.Getenv("__JITENV_SHELL_PID")
+	if raw == "" {
+		return true
+	}
+	want, err := strconv.Atoi(raw)
+	if err != nil || want <= 0 {
+		return true
+	}
+	return os.Getppid() == want || os.Getpid() == want
 }
 
 func firstArg() string {


### PR DESCRIPTION
Closes #52.

## Summary

For \`cwd_glob\` mappings, the wrapper-symlink directory sits on \`\$PATH\` for the entire shell session — and is inherited by every descendant process. So when the user runs an unmapped command (e.g. \`npm\`) that internally \`execvp\`'s a mapped command (e.g. \`node\`), the lookup hits the wrapper symlink and the shim injects mapped env vars into a process the user never directly invoked.

This PR has the shim distinguish "user typed this at the shell prompt" from "spawned by a child of the shell" and skip injection in the latter case.

## Mechanism

1. The bash + zsh hooks now export \`__JITENV_SHELL_PID=\$\$\` at load time.
2. The shim's new \`shouldInject()\` reads it and only injects when **the typing shell is the shim's direct parent**:
   - \`os.Getppid() == shellPID\` — normal case: shell forked, child execvp'd the wrapper.
   - **OR** \`os.Getpid() == shellPID\` — bash exec-optimisation case: when the wrapper is the *last* command of \`bash -c '… ; fakecmd'\`, bash exec's into it directly, so the shim takes over the shell's PID.
3. Otherwise the shim transparently execs the real binary with parent env (no notice, no warning, just runs).
4. When the marker is unset (e.g. user invokes a wrapper from a non-jitenv shell), we still inject — preserves existing behaviour for hand-invoked wrappers.

## Trade-off

Wrapping a mapped command in a sub-shell with **multiple commands** (e.g. \`bash -c 'node x.js; node y.js'\`) won't get vars injected. The typing shell isn't the shim's parent in that case.

The more general \"walk the parent chain looking for the shell PID\" approach was considered and rejected: \`npm\` forks \`node\` from \`npm\`, which is itself a child of the original shell, so a chain walk would *falsely match* — exactly the bug we're fixing.

## Edge cases

- \`exec npm run x\` (explicit shell exec) puts npm at the shell's PID; npm-forked node would then have \`Getppid() == shellPID\` and wrongly inject. Explicit \`exec\` from an interactive prompt is rare enough to accept.
- Marker missing (e.g. wrapper run outside a jitenv-loaded shell) → still injects. Documented in the function comment.

## Tests

New \`TestBashWrapperNoLeakIntoChildProcesses\` in \`internal/shell/hook_wrapper_test.go\`:
- Plants a real \`fakecmd\` (mapped) and a \`fakeparent\` script (unmapped) that runs \`out=\$(fakecmd)\`.
- Direct invocation: asserts \`FOO=from-cwd\`.
- Indirect through \`fakeparent\`: asserts \`FOO=MISSING\` (the leak).
- The trailing \`:\` in the bash script defeats bash's exec-optimisation so the test exercises a real fork chain.
- Verified to fail on \`main\` (without the fix) and pass with it.

Existing wrapper tests (\`TestBashWrapperEndToEnd\`, \`TestBashWrapperPreRunNotice\`, \`TestBashWrapperOutsideMappedDir\`, \`TestBashWrapperReReconcilesOnConfigEdit\`, \`TestBashWrapperAgentDownWarns\`) still pass.

## Files changed

- \`internal/shell/snippets/bash.sh\` — export \`__JITENV_SHELL_PID\`.
- \`internal/shell/snippets/zsh.sh\` — same.
- \`internal/shim/shim.go\` — \`shouldInject()\` gate around the env merge + notice.
- \`internal/shell/hook_wrapper_test.go\` — new regression test.

## Test plan
- [x] \`make fmt vet tidy\` clean.
- [x] \`go test ./...\` green.
- [x] \`make build\` clean.
- [x] New regression test fails on \`main\`, passes here.
- [x] Reviewer (interactive bash + cwd_glob mapping for \`node\`): \`cd\` into the mapped dir, run \`node -e 'console.log(process.env.YOUR_VAR)'\` directly → value present. Then \`npm run\` something that internally execs \`node\` → value absent.