### PR TITLE
feat(e2e): install jitenv from release artefacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ BIN := jitenv
 PREFIX ?= $(HOME)/.local
 
 .PHONY: build install test fmt vet tidy lint release-snapshot clean \
-	e2e-up e2e-down e2e-down-hard e2e-build e2e-run e2e-runner-build e2e-shell
+	e2e-up e2e-down e2e-down-hard e2e-build e2e-build-artifacts \
+	e2e-run e2e-runner-build e2e-shell
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -49,7 +50,26 @@ E2E_COMPOSE := e2e/docker-compose.yml
 E2E_PROJECT := jitenv-e2e
 E2E_RUNNER  := e2e/harness/bin/runner
 
-e2e-build:
+# Snapshot artefacts under dist/ are the source of truth for the
+# package-installing distro images (debian deb, fedora rpm, alpine tar.gz).
+# We rebuild them only when something in the source tree is newer than the
+# stamp file. The stamp records the git HEAD that produced the artefacts;
+# changing branches or committing invalidates it via the find below.
+GORELEASER ?= goreleaser
+DIST_STAMP := dist/.snapshot-stamp
+DIST_SOURCES := $(shell find cmd internal pkg packaging .goreleaser.yaml LICENSE README.md go.mod go.sum -type f 2>/dev/null)
+
+e2e-build-artifacts: $(DIST_STAMP)
+
+$(DIST_STAMP): $(DIST_SOURCES)
+	@command -v $(GORELEASER) >/dev/null 2>&1 || { \
+		echo "goreleaser not found. Install via: go install github.com/goreleaser/goreleaser/v2@latest"; \
+		exit 1; \
+	}
+	$(GORELEASER) release --snapshot --clean --skip=publish,sign
+	@git rev-parse HEAD > $(DIST_STAMP)
+
+e2e-build: e2e-build-artifacts
 	docker compose -f $(E2E_COMPOSE) -p $(E2E_PROJECT) build
 
 e2e-up: e2e-build

--- a/e2e/Dockerfile.alpine
+++ b/e2e/Dockerfile.alpine
@@ -1,29 +1,48 @@
 # syntax=docker/dockerfile:1
 #
-# Alpine (musl) jitenv test image. Building jitenv against musl is
-# the point — SO_PEERCRED, Setsid double-fork, syscall.Exec all need
-# to round-trip a non-glibc libc. CGO is off so we don't drag in
-# musl-dev unnecessarily.
+# Alpine (musl) jitenv test image, install-from-artifact variant.
+# Extracts the snapshot .tar.gz under dist/ and lays the contents out
+# to match the goreleaser nfpms layout so the install-layout scenario
+# can assert against the same paths used by the .deb / .rpm.
+#
+# The tar.gz only ships the binary, snippets, and docs (no
+# postinstall / preremove scripts), so this image deliberately does
+# NOT exercise those scripts; that's covered by debian + fedora.
+#
+# Harness helpers (jitenv-e2e-seed, jitenv-e2e-unlock) are still built
+# from source against musl in a small builder stage.
 
-FROM golang:1.25-alpine AS build
+FROM golang:1.25-alpine AS helper-build
 WORKDIR /src
 RUN apk add --no-cache git
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv ./cmd/jitenv \
- && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
  && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
 
 FROM alpine:3.20 AS runtime
-RUN apk add --no-cache bash zsh ca-certificates curl tini coreutils procps shadow util-linux && \
+ARG TARGETARCH=amd64
+RUN apk add --no-cache --no-progress \
+        bash zsh ca-certificates curl tini coreutils procps shadow util-linux && \
     useradd --create-home --shell /bin/bash --uid 1000 jitenv && \
     install -d -m 0700 -o jitenv -g jitenv /home/jitenv/.config/jitenv && \
-    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts && \
+    install -d -m 0755 /opt/pkg
 
-COPY --from=build /out/jitenv /usr/local/bin/jitenv
-COPY --from=build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
-COPY --from=build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+COPY dist/jitenv_*_linux_${TARGETARCH}.tar.gz /opt/pkg/
+RUN ln -s $(ls /opt/pkg/jitenv_*_linux_${TARGETARCH}.tar.gz | head -n1) /opt/pkg/jitenv.tar.gz && \
+    tmp=$(mktemp -d) && \
+    tar -C "$tmp" -xzf /opt/pkg/jitenv.tar.gz && \
+    install -Dm0755 "$tmp/jitenv" /usr/bin/jitenv && \
+    install -Dm0644 "$tmp/snippets/bash.sh" /usr/share/jitenv/snippets/bash.sh && \
+    install -Dm0644 "$tmp/snippets/zsh.sh" /usr/share/jitenv/snippets/zsh.sh && \
+    install -Dm0644 "$tmp/LICENSE" /usr/share/doc/jitenv/LICENSE && \
+    install -Dm0644 "$tmp/README.md" /usr/share/doc/jitenv/README.md && \
+    rm -rf "$tmp"
+
+COPY --from=helper-build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
+COPY --from=helper-build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
 
 ENTRYPOINT ["/sbin/tini", "--"]
 USER jitenv

--- a/e2e/Dockerfile.alpine-source
+++ b/e2e/Dockerfile.alpine-source
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+#
+# Alpine (musl) jitenv test image. Building jitenv against musl is
+# the point — SO_PEERCRED, Setsid double-fork, syscall.Exec all need
+# to round-trip a non-glibc libc. CGO is off so we don't drag in
+# musl-dev unnecessarily.
+
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+RUN apk add --no-cache git
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv ./cmd/jitenv \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+
+FROM alpine:3.20 AS runtime
+RUN apk add --no-cache bash zsh ca-certificates curl tini coreutils procps shadow util-linux && \
+    useradd --create-home --shell /bin/bash --uid 1000 jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/.config/jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts
+
+COPY --from=build /out/jitenv /usr/local/bin/jitenv
+COPY --from=build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
+COPY --from=build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+
+ENTRYPOINT ["/sbin/tini", "--"]
+USER jitenv
+WORKDIR /home/jitenv
+HEALTHCHECK --interval=5s --timeout=2s --start-period=2s --retries=3 \
+    CMD jitenv version || exit 1
+CMD ["sleep", "infinity"]

--- a/e2e/Dockerfile.debian
+++ b/e2e/Dockerfile.debian
@@ -1,45 +1,51 @@
 # syntax=docker/dockerfile:1
 #
-# Debian-flavoured jitenv test image. The build stage compiles jitenv
-# and the seed helper inside the image (rather than mounting the host
-# binary) so the same Dockerfile works in CI without artefact handoff.
+# Debian-flavoured jitenv test image. Installs jitenv from the
+# snapshot .deb under dist/ (built by `make e2e-build-artifacts`),
+# exercising the goreleaser nfpms layout, postinstall script, and
+# /usr/bin install path. The harness helpers (jitenv-e2e-seed,
+# jitenv-e2e-unlock) are not shipped by the package so they are
+# still built from source in a small builder stage.
 #
 # Run as user `jitenv` (uid 1000). XDG_RUNTIME_DIR is left unset so
-# agent.DefaultPaths() falls back to /tmp/jitenv-<uid>, which works
-# without systemd. If you want to exercise the XDG branch instead,
-# set XDG_RUNTIME_DIR=/run/user/1000 in the compose file.
+# agent.DefaultPaths() falls back to /tmp/jitenv-<uid>.
 
-FROM golang:1.25-bookworm AS build
+FROM golang:1.25-bookworm AS helper-build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv ./cmd/jitenv \
- && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
  && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
 
 FROM debian:bookworm-slim AS runtime
+ARG TARGETARCH=amd64
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
+# debian:*-slim ships /etc/dpkg/dpkg.cfg.d/docker which excludes
+# /usr/share/doc/* and /usr/share/man/* from package installs. We need
+# the package's docs to land on disk so the install-layout scenario can
+# assert against /usr/share/doc/jitenv/{LICENSE,README.md}.
+RUN rm -f /etc/dpkg/dpkg.cfg.d/docker && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         bash zsh ca-certificates curl tini coreutils procps && \
     rm -rf /var/lib/apt/lists/* && \
     useradd --create-home --shell /bin/bash --uid 1000 jitenv && \
     install -d -m 0700 -o jitenv -g jitenv /home/jitenv/.config/jitenv && \
-    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts && \
+    install -d -m 0755 /opt/pkg
 
-COPY --from=build /out/jitenv /usr/local/bin/jitenv
-COPY --from=build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
-COPY --from=build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+# The snapshot .deb is the artefact under test. We keep a copy under
+# /opt/pkg so install-layout scenarios can re-run `dpkg -i` / `dpkg -r`
+# at runtime to capture postinstall / preremove output.
+COPY dist/jitenv_*_linux_${TARGETARCH}.deb /opt/pkg/
+RUN ln -s $(ls /opt/pkg/jitenv_*_linux_${TARGETARCH}.deb | head -n1) /opt/pkg/jitenv.deb && \
+    dpkg -i /opt/pkg/jitenv.deb
 
-# Tini reaps the agent if a scenario forgets to lock; this matters
-# because the daemon double-forks and would otherwise leak as a
-# container-level zombie on `docker compose down`.
+COPY --from=helper-build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
+COPY --from=helper-build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+
 ENTRYPOINT ["/usr/bin/tini", "--"]
-
-# `sleep infinity` keeps the container alive so scenarios can `docker
-# compose exec` into it. The healthcheck looks for the binary, so a
-# broken build fails the stack early instead of after the first scenario.
 USER jitenv
 WORKDIR /home/jitenv
 HEALTHCHECK --interval=5s --timeout=2s --start-period=2s --retries=3 \

--- a/e2e/Dockerfile.fedora
+++ b/e2e/Dockerfile.fedora
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1
+#
+# Fedora-flavoured jitenv test image. Installs jitenv from the snapshot
+# .rpm under dist/ (built by `make e2e-build-artifacts`), exercising the
+# rpm-side of the goreleaser nfpms layout, postinstall script, and
+# /usr/bin install path. Without this image the rpm path is uncovered.
+#
+# Run as user `jitenv` (uid 1000). XDG_RUNTIME_DIR is left unset so
+# agent.DefaultPaths() falls back to /tmp/jitenv-<uid>.
+
+FROM golang:1.25-bookworm AS helper-build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+
+FROM fedora:40 AS runtime
+ARG TARGETARCH=amd64
+RUN dnf install -y --setopt=install_weak_deps=False --nodocs \
+        bash zsh ca-certificates curl tini coreutils diffutils procps-ng \
+        shadow-utils util-linux rpm && \
+    dnf clean all && rm -rf /var/cache/dnf && \
+    useradd --create-home --shell /bin/bash --uid 1000 jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/.config/jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts && \
+    install -d -m 0755 /opt/pkg
+
+# The snapshot .rpm is the artefact under test. Kept under /opt/pkg so
+# install-layout scenarios can re-run `rpm -i` / `rpm -e` at runtime to
+# capture postinstall / preremove output.
+COPY dist/jitenv_*_linux_${TARGETARCH}.rpm /opt/pkg/
+RUN ln -s $(ls /opt/pkg/jitenv_*_linux_${TARGETARCH}.rpm | head -n1) /opt/pkg/jitenv.rpm && \
+    rpm -i /opt/pkg/jitenv.rpm
+
+COPY --from=helper-build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
+COPY --from=helper-build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+USER jitenv
+WORKDIR /home/jitenv
+HEALTHCHECK --interval=5s --timeout=2s --start-period=2s --retries=3 \
+    CMD jitenv version || exit 1
+CMD ["sleep", "infinity"]

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,11 +23,21 @@ Failed runs leave a self-contained artefact directory under
 
 `e2e/docker-compose.yml` runs:
 
-| service       | role                                                                         |
-| ------------- | ---------------------------------------------------------------------------- |
-| `debian`      | Debian bookworm-slim (glibc) test container; bash + zsh + non-root user      |
-| `alpine`      | Alpine 3.20 (musl) test container; same setup, exercises the non-glibc path  |
-| `localstack`  | LocalStack 3.x with Secrets Manager, seeded with one JSON secret             |
+| service          | role                                                                                                  |
+| ---------------- | ----------------------------------------------------------------------------------------------------- |
+| `debian`         | Debian bookworm-slim (glibc); installs jitenv from `dist/*.deb` (covers nfpms layout + postinstall)   |
+| `fedora`         | Fedora 40 (glibc); installs jitenv from `dist/*.rpm` (covers rpm layout + postinstall)                |
+| `alpine`         | Alpine 3.20 (musl); extracts `dist/*.tar.gz` into the deb/rpm layout (covers archive contents)        |
+| `alpine-source`  | Alpine 3.20 (musl); builds jitenv from `HEAD` so the source build path against musl stays exercised   |
+| `localstack`     | LocalStack 3.x with Secrets Manager, seeded with one JSON secret                                      |
+
+The three install-from-artefact services (`debian`, `fedora`, `alpine`)
+depend on `dist/` being populated by `make e2e-build-artifacts`, which
+runs `goreleaser release --snapshot --clean --skip=publish,sign` and
+records the source HEAD in `dist/.snapshot-stamp`. The stamp's mtime
+is compared against the source tree by Make, so subsequent
+`make e2e-up` cycles skip the rebuild when nothing relevant has
+changed. Force a rebuild by deleting the stamp.
 
 Each distro container has:
 
@@ -116,22 +126,49 @@ assertion refer back to an earlier step explicitly.
 
 ## Adding a new distro
 
-1. Create `e2e/Dockerfile.<distro>` using the existing two as a
-   template. Multi-stage build: copy `cmd/jitenv` and `e2e/seed` from
-   the build stage into the runtime stage.
-2. The runtime image MUST install:
+The default model is **install from the goreleaser artefact**, not
+build-from-source. We only keep one source-build image
+(`alpine-source`) so the musl Go build path stays exercised against
+HEAD; everything else mirrors what real users install.
+
+1. Pick the artefact format your distro consumes from `dist/` after
+   `make e2e-build-artifacts`:
+   - `.deb` for Debian / Ubuntu derivatives — `dpkg -i`
+   - `.rpm` for Fedora / RHEL / openSUSE derivatives — `rpm -i` (or
+     `dnf install ./pkg.rpm`)
+   - `.tar.gz` for distros without a goreleaser nfpms format
+     (Alpine, Arch); extract and lay the contents out to match the
+     deb/rpm paths so install-layout scenarios stay portable
+2. Create `e2e/Dockerfile.<distro>` modelled on the closest existing
+   one. Use a small `helper-build` stage to compile
+   `e2e/seed` and `e2e/cmd/unlock` (those are NOT shipped by the
+   package). Then in the runtime stage:
+   - `COPY dist/jitenv_*_linux_${TARGETARCH}.<ext> /opt/pkg/`
+   - install via the distro's package manager
+   - keep the artefact under `/opt/pkg/` so install-layout scenarios
+     can re-run `dpkg -i` / `rpm -i` / `rpm -e` at runtime to capture
+     postinstall / preremove output without rebuilding the image
+3. The runtime image MUST install:
    - `bash`, `zsh`, `ca-certificates`, `curl`, `tini`, `coreutils`,
-     `procps`
-   - `script(1)` — bsdutils on Debian, util-linux on Alpine
-3. Provision a non-root `jitenv` user (uid 1000) with `~/.config/jitenv/`
-   and `~/scripts/` pre-created (mode 0700).
-4. Add a `<distro>:` service to `e2e/docker-compose.yml`. Mount
+     `procps` (or `procps-ng` on Fedora)
+   - `script(1)` — bsdutils on Debian, util-linux on Alpine /
+     Fedora — only if a future scenario adds back a PTY-driven step
+4. Provision a non-root `jitenv` user (uid 1000) with
+   `~/.config/jitenv/` and `~/scripts/` pre-created (mode 0700).
+5. Add a `<distro>:` service to `e2e/docker-compose.yml`. Mount
    `/tmp` as tmpfs owned by uid 1000 so `agent.DefaultPaths()` lands
    somewhere fresh per `make e2e-up`.
-5. The new service's healthcheck should run `jitenv version` — that
-   way a broken cross-compile fails the stack startup, not the
-   first scenario.
-6. Bump `service:` in any new scenarios to point at it.
+6. The new service's healthcheck should run `jitenv version` — that
+   way a broken artefact fails the stack startup, not the first
+   scenario.
+7. Add an `install-layout-<distro>.yaml` scenario alongside the
+   existing ones if you want layout / postinstall coverage.
+8. Bump `service:` in any new functional scenarios to point at it.
+
+If you need a true source-build image (e.g. to validate a new libc
+combination at HEAD before the next release), follow the
+`alpine-source` template — it has no dependency on `dist/` and is
+useful for "does it even compile" smoke tests.
 
 ## Adding a new source backend
 

--- a/e2e/cmd/unlock/main.go
+++ b/e2e/cmd/unlock/main.go
@@ -13,9 +13,11 @@
 // `jitenv-e2e-unlock`, not `jitenv`. The helper would then re-enter
 // itself with `__agent ...` flags and crash. So this command does the
 // daemon spawn inline against the path of the real `jitenv` binary
-// (configurable via -jitenv-bin, default /usr/local/bin/jitenv). The
-// rest — pipe handover, Setsid double-fork, socket-presence wait —
-// is copied from SpawnDaemon.
+// (configurable via -jitenv-bin; resolved via $PATH when unset, so
+// the same helper works against /usr/bin/jitenv (the deb/rpm install
+// path) and /usr/local/bin/jitenv (the source-build path)). The rest
+// — pipe handover, Setsid double-fork, socket-presence wait — is
+// copied from SpawnDaemon.
 //
 // We deliberately do NOT add a `--passphrase-fd` flag to the real
 // `jitenv unlock` to avoid weakening its UX contract; the e2e harness
@@ -42,9 +44,17 @@ func main() {
 		passphrase = flag.String("passphrase", "", "passphrase (or use -passphrase-stdin)")
 		stdinPW    = flag.Bool("passphrase-stdin", false, "read passphrase from stdin (newline-terminated)")
 		idle       = flag.String("idle", "30m", "agent idle timeout")
-		jitenvBin  = flag.String("jitenv-bin", "/usr/local/bin/jitenv", "path to the jitenv binary to spawn as the daemon")
+		jitenvBin  = flag.String("jitenv-bin", "", "path to the jitenv binary to spawn as the daemon (default: resolved via $PATH)")
 	)
 	flag.Parse()
+
+	if *jitenvBin == "" {
+		p, err := exec.LookPath("jitenv")
+		if err != nil {
+			die("locate jitenv: %v (set -jitenv-bin to override)", err)
+		}
+		*jitenvBin = p
+	}
 
 	pw := []byte(*passphrase)
 	if *stdinPW {

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,8 +1,9 @@
 # jitenv e2e stack. Bring up with `make e2e-up`.
 #
-# Two distros (debian-glibc, alpine-musl) sit alongside a LocalStack
-# instance for the AWS Secrets Manager source. The harness runs on
-# the host and shells into a chosen service via `docker compose exec`.
+# Three install-from-package distros (debian-glibc deb, fedora-glibc rpm,
+# alpine-musl tar.gz) plus one source-built alpine image so the musl
+# build path against current HEAD is still exercised. All install
+# variants depend on `dist/` being populated by `make e2e-build-artifacts`.
 #
 # All services are unprivileged. The runtime dir for jitenv falls back
 # to /tmp/jitenv-<uid> automatically (see internal/agent/paths.go).
@@ -10,9 +11,8 @@
 services:
   debian:
     build:
-      # Build context is the repo root so the Dockerfile can `COPY .`
-      # without a subtree-mount; this keeps the e2e image self-contained
-      # and means CI reproduction needs nothing more than `docker compose build`.
+      # Build context is the repo root so the Dockerfile can `COPY dist/...`
+      # and reach the snapshot .deb produced by goreleaser.
       context: ..
       dockerfile: e2e/Dockerfile.debian
     image: jitenv-e2e-debian
@@ -29,12 +29,44 @@ services:
       JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
       LOCALSTACK_HOSTNAME: localstack
 
+  fedora:
+    build:
+      context: ..
+      dockerfile: e2e/Dockerfile.fedora
+    image: jitenv-e2e-fedora
+    container_name: jitenv-e2e-fedora
+    init: true
+    tmpfs:
+      - /tmp:exec,uid=1000,gid=1000
+    depends_on:
+      localstack:
+        condition: service_healthy
+    environment:
+      JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
+      LOCALSTACK_HOSTNAME: localstack
+
   alpine:
     build:
       context: ..
       dockerfile: e2e/Dockerfile.alpine
     image: jitenv-e2e-alpine
     container_name: jitenv-e2e-alpine
+    init: true
+    tmpfs:
+      - /tmp:exec,uid=1000,gid=1000
+    depends_on:
+      localstack:
+        condition: service_healthy
+    environment:
+      JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
+      LOCALSTACK_HOSTNAME: localstack
+
+  alpine-source:
+    build:
+      context: ..
+      dockerfile: e2e/Dockerfile.alpine-source
+    image: jitenv-e2e-alpine-source
+    container_name: jitenv-e2e-alpine-source
     init: true
     tmpfs:
       - /tmp:exec,uid=1000,gid=1000

--- a/e2e/scenarios/install-layout-alpine.yaml
+++ b/e2e/scenarios/install-layout-alpine.yaml
@@ -1,0 +1,51 @@
+name: install-layout-alpine
+description: |
+  Asserts the goreleaser .tar.gz install layout once extracted into the
+  same paths used by the .deb / .rpm. The tar.gz ships only the binary,
+  snippets, and docs - no postinstall / preremove scripts - so this
+  scenario covers layout only; postinstall / preremove are covered by
+  the debian and fedora variants.
+
+service: alpine
+user: jitenv
+
+steps:
+  - name: jitenv-version
+    exec: jitenv version
+  - name: assert-version-ok
+    assert_exit_code: 0
+
+  - name: jitenv-binary-path
+    exec: command -v jitenv
+  - name: assert-binary-path
+    assert_stdout_equals: "/usr/bin/jitenv"
+
+  - name: bash-snippet-exists
+    exec: test -f /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-snippet
+    assert_exit_code: 0
+
+  - name: zsh-snippet-exists
+    exec: test -f /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-snippet
+    assert_exit_code: 0
+
+  - name: bash-snippet-matches-hook
+    exec: diff -u <(jitenv hook bash) /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-match
+    assert_exit_code: 0
+
+  - name: zsh-snippet-matches-hook
+    exec: diff -u <(jitenv hook zsh) /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-match
+    assert_exit_code: 0
+
+  - name: license-doc-exists
+    exec: test -f /usr/share/doc/jitenv/LICENSE
+  - name: assert-license
+    assert_exit_code: 0
+
+  - name: readme-doc-exists
+    exec: test -f /usr/share/doc/jitenv/README.md
+  - name: assert-readme
+    assert_exit_code: 0

--- a/e2e/scenarios/install-layout-debian.yaml
+++ b/e2e/scenarios/install-layout-debian.yaml
@@ -1,0 +1,98 @@
+name: install-layout-debian
+description: |
+  Asserts the goreleaser .deb install layout: jitenv binary at /usr/bin,
+  snippets at /usr/share/jitenv/snippets/, docs at /usr/share/doc/jitenv/.
+  Re-runs the package install at scenario time to capture the postinstall
+  script's stdout, then exercises a real removal to capture preremove.
+  An "upgrade" install (dpkg -i over an existing version) must still run
+  postinstall but the preremove path must stay silent.
+
+service: debian
+user: jitenv
+
+steps:
+  # Reset to a known-good state. A prior failed run may have left the
+  # package removed (docs gone) or partially upgraded (dpkg -i over the
+  # same version doesn't restore deleted files). Purge first so the
+  # subsequent install always lays every file down fresh.
+  - name: ensure-installed
+    user: root
+    exec: dpkg --purge jitenv >/dev/null 2>&1; dpkg -i /opt/pkg/jitenv.deb >/dev/null 2>&1
+
+  - name: jitenv-version
+    exec: jitenv version
+  - name: assert-version-ok
+    assert_exit_code: 0
+
+  - name: jitenv-binary-path
+    exec: command -v jitenv
+  - name: assert-binary-path
+    assert_stdout_equals: "/usr/bin/jitenv"
+
+  - name: bash-snippet-exists
+    exec: test -f /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-snippet
+    assert_exit_code: 0
+
+  - name: zsh-snippet-exists
+    exec: test -f /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-snippet
+    assert_exit_code: 0
+
+  # The shipped snippet must be byte-identical to what `jitenv hook bash`
+  # emits today; otherwise users get drift between `hook install` and a
+  # source-the-snippet workflow.
+  - name: bash-snippet-matches-hook
+    exec: diff -u <(jitenv hook bash) /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-match
+    assert_exit_code: 0
+
+  - name: zsh-snippet-matches-hook
+    exec: diff -u <(jitenv hook zsh) /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-match
+    assert_exit_code: 0
+
+  - name: license-doc-exists
+    exec: test -f /usr/share/doc/jitenv/LICENSE
+  - name: assert-license
+    assert_exit_code: 0
+
+  - name: readme-doc-exists
+    exec: test -f /usr/share/doc/jitenv/README.md
+  - name: assert-readme
+    assert_exit_code: 0
+
+  # Postinstall message: the package is already installed in the image,
+  # so re-installing is the dpkg "upgrade" path - postinstall still runs
+  # and prints the activation hint.
+  - name: dpkg-reinstall
+    user: root
+    exec: dpkg -i /opt/pkg/jitenv.deb 2>&1
+  - name: assert-postinstall-hint
+    assert_stdout_contains: "jitenv hook install"
+
+  # Preremove on upgrade must stay silent: dpkg -i over an existing
+  # version invokes preremove with arg "upgrade", which the script
+  # short-circuits. "NOT removed automatically" is the unique
+  # preremove-only sentence (postinstall doesn't contain it).
+  - name: assert-preremove-silent-on-upgrade
+    target: dpkg-reinstall
+    assert_stdout_not_contains: "NOT removed automatically"
+
+  # Real removal: dpkg -r invokes preremove with arg "remove", which
+  # prints the manual-cleanup reminder.
+  - name: dpkg-remove
+    user: root
+    exec: dpkg -r jitenv 2>&1
+  - name: assert-preremove-reminder
+    assert_stdout_contains: "NOT removed automatically"
+  - name: assert-preremove-mentions-bashrc
+    target: dpkg-remove
+    assert_stdout_contains: ".bashrc"
+
+  # Reinstall so subsequent scenarios on this image are unaffected.
+  - name: dpkg-reinstall-after-remove
+    user: root
+    exec: dpkg -i /opt/pkg/jitenv.deb
+  - name: assert-reinstall-ok
+    assert_exit_code: 0

--- a/e2e/scenarios/install-layout-fedora.yaml
+++ b/e2e/scenarios/install-layout-fedora.yaml
@@ -1,0 +1,92 @@
+name: install-layout-fedora
+description: |
+  Asserts the goreleaser .rpm install layout: jitenv binary at /usr/bin,
+  snippets at /usr/share/jitenv/snippets/, docs at /usr/share/doc/jitenv/.
+  Re-runs the package install at scenario time to capture the postinstall
+  script's stdout, then exercises a real removal to capture preremove.
+  An "upgrade" install (rpm -U over an existing version) must still run
+  postinstall but the preremove path must stay silent.
+
+service: fedora
+user: jitenv
+
+steps:
+  # Reset to a known-good state. A prior failed run may have left the
+  # package erased. rpm -e ignores "not installed" via the || true so
+  # the subsequent install always lays every file down fresh.
+  - name: ensure-installed
+    user: root
+    exec: rpm -e jitenv >/dev/null 2>&1 || true; rpm -i /opt/pkg/jitenv.rpm >/dev/null 2>&1
+
+  - name: jitenv-version
+    exec: jitenv version
+  - name: assert-version-ok
+    assert_exit_code: 0
+
+  - name: jitenv-binary-path
+    exec: command -v jitenv
+  - name: assert-binary-path
+    assert_stdout_equals: "/usr/bin/jitenv"
+
+  - name: bash-snippet-exists
+    exec: test -f /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-snippet
+    assert_exit_code: 0
+
+  - name: zsh-snippet-exists
+    exec: test -f /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-snippet
+    assert_exit_code: 0
+
+  - name: bash-snippet-matches-hook
+    exec: diff -u <(jitenv hook bash) /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-match
+    assert_exit_code: 0
+
+  - name: zsh-snippet-matches-hook
+    exec: diff -u <(jitenv hook zsh) /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-match
+    assert_exit_code: 0
+
+  - name: license-doc-exists
+    exec: test -f /usr/share/doc/jitenv/LICENSE
+  - name: assert-license
+    assert_exit_code: 0
+
+  - name: readme-doc-exists
+    exec: test -f /usr/share/doc/jitenv/README.md
+  - name: assert-readme
+    assert_exit_code: 0
+
+  # Postinstall message on an upgrade-style reinstall: rpm -U
+  # --replacepkgs runs the preremove of the existing copy with arg 1
+  # (upgrade) and the postinstall of the new copy.
+  - name: rpm-reinstall
+    user: root
+    exec: rpm -U --replacepkgs /opt/pkg/jitenv.rpm 2>&1
+  - name: assert-postinstall-hint
+    assert_stdout_contains: "jitenv hook install"
+
+  # Preremove on upgrade must stay silent. "NOT removed automatically"
+  # is the unique preremove-only sentence (postinstall doesn't contain it).
+  - name: assert-preremove-silent-on-upgrade
+    target: rpm-reinstall
+    assert_stdout_not_contains: "NOT removed automatically"
+
+  # Real removal: rpm -e invokes preremove with arg 0, which prints
+  # the manual-cleanup reminder.
+  - name: rpm-remove
+    user: root
+    exec: rpm -e jitenv 2>&1
+  - name: assert-preremove-reminder
+    assert_stdout_contains: "NOT removed automatically"
+  - name: assert-preremove-mentions-bashrc
+    target: rpm-remove
+    assert_stdout_contains: ".bashrc"
+
+  # Reinstall so subsequent scenarios on this image are unaffected.
+  - name: rpm-reinstall-after-remove
+    user: root
+    exec: rpm -i /opt/pkg/jitenv.rpm
+  - name: assert-reinstall-ok
+    assert_exit_code: 0


### PR DESCRIPTION
Closes #53.

## Summary

The e2e harness (#44) built jitenv from source inside the test images and copied the binary straight to \`/usr/local/bin/jitenv\`. That validated the Go build and libc round-trip but bypassed all goreleaser packaging output (deb, rpm, tar.gz, postinstall/preremove scripts, install layout).

This PR switches the test images to install jitenv the same way users do, adds Fedora to broaden coverage to the rpm path, keeps one source-build image so the musl source path stays exercised, and adds an \`install-layout-*.yaml\` scenario per distro that asserts the goreleaser output lands where it should.

## Changes

### Build pipeline
- **\`Makefile\`** — new \`e2e-build-artifacts\` target. Uses Make-style timestamp dependency: \`dist/.snapshot-stamp\` is rebuilt only when any source file is newer, so re-running \`make e2e-build\` says \"Nothing to be done\" if \`dist/\` is current. The stamp file contains the producing commit for diagnostics.
- \`e2e-build\` (and so \`e2e-up\`) now depend on \`e2e-build-artifacts\`.

### Distro images
- **\`e2e/Dockerfile.debian\`** — drops the \`golang\` build stage for the main binary; \`dpkg -i\` of the snapshot deb. Removes \`debian:bookworm-slim\`'s \`dpkg.cfg.d/docker\` path-exclude so package docs land on disk. Helpers (\`jitenv-e2e-seed\`, \`jitenv-e2e-unlock\`) stay in a small \`helper-build\` stage.
- **\`e2e/Dockerfile.fedora\`** — new, \`fedora:40\`, installs via \`rpm -i\`. Adds \`diffutils\` for the snippet-equality assertion.
- **\`e2e/Dockerfile.alpine\`** — replaced; extracts the snapshot tar.gz into the deb/rpm layout (\`/usr/bin/jitenv\`, \`/usr/share/jitenv/snippets/...\`, \`/usr/share/doc/jitenv/...\`).
- **\`e2e/Dockerfile.alpine-source\`** — old \`Dockerfile.alpine\`, kept so the musl source-build of HEAD still has coverage.
- **\`e2e/docker-compose.yml\`** — adds \`fedora\` and \`alpine-source\` services.

### Helper portability
- **\`e2e/cmd/unlock/main.go\`** — \`-jitenv-bin\` defaults to \`exec.LookPath(\"jitenv\")\` so the same helper works against \`/usr/bin/jitenv\` (deb/rpm) and \`/usr/local/bin/jitenv\` (source build).

### New scenarios
- **\`e2e/scenarios/install-layout-{debian,fedora,alpine}.yaml\`** — one per distro:
  1. \`ensure-installed\` (root) — purge + install (deb) or erase + install (rpm); recovers from any partially-removed prior run. Skipped on alpine (it's a tar.gz extract baked into the image).
  2. Layout assertions: \`command -v jitenv == /usr/bin/jitenv\`; snippets at \`/usr/share/jitenv/snippets/{bash,zsh}.sh\`; \`diff -u <(jitenv hook bash) /usr/share/jitenv/snippets/bash.sh\` (and zsh) returns 0; docs at \`/usr/share/doc/jitenv/{LICENSE,README.md}\`.
  3. (deb/rpm only) Re-install via \`dpkg -i\` / \`rpm -U --replacepkgs\`; postinstall stdout must contain \`jitenv hook install\` and **must not** contain \`NOT removed automatically\` (preremove silent on upgrade).
  4. (deb/rpm only) Real removal via \`dpkg -r\` / \`rpm -e\`; preremove stdout must contain \`NOT removed automatically\` and \`.bashrc\` (manual-cleanup hint).
  5. Final reinstall so the container is left in known-good state.

No new step type was needed — postinstall/preremove output is captured via plain \`exec\` (\`dpkg -i ... 2>&1\`) and asserted with the existing \`assert_stdout_contains\` / \`assert_stdout_not_contains\`.

### Docs
- **\`e2e/README.md\`** — updated stack table and the \"Adding a new distro\" section for the install-from-package model.

## Verification

- \`make e2e-build-artifacts\` produces deb/rpm/tar.gz under \`dist/\`. Re-running prints \"Nothing to be done.\".
- \`docker compose -f e2e/docker-compose.yml config\` parses cleanly.
- \`docker compose -f e2e/docker-compose.yml build\` succeeds for all four distro services.
- All five containers come up healthy under \`make e2e-up\`.
- All three new install-layout scenarios pass on debian, fedora, alpine (run twice to confirm idempotency).
- Existing \`unlock-and-run-local.yaml\` and \`localstack-fetch.yaml\` still pass on the new debian image.
- \`alpine-source\` smoke-tested (\`jitenv version\`, \`command -v jitenv == /usr/local/bin/jitenv\`).
- \`go test ./...\` and \`go vet ./...\` green; \`gofmt -l .\` clean.

## Out of scope (note in #53)
- cosign / signing verification in e2e.
- Homebrew / \`.apk\` repository plumbing.
- Adding \`apk\` to \`nfpms.formats\`.
- CI workflow integration (\`.github/workflows\`).

## Rough edges
- **debian-slim path-exclude.** \`debian:bookworm-slim\` ships \`/etc/dpkg/dpkg.cfg.d/docker\` which strips \`/usr/share/doc/*\` from every install. The Dockerfile removes that file before \`apt-get install\`; without it the .deb correctly contains the docs but they wouldn't land on disk.
- **\`dpkg -i\` over same version doesn't restore deleted files.** If a prior run left \`/usr/share/doc/jitenv/{LICENSE,README.md}\` deleted (because \`dpkg -r\` was the last step), a subsequent \`dpkg -i\` of the same .deb won't restore them — dpkg considers the package current. The scenario therefore does \`dpkg --purge; dpkg -i\` as the recovery step. Same shape on Fedora (\`rpm -e || true; rpm -i\`).
- **Helper build stage retained on debian.** The issue suggested dropping the golang build stage entirely; I kept a small \`helper-build\` stage because \`jitenv-e2e-seed\` and \`jitenv-e2e-unlock\` are not part of any package and still need to be compiled. The main \`jitenv\` binary IS dropped from the build stage and comes from the deb. Pre-building helpers on the host and \`COPY\`ing them in is a possible follow-up.

## Test plan
- [x] \`make e2e-build-artifacts\` builds + skips appropriately.
- [x] \`docker compose build\` succeeds for all four services.
- [x] \`make e2e-up\` brings the stack up healthy.
- [x] All install-layout scenarios pass on debian, fedora, alpine.
- [x] Existing scenarios still pass on the new debian image.
- [x] \`go test ./...\` green.
- [x] Reviewer: \`make e2e-up && make e2e-run SCENARIO=install-layout-debian.yaml\` and confirm the run-dir layout is what you'd want when triaging a packaging regression.