### PR TITLE
fix(hook): non-interactive UX, stale docs, dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,11 @@ jitenv is a 3-process design that keeps secrets out of the parent shell:
 The bash/zsh snippets switch on the exit code of `jitenv is-mapped`:
 - **0** → mapped, route through `jitenv run`.
 - **1** → not mapped, run normally.
-- **2** → agent unreachable. The hook prints a red 10s warning and lets Ctrl-C abort. This is the "agent is locked" UX path; do not collapse it into 1.
+- **2** → config unreadable. Run normally — no env injection, no warning. Treated like an unmapped path; only `JITENV_HOOK_DEBUG=1` reveals it.
 
-See `internal/cli/ismapped.go` for the exit-code contract and `bash.sh:74-100` for the dispatch.
+`jitenv is-mapped` reads the config directly and never contacts the agent, so exit 2 always means a missing/malformed `config.toml`, never an agent-down condition. The agent-down UX (red countdown, "Press Enter to skip, Ctrl+C to abort") lives in `internal/agentwarn/agentwarn.go` and only fires inside `jitenv run` / the cwd_glob shim — i.e. *after* `is-mapped` returned 0.
+
+See `internal/cli/ismapped.go` for the exit-code contract and `bash.sh` for the dispatch.
 
 ### Source plugin model
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ make test            # go test ./...
 make install         # installs to $PREFIX/bin (default ~/.local/bin)
 ```
 
-Go 1.22+ required.
+Go 1.25+ required (see `go.mod`).
 
 ## License
 

--- a/docs/shell-hook.md
+++ b/docs/shell-hook.md
@@ -52,11 +52,32 @@ bug:
 |---|---|---|
 | **0** | mapped | Re-run the command via `jitenv run` so the env vars are injected. |
 | **1** | not mapped | Run the command normally — no jitenv involvement. |
-| **2** | agent unreachable | Print a red 10-second warning. Ctrl+C aborts; otherwise the original command runs (with no env-var injection). This is the "agent is locked" UX path. |
+| **2** | config unreadable | Run the command normally — no env-var injection, no warning. A broken or missing config is treated like an unmapped path; the user sees nothing unless `JITENV_HOOK_DEBUG=1`. |
+
+`jitenv is-mapped` reads the config file directly and never contacts
+the agent, so an exit code 2 always means the on-disk config is
+missing or malformed. The agent-unreachable UX (red countdown, **Press
+Enter to skip, Ctrl+C to abort**) lives inside `jitenv run` and the
+cwd_glob shim — see `internal/agentwarn/agentwarn.go`. It only fires
+*after* `is-mapped` returned 0 and `jitenv run` then failed to reach
+the agent.
 
 You can see the dispatch in `internal/shell/snippets/bash.sh`. Set
 `JITENV_HOOK_DEBUG=1` in your shell to see which branch the trap
 took for each command.
+
+## Non-interactive use (CI, scripts)
+
+Two env-var knobs make the hook quiet in scripted contexts:
+
+- `JITENV_NO_NOTICE=1` suppresses the green `jitenv: injected N
+  variables` line that `jitenv run` and the shim print on success.
+  The conventional `CI=true` (set by GitHub Actions, GitLab CI,
+  CircleCI, Travis) has the same effect automatically.
+- `JITENV_HOOK_DELAY=0` skips the agent-down countdown. The countdown
+  is also auto-skipped when stdin is not a TTY, so piped or
+  redirected invocations never block — the warning line still prints
+  once so the failure mode is visible in logs.
 
 ## Bash internals: `extdebug` + DEBUG trap
 

--- a/internal/agentwarn/agentwarn.go
+++ b/internal/agentwarn/agentwarn.go
@@ -17,12 +17,19 @@ import (
 	"os/signal"
 	"strconv"
 	"time"
+
+	"golang.org/x/term"
 )
 
 // WarnAndWait paints the warning + countdown to stderr and returns
 // true when the user aborted via Ctrl+C (caller should not exec).
 // Returns false on Enter or timeout (caller should exec, possibly
 // without injected env vars).
+//
+// Skipped entirely when stdin is not a TTY: no human can press
+// Enter, so the countdown serves no purpose and only adds latency
+// to scripted / piped invocations. The warning line is still
+// printed once so the failure mode is visible in logs.
 func WarnAndWait(target string) bool {
 	const red = "\033[1;31m"
 	const reset = "\033[0m"
@@ -32,6 +39,13 @@ func WarnAndWait(target string) bool {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			total = n
 		}
+	}
+
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Fprintf(os.Stderr,
+			"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
+			red, target, reset)
+		return false
 	}
 
 	fmt.Fprintf(os.Stderr,

--- a/internal/agentwarn/agentwarn_test.go
+++ b/internal/agentwarn/agentwarn_test.go
@@ -1,0 +1,39 @@
+package agentwarn
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestWarnAndWait_NonTTYReturnsImmediately guards the non-interactive
+// short-circuit: stdin is a pipe in tests, so the function must exit
+// without spending any time in the per-second tick loop. Without this
+// short-circuit, scripted invocations would block JITENV_HOOK_DELAY
+// seconds (default 10) on every agent-down call (#64).
+func TestWarnAndWait_NonTTYReturnsImmediately(t *testing.T) {
+	t.Setenv("JITENV_HOOK_DELAY", "10")
+
+	// Replace stdin with a pipe (definitely not a TTY) for the
+	// duration of the test, then restore.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	prev := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = prev })
+
+	start := time.Now()
+	aborted := WarnAndWait("/some/script.sh")
+	elapsed := time.Since(start)
+
+	if aborted {
+		t.Fatal("expected aborted=false on the non-TTY skip path")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("non-TTY skip should be instant; took %s", elapsed)
+	}
+}

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -29,6 +29,30 @@ func buildBinary(t *testing.T) string {
 	return out
 }
 
+// filterEnvKeys returns env with any "KEY=..." entries whose KEY is
+// in keys removed. Used to strip CI / JITENV_NO_NOTICE before
+// spawning child processes so tests can exercise the notice path
+// even under GitHub Actions (which sets CI=true).
+func filterEnvKeys(env []string, keys ...string) []string {
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		i := strings.IndexByte(kv, '=')
+		if i < 0 {
+			out = append(out, kv)
+			continue
+		}
+		if _, skip := drop[kv[:i]]; skip {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
 func TestRunInjectsEnvAndExecs(t *testing.T) {
 	bin := buildBinary(t)
 
@@ -105,7 +129,7 @@ func TestRunInjectsEnvAndExecs(t *testing.T) {
 	// Sanity: is-mapped via binary. Note: is-mapped reads config
 	// directly (no agent dial), so JITENV_CONFIG has to point at the
 	// test fixture for the lookup to find the script.
-	subprocEnv := append(os.Environ(),
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
 		"XDG_RUNTIME_DIR="+runtimeDir,
 		"JITENV_CONFIG="+cfgPath,
 	)
@@ -322,7 +346,10 @@ func TestRunPreRunNotice(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	subprocEnv := append(os.Environ(),
+	// CI / JITENV_NO_NOTICE suppress the notice (see runnotice.Enabled);
+	// strip them so this test exercises the on path even when run under
+	// GitHub Actions or with the var set in the developer's shell.
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
 		"XDG_RUNTIME_DIR="+runtimeDir,
 		"JITENV_CONFIG="+cfgPath,
 	)

--- a/internal/runnotice/runnotice.go
+++ b/internal/runnotice/runnotice.go
@@ -18,13 +18,30 @@ const (
 	ansiReset = "\033[0m"
 )
 
-// Enabled loads the on-disk config and returns whether the pre-run
-// notice should be printed. The flag is plaintext TOML, so no master
-// key is needed. The notice is on by default; only an explicit
-// `pre_run_notice = false` suppresses it. Config-load errors fall
-// back to off so a broken config never starts surfacing surprise
-// output to the user's terminal.
+// Enabled returns whether the pre-run notice should be printed.
+//
+// Resolution order, first match wins:
+//
+//  1. JITENV_NO_NOTICE set to a non-empty value → off. Per-invocation
+//     escape hatch for scripts and one-off commands; no config edit
+//     required.
+//  2. CI set to a non-empty value → off. Convention used by GitHub
+//     Actions, GitLab CI, CircleCI, Travis — pipelines that pipe
+//     credentials through jitenv don't want a stderr line per call.
+//  3. agent.pre_run_notice in config.toml. Default is on (the helper
+//     PreRunNoticeEnabled returns true for a missing key); explicit
+//     false suppresses.
+//  4. Config-load failure → off. A broken config should never start
+//     surfacing surprise output to the user's terminal.
+//
+// The flag is plaintext TOML, so no master key is needed.
 func Enabled() bool {
+	if os.Getenv("JITENV_NO_NOTICE") != "" {
+		return false
+	}
+	if os.Getenv("CI") != "" {
+		return false
+	}
 	cfgPath, err := config.Resolve(os.Getenv("JITENV_CONFIG"))
 	if err != nil {
 		return false

--- a/internal/runnotice/runnotice_test.go
+++ b/internal/runnotice/runnotice_test.go
@@ -2,8 +2,12 @@ package runnotice
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gv/jitenv/internal/config"
 )
 
 func TestWrite_TTYHasAnsi(t *testing.T) {
@@ -43,5 +47,52 @@ func TestWrite_SingularPlural(t *testing.T) {
 	Write(&buf, 2, false)
 	if got := buf.String(); got != "jitenv: injected 2 variables\n" {
 		t.Fatalf("plural form for 2: %q", got)
+	}
+}
+
+// TestEnabled_EnvOverrides drives the JITENV_NO_NOTICE / CI escape
+// hatches so CI runs and ad-hoc scripts can suppress the notice
+// without editing a persistent config (#60).
+func TestEnabled_EnvOverrides(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := config.InitNew(cfgPath, []byte("hunter2-runnotice")); err != nil {
+		t.Fatalf("InitNew: %v", err)
+	}
+	t.Setenv("JITENV_CONFIG", cfgPath)
+
+	t.Setenv("CI", "")
+	t.Setenv("JITENV_NO_NOTICE", "")
+	if !Enabled() {
+		t.Fatal("baseline: missing pre_run_notice key should default to enabled")
+	}
+
+	t.Setenv("JITENV_NO_NOTICE", "1")
+	if Enabled() {
+		t.Error("JITENV_NO_NOTICE=1 must suppress the notice")
+	}
+	t.Setenv("JITENV_NO_NOTICE", "")
+
+	t.Setenv("CI", "true")
+	if Enabled() {
+		t.Error("CI=true must suppress the notice")
+	}
+	t.Setenv("CI", "")
+}
+
+// TestEnabled_BrokenConfigIsSilent guards the fallback: a missing or
+// unparseable config must not produce surprise stderr output.
+func TestEnabled_BrokenConfigIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("not valid = toml = ["), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Setenv("JITENV_CONFIG", cfgPath)
+	t.Setenv("JITENV_NO_NOTICE", "")
+	t.Setenv("CI", "")
+
+	if Enabled() {
+		t.Error("broken config must fall back to off")
 	}
 }

--- a/internal/shell/hook_e2e_test.go
+++ b/internal/shell/hook_e2e_test.go
@@ -169,9 +169,7 @@ eval "$(%s/jitenv hook bash)"
 		"XDG_RUNTIME_DIR="+runtimeDir,
 		"JITENV_HOOK_DELAY=1",
 	)
-	start := time.Now()
 	out, err := cmd.CombinedOutput()
-	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("bash run: %v\noutput=%s", err, out)
 	}
@@ -180,11 +178,10 @@ eval "$(%s/jitenv hook bash)"
 		t.Errorf("expected red 'agent is not loaded' warning; got:\n%s", got)
 	}
 	if !strings.Contains(got, "RAN") {
-		t.Errorf("expected the script to still run after the delay; got:\n%s", got)
+		t.Errorf("expected the script to still run; got:\n%s", got)
 	}
-	if elapsed < 800*time.Millisecond {
-		t.Errorf("expected the hook to wait ~1s; only %s elapsed", elapsed)
-	}
+	// Stdin is a pipe (bash -c), so WarnAndWait short-circuits the
+	// countdown — we no longer assert on elapsed time. See #64.
 }
 
 // TestBashHookAgentDownSilentForUnmapped is the regression for the

--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -296,11 +296,9 @@ fakecmd
 	))
 	cmd.Env = append(os.Environ(),
 		"XDG_RUNTIME_DIR="+runtimeDir,
-		"JITENV_HOOK_DELAY=1", // shrink the 10s wait
+		"JITENV_HOOK_DELAY=1",
 	)
-	start := time.Now()
 	out, err := cmd.CombinedOutput()
-	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("bash run: %v\noutput=%s", err, out)
 	}
@@ -309,11 +307,10 @@ fakecmd
 		t.Errorf("expected red 'agent is not loaded' warning; got:\n%s", got)
 	}
 	if !strings.Contains(got, "RAN") {
-		t.Errorf("expected fakecmd to still run after the countdown; got:\n%s", got)
+		t.Errorf("expected fakecmd to still run; got:\n%s", got)
 	}
-	if elapsed < 800*time.Millisecond {
-		t.Errorf("expected the shim to wait ~1s; only %s elapsed", elapsed)
-	}
+	// Stdin is a pipe (bash -c), so WarnAndWait short-circuits the
+	// countdown — we no longer assert on elapsed time. See #64.
 }
 
 // TestBashWrapperOutsideMappedDir exercises the "outside" case: cd

--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -215,7 +215,10 @@ __jitenv_chpwd
 fakecmd
 `, binDir, fakeBin, cfgPath, binDir, projectDir,
 	))
-	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	// CI / JITENV_NO_NOTICE auto-suppress the notice; strip them so
+	// this test exercises the on path even when run under GitHub
+	// Actions.
+	cmd.Env = append(filterEnv(os.Environ(), "CI", "JITENV_NO_NOTICE"), "XDG_RUNTIME_DIR="+runtimeDir)
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -228,6 +231,30 @@ fakecmd
 	if !strings.Contains(stderr.String(), "jitenv: injected 1 variable") {
 		t.Errorf("expected pre-run notice on stderr; got:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
 	}
+}
+
+// filterEnv returns env with any "KEY=..." entries whose KEY is in
+// keys removed. Mirrors filterEnvKeys in run_e2e_test.go; kept
+// separate to avoid an exported test-helper dependency between
+// packages.
+func filterEnv(env []string, keys ...string) []string {
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		i := strings.IndexByte(kv, '=')
+		if i < 0 {
+			out = append(out, kv)
+			continue
+		}
+		if _, skip := drop[kv[:i]]; skip {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // TestBashWrapperAgentDownWarns is the locked-agent UX for cwd_glob:

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -77,44 +77,11 @@ PROMPT_COMMAND="__jitenv_chpwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 
 shopt -s extdebug
 
-# Print the "agent not loaded" warning in red and count down 10 seconds
-# before returning. Ctrl+C during the countdown is caught and converted
-# into a non-zero return so the caller can cancel the original command.
-__jitenv_warn_no_agent() {
-    local target="$1"
-    local aborted=0
-    trap 'aborted=1' INT
-
-    local red=$'\033[1;31m'
-    local reset=$'\033[0m'
-
-    printf '%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n' \
-        "$red" "$target" "$reset" >&2
-    printf '%sWill run the command anyway in 10s. Press Enter to skip, Ctrl+C to abort.%s\n' \
-        "$red" "$reset" >&2
-
-    local total=${JITENV_HOOK_DELAY:-10}
-    local i
-    for ((i=total; i>0; i--)); do
-        (( aborted )) && break
-        printf '\r%s  %2ds remaining %s' "$red" "$i" "$reset" >&2
-        # `read -t 1 -n 1` waits up to one second for one keystroke.
-        # On Enter (or any key) it returns 0 and we skip; on timeout
-        # it returns non-zero and we keep counting down.
-        if read -t 1 -n 1 -s -r -p "" 2>/dev/null; then
-            break
-        fi
-        (( aborted )) && break
-    done
-
-    trap - INT
-    if (( aborted )); then
-        printf '\n%saborted — command not executed.%s\n' "$red" "$reset" >&2
-        return 1
-    fi
-    printf '\n' >&2
-    return 0
-}
+# The agent-down "Press Enter to skip, Ctrl+C to abort" countdown is
+# implemented in Go (internal/agentwarn/agentwarn.go) and rendered by
+# `jitenv run` / the shim. Nothing in the shell hook needs to paint
+# it — the hook just routes through `jitenv run` and lets the Go side
+# handle the UX uniformly across path-mapped and cwd_glob flows.
 
 # Set JITENV_HOOK_DEBUG=1 to log each branch the trap takes.
 __jitenv_log() {

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -58,45 +58,11 @@ precmd_functions+=(__jitenv_chpwd)
 # Populate once at hook-load.
 __jitenv_chpwd
 
-# Warn loudly when the agent isn't reachable, count down 10 seconds,
-# and let Ctrl+C abort. Returns non-zero on abort so the caller's `&&`
-# short-circuits the actual command.
-__jitenv_warn_no_agent() {
-    emulate -L zsh
-    local target="$1"
-    local aborted=0
-    trap 'aborted=1' INT
-
-    local red=$'\033[1;31m'
-    local reset=$'\033[0m'
-
-    printf '%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n' \
-        "$red" "$target" "$reset" >&2
-    printf '%sWill run the command anyway in 10s. Press Enter to skip, Ctrl+C to abort.%s\n' \
-        "$red" "$reset" >&2
-
-    local total=${JITENV_HOOK_DELAY:-10}
-    local i
-    for ((i=total; i>0; i--)); do
-        (( aborted )) && break
-        printf '\r%s  %2ds remaining %s' "$red" "$i" "$reset" >&2
-        # zsh's read: -t timeout (seconds), -k 1 (one char), -s silent.
-        # Returns 0 if a key was read, non-zero on timeout — same shape
-        # as the bash version.
-        if read -t 1 -k 1 -s 2>/dev/null; then
-            break
-        fi
-        (( aborted )) && break
-    done
-
-    trap - INT
-    if (( aborted )); then
-        printf '\n%saborted — command not executed.%s\n' "$red" "$reset" >&2
-        return 1
-    fi
-    printf '\n' >&2
-    return 0
-}
+# The agent-down "Press Enter to skip, Ctrl+C to abort" countdown is
+# implemented in Go (internal/agentwarn/agentwarn.go) and rendered by
+# `jitenv run` / the shim. Nothing in the shell hook needs to paint
+# it — the hook just routes through `jitenv run` and lets the Go side
+# handle the UX uniformly across path-mapped and cwd_glob flows.
 
 # Set JITENV_HOOK_DEBUG=1 to log each branch the widget takes.
 __jitenv_log() {


### PR DESCRIPTION
Pools the v0.5.0 review follow-ups into one PR — all related to non-interactive UX, stale shell-hook documentation, and dead code from the \`is-mapped\` refactor.

Closes #58, #59, #60, #63, #64.

## Changes

### Docs (#58, #63)

- **\`docs/shell-hook.md\`** — exit-code table fixed: code 2 means \"config unreadable\" (run normally, no warning), not \"agent unreachable\". Added a paragraph pointing at \`internal/agentwarn\` as the actual home of the agent-down countdown. Added a new \"Non-interactive use (CI, scripts)\" section documenting \`JITENV_NO_NOTICE\` and \`JITENV_HOOK_DELAY=0\` knobs.
- **\`CLAUDE.md\`** — same exit-code-2 correction.
- **\`README.md\`** — \"Go 1.22+ required\" → \"Go 1.25+ required\" to match \`go.mod\`.

### Shell snippets (#59)

- **\`internal/shell/snippets/{bash,zsh}.sh\`** — deleted \`__jitenv_warn_no_agent\`. Dead code; bash version had a hardcoded \"10s\" message that contradicted \`JITENV_HOOK_DELAY\`. The countdown now lives in \`internal/agentwarn/agentwarn.go\` exclusively, painted by \`jitenv run\` and the cwd_glob shim.

### Pre-run notice (#60)

- **\`internal/runnotice/runnotice.go\`** — \`Enabled()\` short-circuits on \`JITENV_NO_NOTICE\` (explicit per-invocation opt-out) and \`CI\` (auto-detect for GitHub Actions, GitLab CI, CircleCI, Travis). No persistent config edit needed for ephemeral CI environments.

### Agent-down warning (#64)

- **\`internal/agentwarn/agentwarn.go\`** — \`WarnAndWait\` short-circuits when stdin isn't a TTY. Prints the warning line once so the failure mode is visible in logs, then returns immediately. No human can press Enter in a piped/scripted context, so the per-second countdown was pure latency.

## Tests

- **\`internal/runnotice/runnotice_test.go\`** — \`TestEnabled_EnvOverrides\` covers \`JITENV_NO_NOTICE\`, \`CI\`, and the default-on baseline; new \`TestEnabled_BrokenConfigIsSilent\` guards the malformed-config fallback.
- **\`internal/agentwarn/agentwarn_test.go\`** (new) — \`TestWarnAndWait_NonTTYReturnsImmediately\` pipes stdin and asserts \`WarnAndWait\` returns in <1s with \`JITENV_HOOK_DELAY=10\`.
- **\`internal/shell/hook_e2e_test.go\` / \`hook_wrapper_test.go\`** — two existing tests that asserted on the countdown's elapsed time updated to drop the timing assertion. They were exercising an implementation detail that's deliberately gone in non-TTY contexts. Warning-line presence and command-still-runs assertions remain.

## E2E coverage

Full e2e harness ran green against all 4 distro images (debian, alpine, alpine-source, fedora) plus LocalStack:

| Scenario | Result |
|---|---|
| \`unlock-and-run-local.yaml\` | ✅ pass |
| \`localstack-fetch.yaml\` | ✅ pass |
| \`install-layout-debian.yaml\` | ✅ pass |
| \`install-layout-fedora.yaml\` | ✅ pass |
| \`install-layout-alpine.yaml\` | ✅ pass |

## Test plan
- [x] \`make fmt vet tidy\` clean.
- [x] \`go test ./...\` green.
- [x] \`make build\` clean.
- [x] \`make e2e-up && make e2e-run SCENARIO=...\` for all 5 scenarios.
- [x] Reviewer (interactive bash): break your config, run a mapped script, confirm no warning + script runs (was the bug). Restore config, lock the agent, run a mapped script, confirm the red warning + countdown still appear.
- [x] Reviewer (CI / piped): \`JITENV_HOOK_DELAY=10 jitenv run ./mapped 2>/tmp/err < /dev/null\` returns immediately; \`/tmp/err\` contains the warning line.