### PR TITLE
ci: add macos-latest job to exercise darwin-specific code paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,35 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: release --snapshot --clean --skip=publish,sign
+
+  test-macos:
+    # Exercises the platform-specific paths that linux runners can't
+    # touch: peer_darwin.go (LOCAL_PEERCRED), os.TempDir() runtime-dir
+    # fallback, the Setsid double-fork on darwin. Without this the
+    # macOS port is "compiles" coverage only, so any syscall-level
+    # regression would only surface after release. See #61.
+    name: test (macos)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Download modules
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Test
+        # Skip the shell-* e2e suites: they shell out to bash with
+        # restricted PATHs and rely on GNU coreutils not present in
+        # the macOS runner image. The peer-cred / agent / run paths
+        # are the macOS-specific surface we actually want covered here.
+        run: go test -race -covermode=atomic ./internal/agent/... ./internal/agentwarn/... ./internal/cli/... ./internal/config/... ./internal/crypto/... ./internal/run/... ./internal/runnotice/... ./internal/sources/... ./internal/tui/... ./internal/version/...

--- a/internal/agent/daemonize_test.go
+++ b/internal/agent/daemonize_test.go
@@ -24,6 +24,21 @@ func buildBinary(t *testing.T) string {
 	return out
 }
 
+// shortRuntimeDir creates a per-test runtime directory under /tmp so the
+// Unix-socket path stays well under macOS's 104-byte sun_path limit.
+// t.TempDir() on macOS sits under /var/folders/.../T/TestName123/001/
+// which is ~90 chars before we even append jitenv/agent.sock, blowing
+// the limit and producing "bind: invalid argument".
+func shortRuntimeDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "jr-")
+	if err != nil {
+		t.Fatalf("mkdir tmp runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestSpawnDaemonEndToEnd(t *testing.T) {
 	if os.Getenv("CI_NO_BUILD") != "" {
 		t.Skip("skipping daemon e2e in CI_NO_BUILD")
@@ -51,11 +66,9 @@ func TestSpawnDaemonEndToEnd(t *testing.T) {
 		}
 	}()
 
-	// Per-test runtime dir.
-	runtimeDir := filepath.Join(dir, "runtime")
-	if err := os.MkdirAll(runtimeDir, 0700); err != nil {
-		t.Fatalf("mkdir runtime: %v", err)
-	}
+	// Per-test runtime dir under /tmp to stay under macOS's 104-byte
+	// sun_path limit for Unix sockets.
+	runtimeDir := shortRuntimeDir(t)
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 	paths, err := DefaultPaths()
 	if err != nil {

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -29,6 +29,21 @@ func buildBinary(t *testing.T) string {
 	return out
 }
 
+// shortRuntimeDir creates a per-test runtime directory under /tmp so
+// the Unix-socket path stays well under macOS's 104-byte sun_path
+// limit. t.TempDir() on macOS sits under /var/folders/.../T/...
+// which is ~90 chars before we even append jitenv/agent.sock,
+// blowing the limit and producing "bind: invalid argument".
+func shortRuntimeDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "jr-")
+	if err != nil {
+		t.Fatalf("mkdir tmp runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestRunInjectsEnvAndExecs(t *testing.T) {
 	bin := buildBinary(t)
 
@@ -71,8 +86,7 @@ func TestRunInjectsEnvAndExecs(t *testing.T) {
 	}
 
 	// Spawn the daemon.
-	runtimeDir := filepath.Join(dir, "runtime")
-	_ = os.MkdirAll(runtimeDir, 0700)
+	runtimeDir := shortRuntimeDir(t)
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 	paths, _ := agent.DefaultPaths()
 
@@ -195,8 +209,7 @@ func TestRunLocalBag(t *testing.T) {
 	}
 
 	// Spawn the daemon.
-	runtimeDir := filepath.Join(dir, "runtime")
-	_ = os.MkdirAll(runtimeDir, 0700)
+	runtimeDir := shortRuntimeDir(t)
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 	paths, _ := agent.DefaultPaths()
 
@@ -292,8 +305,7 @@ func TestRunPreRunNotice(t *testing.T) {
 		t.Fatalf("rename: %v", err)
 	}
 
-	runtimeDir := filepath.Join(dir, "runtime")
-	_ = os.MkdirAll(runtimeDir, 0700)
+	runtimeDir := shortRuntimeDir(t)
 	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
 	paths, _ := agent.DefaultPaths()
 


### PR DESCRIPTION
Closes #61.

## Summary

Adds a \`test-macos\` job to \`.github/workflows/ci.yml\` that runs on \`macos-latest\` and executes the Go test suite against the packages that actually have platform-sensitive code:

- \`internal/agent\` — \`peer_darwin.go\` (LOCAL_PEERCRED), \`SpawnDaemon\`, the agent socket lifecycle.
- \`internal/agentwarn\`, \`internal/run\`, \`internal/runnotice\` — TTY detection, stdin handling, syscall.Exec.
- \`internal/cli\`, \`internal/config\`, \`internal/crypto\`, \`internal/sources\`, \`internal/tui\`, \`internal/version\` — the rest of the surface, mostly portable but worth exercising on darwin once.

## Why

Until this PR, the CI matrix was \`ubuntu-latest\` only. The cross-compile step at \`ci.yml:59-62\` verifies darwin builds — but runs zero darwin tests. The agent's security boundary (UID-rejection on the socket) depends on \`peer_darwin.go\` working. Any syscall-level regression (wrong constant, wrong struct field offset, wrong socket level) would only surface after release, in the form of either crashes on every connection or — worse — silently allowing other UIDs to talk to the agent.

## Why not run \`./...\`

\`internal/shell\` is excluded. Those tests shell out to bash with a restricted PATH and depend on GNU coreutils (\`stat -c\`, etc.) that aren't in the macOS runner image. Running them on macos-latest would either flake or require porting all those e2e helpers to BSD-style coreutils — separate work, not blocking this PR. The peer-cred / agent / run packages are the real macOS-sensitive surface and they ARE covered here.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"\` — YAML parses cleanly.
- [x] Reviewer: confirm the new job appears in the Actions UI on the next push and goes green.