### PR TITLE
docs(release): document squash-merge policy for release-please

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,9 +5,10 @@ How releases are cut, how to verify them as a user, and how to recover when the 
 ## TL;DR — happy path
 
 1. Land changes on `main` using [Conventional Commits](https://www.conventionalcommits.org). At minimum, one `feat:`, `fix:`, `perf:`, `revert:`, or `docs:` commit must be present since the last release — `chore:`/`ci:`/`build:`/`refactor:`/`style:`/`test:` are CHANGELOG-hidden and won't trigger a release on their own.
-2. Within ~2 minutes, `release-please` opens (or updates) a `chore(main): release X.Y.Z` PR.
-3. Review the PR's `CHANGELOG.md` diff and merge it.
-4. The merge creates tag `vX.Y.Z` and fires `.github/workflows/release.yml`.
+2. **Merge PRs with squash-merge** (see [Merge policy](#merge-policy)). A plain merge commit causes release-please to attribute the same conventional-commit subject to both the merge commit and the feature commit, producing duplicate CHANGELOG entries.
+3. Within ~2 minutes, `release-please` opens (or updates) a `chore(main): release X.Y.Z` PR.
+4. Review the PR's `CHANGELOG.md` diff and merge it (also via squash, for the same reason).
+5. The merge creates tag `vX.Y.Z` and fires `.github/workflows/release.yml`.
 5. ~3–5 minutes later, the GitHub Release at `https://github.com/Galvill/jitenv/releases/tag/vX.Y.Z` carries:
    - `jitenv_X.Y.Z_linux_amd64.tar.gz` / `_arm64.tar.gz`
    - `jitenv_X.Y.Z_linux_amd64.deb` / `_arm64.deb`
@@ -22,6 +23,34 @@ unpacking — it prints a reminder telling the user to run
 cannot safely modify a user's `~/.bashrc`). `packaging/preremove.sh`
 prints the matching cleanup hint on uninstall, but stays silent on
 package upgrades.
+
+## Merge policy
+
+**Squash-merge only.** A plain merge commit's body inherits the
+incoming branch's commits, so release-please scans both the merge
+commit AND the underlying feature commit and attributes the same
+`feat:` / `fix:` subject to both — the v0.5.0 CHANGELOG had every
+PR show up twice for this reason ([#62](https://github.com/Galvill/jitenv/issues/62)).
+Squash flattens each PR to a single commit on `main` whose subject
+is the conv-commit, so each PR shows up exactly once.
+
+To enforce this, the repo settings must allow only squash-merge:
+
+```sh
+gh repo edit \
+  --enable-squash-merge \
+  --enable-merge-commit=false \
+  --enable-rebase-merge=false \
+  --delete-branch-on-merge
+```
+
+Run as a repo admin once. Until that's applied, contributors are
+free to pick any merge mode in the GitHub UI and CHANGELOG
+duplication will keep recurring.
+
+The squash commit's title should be the PR title (the GitHub default).
+The squash commit's body can be left as the PR description or
+trimmed to a single line — both work for release-please.
 
 ## Versioning rules
 


### PR DESCRIPTION
Closes #62.

## Summary

The v0.5.0 CHANGELOG ([visible in #42](https://github.com/Galvill/jitenv/pull/42)) had every PR show up **twice**:

\`\`\`
* **e2e:** containerised harness with two distros + LocalStack ([cbd1848])
* **e2e:** containerised harness with two distros + LocalStack ([fad6bff])
\`\`\`

\`cbd1848\` is the merge commit (title: \`Merge pull request #44 from Galvill/feat/e2e-harness\`); \`fad6bff\` is the feature commit (title: \`feat(e2e): containerised harness with two distros + LocalStack\`). release-please walks \`git log\` between releases and matches the conv-commit regex against both the title AND the body of every commit. GitHub's default merge-commit body lists the incoming branch's commits, so the feature subject gets attributed to the merge commit too.

**Squash-merge** flattens each PR to a single commit on \`main\` whose title is the conv-commit subject, so release-please sees each PR exactly once.

## What this PR does

- Adds a \"Merge policy\" section to \`docs/RELEASING.md\` explaining why squash-merge is required and surfacing the one-line \`gh repo edit\` that locks the repo to it.
- Updates the \"happy path\" TL;DR to point at the new section.

## What this PR does NOT do

The actual repo-settings change. \`gh repo edit\` affects every contributor's UI, so I left it for the repo admin to apply explicitly. The command:

\`\`\`sh
gh repo edit \\
  --enable-squash-merge \\
  --enable-merge-commit=false \\
  --enable-rebase-merge=false \\
  --delete-branch-on-merge
\`\`\`

Once that runs, the GitHub PR UI will only offer \"Squash and merge\" and CHANGELOG duplication stops on the next release.

## What about the existing duplicates in v0.5.0?

If #42 is still open when the policy lands, the next release-please run will regenerate the CHANGELOG from scratch — but only future PRs benefit from squash-merge, so the v0.5.0 entries already in \`CHANGELOG.md\` will keep their duplicates unless someone hand-edits them before merging #42.

The cleanest move: amend \`CHANGELOG.md\` in #42 by hand to deduplicate, merge, then apply the squash-merge setting. From v0.5.1 onward, no more duplicates.

## Test plan

- [x] \`docs/RELEASING.md\` renders cleanly in the GitHub markdown preview.
- [x] Reviewer (admin): run the \`gh repo edit\` line above. The next PR merge should only offer \"Squash and merge\" in the UI.