### PR TITLE
feat(e2e): CI workflow, three missing scenarios, and zsh hook coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,85 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "release/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: docker-compose harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+
+      - name: Build snapshot artefacts
+        run: make e2e-build-artifacts
+
+      - name: Bring up stack
+        run: make e2e-up
+
+      # Loop every YAML under e2e/scenarios/. A single failure marks the
+      # job as failed but the loop continues so the run-dir artefact
+      # covers every scenario, not just the first to break.
+      - name: Run all scenarios
+        id: scenarios
+        run: |
+          set -u
+          failed=0
+          for scn in e2e/scenarios/*.yaml; do
+            name=$(basename "$scn")
+            echo "::group::scenario $name"
+            if ! make e2e-run SCENARIO="$name"; then
+              echo "::error::scenario $name failed"
+              failed=$((failed+1))
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$failed" -gt 0 ]; then
+            echo "$failed scenario(s) failed"
+            exit 1
+          fi
+
+      # The harness drops every run under e2e/runs/<scenario>-<UTC>/ —
+      # those directories are the diagnosable bug report (summary.json,
+      # per-step stdout/stderr/exit, teardown captures). Upload them
+      # whenever any step before this one failed so a maintainer can
+      # triage from the artefact alone.
+      - name: Upload run dirs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-runs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: e2e/runs/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Tear down stack
+        if: always()
+        run: make e2e-down

--- a/e2e/Dockerfile.alpine
+++ b/e2e/Dockerfile.alpine
@@ -19,7 +19,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
- && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-reload ./e2e/cmd/reload
 
 FROM alpine:3.20 AS runtime
 ARG TARGETARCH=amd64
@@ -43,6 +44,7 @@ RUN ln -s $(ls /opt/pkg/jitenv_*_linux_${TARGETARCH}.tar.gz | head -n1) /opt/pkg
 
 COPY --from=helper-build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
 COPY --from=helper-build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+COPY --from=helper-build /out/jitenv-e2e-reload /usr/local/bin/jitenv-e2e-reload
 
 ENTRYPOINT ["/sbin/tini", "--"]
 USER jitenv

--- a/e2e/Dockerfile.alpine-source
+++ b/e2e/Dockerfile.alpine-source
@@ -13,7 +13,8 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv ./cmd/jitenv \
  && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
- && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-reload ./e2e/cmd/reload
 
 FROM alpine:3.20 AS runtime
 RUN apk add --no-cache bash zsh ca-certificates curl tini coreutils procps shadow util-linux && \
@@ -24,6 +25,7 @@ RUN apk add --no-cache bash zsh ca-certificates curl tini coreutils procps shado
 COPY --from=build /out/jitenv /usr/local/bin/jitenv
 COPY --from=build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
 COPY --from=build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+COPY --from=build /out/jitenv-e2e-reload /usr/local/bin/jitenv-e2e-reload
 
 ENTRYPOINT ["/sbin/tini", "--"]
 USER jitenv

--- a/e2e/Dockerfile.debian
+++ b/e2e/Dockerfile.debian
@@ -16,7 +16,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
- && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-reload ./e2e/cmd/reload
 
 FROM debian:bookworm-slim AS runtime
 ARG TARGETARCH=amd64
@@ -44,6 +45,7 @@ RUN ln -s $(ls /opt/pkg/jitenv_*_linux_${TARGETARCH}.deb | head -n1) /opt/pkg/ji
 
 COPY --from=helper-build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
 COPY --from=helper-build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+COPY --from=helper-build /out/jitenv-e2e-reload /usr/local/bin/jitenv-e2e-reload
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 USER jitenv

--- a/e2e/Dockerfile.fedora
+++ b/e2e/Dockerfile.fedora
@@ -14,7 +14,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
- && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-reload ./e2e/cmd/reload
 
 FROM fedora:40 AS runtime
 ARG TARGETARCH=amd64
@@ -36,6 +37,7 @@ RUN ln -s $(ls /opt/pkg/jitenv_*_linux_${TARGETARCH}.rpm | head -n1) /opt/pkg/ji
 
 COPY --from=helper-build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
 COPY --from=helper-build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+COPY --from=helper-build /out/jitenv-e2e-reload /usr/local/bin/jitenv-e2e-reload
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 USER jitenv

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,6 +48,9 @@ Each distro container has:
 - `/usr/local/bin/jitenv-e2e-seed` — fixture-config generator.
 - `/usr/local/bin/jitenv-e2e-unlock` — non-interactive replacement for
   `jitenv unlock` (see "Driving unlock" below).
+- `/usr/local/bin/jitenv-e2e-reload` — sends `OpReload` to a running
+  agent; the mid-session-reload scenario uses it as the harness
+  analogue of the TUI's post-save `pingAgentReload`.
 
 ## Run-dir layout
 
@@ -233,9 +236,9 @@ When a scenario fails, look at these files in order:
 ## Out of scope (deferred to follow-ups)
 
 - Vault, mock GitHub, OIDC services
-- Fedora / Arch distros
-- CI workflow integration (`.github/workflows/e2e.yml`)
-- Scenarios for: locked-agent UX, glob mappings, mid-session
-  `pingAgentReload`
-- zsh hook scenarios (the snippets are installed but no scenario
-  exercises them yet)
+- Arch distro (fedora is now covered)
+- Multi-distro coverage of functional scenarios beyond what
+  `install-layout-*` already gives — debian is the canonical
+  reference for behaviour tests; cross-distro packaging is what the
+  install-layout family exists for
+- More than one zsh hook scenario

--- a/e2e/cmd/reload/main.go
+++ b/e2e/cmd/reload/main.go
@@ -1,0 +1,42 @@
+// Command jitenv-e2e-reload sends an OpReload to a running jitenv
+// agent. It mirrors what `internal/tui/tui.go:pingAgentReload` does
+// after a successful TUI save, but as a standalone binary the e2e
+// harness can invoke from a scenario step.
+//
+// The real production trigger lives inside the TUI (and the shell
+// hook's mtime check that reconciles symlinks); neither is reachable
+// from a non-interactive `docker exec`, so the harness ships its own
+// tiny client. Resolves the agent socket via `agent.DefaultPaths()`
+// — same fallback chain (XDG_RUNTIME_DIR → /tmp/jitenv-<uid>) as the
+// real client.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gv/jitenv/internal/agent"
+)
+
+func main() {
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		die("agent paths: %v", err)
+	}
+	if _, err := os.Stat(paths.Socket); err != nil {
+		die("agent socket %s not present: %v", paths.Socket, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := agent.NewClient(paths.Socket).Reload(ctx); err != nil {
+		die("reload: %v", err)
+	}
+	fmt.Fprintln(os.Stdout, "agent reloaded")
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "jitenv-e2e-reload: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/e2e/scenarios/glob-and-bag-expansion.yaml
+++ b/e2e/scenarios/glob-and-bag-expansion.yaml
@@ -1,0 +1,79 @@
+name: glob-and-bag-expansion
+description: |
+  Two features in one fixture:
+
+    - The mapping uses Glob (`/home/jitenv/scripts/*.sh`) instead of an
+      exact Path, so the resolver's glob branch matches via doublestar.
+    - A single VarRef with empty Name + empty Key expands the whole
+      local bag (FOO, BAR, BAZ) into the child env.
+
+  Drives one of the matching files via `jitenv run` and asserts every
+  bag key appears in the child's environment.
+
+service: debian
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed \
+        -out "$JITENV_CONFIG" \
+        -variant local-glob \
+        -glob '/home/jitenv/scripts/*.sh'
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: validate-config
+    exec: jitenv config validate
+  - name: assert-validate-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/show.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      printf 'BAZ=%s\n' "$BAZ"
+      EOF
+      chmod +x /home/jitenv/scripts/show.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  # `is-mapped` against the glob-covered path must hit (exit 0). This
+  # exercises Index.Mapped's glob branch.
+  - name: is-mapped-via-glob
+    exec: jitenv is-mapped /home/jitenv/scripts/show.sh
+  - name: assert-mapped-via-glob
+    assert_exit_code: 0
+
+  - name: run-via-jitenv
+    exec: jitenv run /home/jitenv/scripts/show.sh
+    timeout: 30s
+  - name: assert-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+  - name: assert-bar
+    assert_stdout_contains: "BAR=value-from-local-bar"
+  - name: assert-baz
+    assert_stdout_contains: "BAZ=value-from-local-baz"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/scenarios/locked-agent-warning.yaml
+++ b/e2e/scenarios/locked-agent-warning.yaml
@@ -1,0 +1,83 @@
+name: locked-agent-warning
+description: |
+  Exercises the two "agent unavailable" UX paths:
+
+    1. `jitenv run` against a mapped script with no running agent. The
+       Go-side WarnAndWait prints the red "agent is not loaded" line on
+       stderr, suppresses the interactive countdown because stdin is
+       not a TTY under `docker exec -T`, then executes the script with
+       the parent env (no injected vars). Exit code is the script's.
+
+    2. `jitenv is-mapped` against a missing config: exits 2, which the
+       shell hook treats as "agent unreachable" and falls back to
+       running the user's command unchanged.
+
+service: debian
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed -out "$JITENV_CONFIG" -variant local -script /home/jitenv/scripts/show.sh
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/show.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'ran=ok\n'
+      EOF
+      chmod +x /home/jitenv/scripts/show.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  # Bring the agent up, then immediately lock it. After this point the
+  # socket is gone but the encrypted config remains, so `jitenv run`
+  # takes the "agent unreachable" branch in fetchOrWarn.
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  - name: lock-agent
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0
+
+  # `jitenv run` should: succeed (script exits 0), print the warning on
+  # stderr, run the script (stdout shows ran=ok), and NOT inject the
+  # bag's FOO (so FOO= appears empty in stdout).
+  - name: run-with-agent-locked
+    exec: jitenv run /home/jitenv/scripts/show.sh
+    timeout: 30s
+  - name: assert-run-exit-ok
+    assert_exit_code: 0
+  - name: assert-warning-printed
+    assert_stderr_contains: "agent is not loaded"
+  - name: assert-script-ran
+    assert_stdout_contains: "ran=ok"
+  - name: assert-no-injection
+    assert_stdout_contains: "FOO="
+  - name: assert-no-leak
+    target: run-with-agent-locked
+    assert_stdout_not_contains: "value-from-local-foo"
+
+  # `is-mapped` with a missing config must exit 2. The shell hook
+  # branches on this code; the harness asserts it directly.
+  - name: ismapped-missing-config
+    exec: JITENV_CONFIG=/tmp/jitenv-nonexistent.toml jitenv is-mapped /home/jitenv/scripts/show.sh
+  - name: assert-ismapped-exit-2
+    assert_exit_code: 2

--- a/e2e/scenarios/mid-session-reload.yaml
+++ b/e2e/scenarios/mid-session-reload.yaml
@@ -1,0 +1,99 @@
+name: mid-session-reload
+description: |
+  Exercises the agent's OpReload path. The TUI fires this after a
+  successful save (internal/tui/save.go calls pingAgentReload) so an
+  edit propagates without a lock/unlock cycle. Here the harness drives
+  it via a small standalone helper (jitenv-e2e-reload) that wraps
+  agent.Client.Reload.
+
+  Flow:
+    1. Seed config A (FOO=value-from-local-foo), unlock, run the
+       mapped script → asserts the "v1" values.
+    2. Reseed with the local-alt variant, preserving Meta so the
+       agent's existing derived key still decrypts the new file.
+    3. Ping OpReload via jitenv-e2e-reload.
+    4. Re-run the script → asserts the "v2" values and asserts the
+       "v1" values are NOT present (agent really swapped resolvers).
+
+service: debian
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config-v1
+    exec: |
+      jitenv-e2e-seed -out "$JITENV_CONFIG" -variant local -script /home/jitenv/scripts/show.sh
+  - name: assert-seed-v1-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/show.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      EOF
+      chmod +x /home/jitenv/scripts/show.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  - name: run-v1
+    exec: jitenv run /home/jitenv/scripts/show.sh
+    timeout: 30s
+  - name: assert-v1-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+  - name: assert-v1-bar
+    assert_stdout_contains: "BAR=value-from-local-bar"
+  # Sanity: v1 must NOT contain the v2 marker yet.
+  - name: assert-v1-no-v2-foo
+    target: run-v1
+    assert_stdout_not_contains: "value-from-local-foo-v2"
+
+  # Reseed in place. -preserve-meta keeps the same salt + verify
+  # sentinel so the running agent's key (derived from the v1 meta)
+  # still decrypts the v2 file. Without that flag the reload below
+  # would fail with a decrypt error.
+  - name: reseed-v2
+    exec: |
+      jitenv-e2e-seed \
+        -out "$JITENV_CONFIG" \
+        -variant local-alt \
+        -script /home/jitenv/scripts/show.sh \
+        -preserve-meta
+  - name: assert-reseed-ok
+    assert_exit_code: 0
+
+  - name: ping-reload
+    exec: jitenv-e2e-reload
+  - name: assert-reload-ok
+    assert_exit_code: 0
+  - name: assert-reload-confirmed
+    assert_stdout_contains: "agent reloaded"
+
+  - name: run-v2
+    exec: jitenv run /home/jitenv/scripts/show.sh
+    timeout: 30s
+  - name: assert-v2-foo
+    assert_stdout_contains: "FOO=value-from-local-foo-v2"
+  - name: assert-v2-bar
+    assert_stdout_contains: "BAR=value-from-local-bar-v2"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/scenarios/zsh-hook-injects-env.yaml
+++ b/e2e/scenarios/zsh-hook-injects-env.yaml
@@ -1,0 +1,98 @@
+name: zsh-hook-injects-env
+description: |
+  Exercises the zsh `__jitenv_accept_line` widget in a real zsh process.
+  The widget normally runs inside zle when the user submits a line; we
+  cannot drive zle reliably under `docker exec -T` (no controlling TTY,
+  and script(1)-allocated PTYs have well-known input timing issues —
+  see e2e/README.md). So we:
+
+    1. Shim `zle` as a no-op function in the calling zsh, then source
+       the snippet. This loads the widget definition without trying to
+       enter line-editor mode at hook-load time.
+    2. Set BUFFER to a mapped absolute path and invoke
+       `__jitenv_accept_line` directly. The shimmed `zle .accept-line`
+       at the end of the widget no-ops, so BUFFER is observable
+       afterwards.
+    3. Assert BUFFER got rewritten to `jitenv run "<path>"…`.
+    4. Eval the rewritten BUFFER from zsh and capture the script's
+       output — asserts the bag values FOO/BAR were injected, exactly
+       like the bash unlock-and-run-local case.
+
+  This covers the same load-bearing branch the bash hook tests cover
+  (resolve absolute path → is-mapped → rewrite to `jitenv run`), just
+  through the zsh code path.
+
+service: debian
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed -out "$JITENV_CONFIG" -variant local -script /home/jitenv/scripts/showz.sh
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/showz.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      EOF
+      chmod +x /home/jitenv/scripts/showz.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  # Load the snippet under a stubbed `zle` and assert BUFFER rewrites
+  # to `jitenv run "…"`. The widget body resolves the path, calls
+  # `jitenv is-mapped`, and on rc=0 sets BUFFER. The trailing
+  # `zle .accept-line` no-ops via our shim.
+  - name: zsh-rewrite-buffer
+    exec: |
+      zsh -c '
+        zle() { return 0; }
+        eval "$(jitenv hook zsh)"
+        typeset BUFFER="/home/jitenv/scripts/showz.sh"
+        __jitenv_accept_line
+        printf "BUFFER=%s\n" "$BUFFER"
+      '
+  - name: assert-zsh-rewrites
+    assert_stdout_contains: 'BUFFER=jitenv run "/home/jitenv/scripts/showz.sh"'
+
+  # End-to-end via the rewritten BUFFER: run it through eval inside
+  # zsh and inspect the script's stdout for the injected bag values.
+  - name: zsh-execute-rewritten
+    exec: |
+      zsh -c '
+        zle() { return 0; }
+        eval "$(jitenv hook zsh)"
+        typeset BUFFER="/home/jitenv/scripts/showz.sh"
+        __jitenv_accept_line
+        eval "$BUFFER"
+      '
+    timeout: 30s
+  - name: assert-zsh-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+  - name: assert-zsh-bar
+    assert_stdout_contains: "BAR=value-from-local-bar"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/seed/seed.go
+++ b/e2e/seed/seed.go
@@ -13,6 +13,13 @@
 //   - local        a local-bag-only fixture: sources.vault (local) +
 //     secrets.demo containing FOO/BAR; mapping on
 //     /home/jitenv/scripts/show.sh expands the bag.
+//   - local-alt    same shape as local but the bag values are
+//     suffixed with "-v2" so a reload scenario can tell
+//     them apart after re-seeding.
+//   - local-glob   like local but the mapping uses Glob instead of
+//     Path (defaults to /home/jitenv/scripts/*.sh) and
+//     the bag carries FOO/BAR/BAZ to exercise full bag
+//     expansion via a single empty-Name VarRef.
 //   - localstack   an aws-source fixture pointing at LocalStack with
 //     static dummy creds; mapping on .../show.sh fetches
 //     one key from the seeded SM secret.
@@ -29,12 +36,14 @@ import (
 
 func main() {
 	var (
-		out        = flag.String("out", "", "output path for config.toml (required)")
-		passphrase = flag.String("passphrase", "e2e-test-pass", "passphrase for the encrypted config")
-		variant    = flag.String("variant", "local", "fixture variant: local | localstack")
-		scriptPath = flag.String("script", "/home/jitenv/scripts/show.sh", "absolute path used in the mapping")
-		smARN      = flag.String("sm-arn", "arn:aws:secretsmanager:us-east-1:000000000000:secret:jitenv/demo", "SM secret ARN (localstack variant)")
-		smEndpoint = flag.String("sm-endpoint", "http://localstack:4566", "SM endpoint URL (localstack variant)")
+		out          = flag.String("out", "", "output path for config.toml (required)")
+		passphrase   = flag.String("passphrase", "e2e-test-pass", "passphrase for the encrypted config")
+		variant      = flag.String("variant", "local", "fixture variant: local | local-alt | local-glob | localstack")
+		scriptPath   = flag.String("script", "/home/jitenv/scripts/show.sh", "absolute path used in the mapping (path variants)")
+		globPath     = flag.String("glob", "/home/jitenv/scripts/*.sh", "glob pattern used in the mapping (local-glob variant)")
+		smARN        = flag.String("sm-arn", "arn:aws:secretsmanager:us-east-1:000000000000:secret:jitenv/demo", "SM secret ARN (localstack variant)")
+		smEndpoint   = flag.String("sm-endpoint", "http://localstack:4566", "SM endpoint URL (localstack variant)")
+		preserveMeta = flag.Bool("preserve-meta", false, "preserve the existing config's Meta (salt + verify sentinel) so a running agent's derived key still decrypts the new file")
 	)
 	flag.Parse()
 
@@ -42,23 +51,49 @@ func main() {
 		fmt.Fprintln(os.Stderr, "seed: -out is required")
 		os.Exit(2)
 	}
-	if err := run(*out, []byte(*passphrase), *variant, *scriptPath, *smARN, *smEndpoint); err != nil {
+	if err := run(*out, []byte(*passphrase), *variant, *scriptPath, *globPath, *smARN, *smEndpoint, *preserveMeta); err != nil {
 		fmt.Fprintf(os.Stderr, "seed: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stdout, "wrote %s (variant=%s)\n", *out, *variant)
 }
 
-func run(out string, pw []byte, variant, scriptPath, smARN, smEndpoint string) error {
+func run(out string, pw []byte, variant, scriptPath, globPath, smARN, smEndpoint string, preserveMeta bool) error {
 	if err := os.MkdirAll(dirOf(out), 0700); err != nil {
 		return fmt.Errorf("mkdir parent: %w", err)
 	}
-	if err := config.InitNew(out, pw); err != nil {
-		return fmt.Errorf("init config: %w", err)
-	}
-	cfg, err := config.Load(out)
-	if err != nil {
-		return fmt.Errorf("reload config: %w", err)
+	// preserveMeta keeps the existing file's Meta (salt + verify
+	// sentinel) when reseeding. Without it, every reseed picks a new
+	// salt and any running agent — whose key was derived from the
+	// previous salt — can no longer decrypt the file. The
+	// mid-session-reload scenario depends on this: it reseeds while
+	// the agent is up and then pings OpReload.
+	var cfg *config.Config
+	if preserveMeta {
+		existing, err := config.Load(out)
+		if err != nil {
+			return fmt.Errorf("load existing config (preserve-meta): %w", err)
+		}
+		// Verify the passphrase derives the same key, otherwise the
+		// agent would have rejected the new contents anyway.
+		if _, err := config.DeriveKeyFromMeta(existing, pw); err != nil {
+			return fmt.Errorf("verify passphrase against existing meta: %w", err)
+		}
+		cfg = &config.Config{Version: existing.Version, Meta: existing.Meta, Agent: existing.Agent}
+	} else {
+		if _, err := os.Stat(out); err == nil {
+			if err := os.Remove(out); err != nil {
+				return fmt.Errorf("remove existing config: %w", err)
+			}
+		}
+		if err := config.InitNew(out, pw); err != nil {
+			return fmt.Errorf("init config: %w", err)
+		}
+		loaded, err := config.Load(out)
+		if err != nil {
+			return fmt.Errorf("reload config: %w", err)
+		}
+		cfg = loaded
 	}
 	key, err := config.DeriveKeyFromMeta(cfg, pw)
 	if err != nil {
@@ -68,7 +103,15 @@ func run(out string, pw []byte, variant, scriptPath, smARN, smEndpoint string) e
 
 	switch variant {
 	case "local":
-		if err := applyLocal(cfg, key, scriptPath); err != nil {
+		if err := applyLocal(cfg, key, scriptPath, "value-from-local-foo", "value-from-local-bar"); err != nil {
+			return err
+		}
+	case "local-alt":
+		if err := applyLocal(cfg, key, scriptPath, "value-from-local-foo-v2", "value-from-local-bar-v2"); err != nil {
+			return err
+		}
+	case "local-glob":
+		if err := applyLocalGlob(cfg, key, globPath); err != nil {
 			return err
 		}
 	case "localstack":
@@ -76,7 +119,7 @@ func run(out string, pw []byte, variant, scriptPath, smARN, smEndpoint string) e
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown variant %q (want: local | localstack)", variant)
+		return fmt.Errorf("unknown variant %q (want: local | local-alt | local-glob | localstack)", variant)
 	}
 
 	return config.AtomicSave(out, cfg)
@@ -84,13 +127,14 @@ func run(out string, pw []byte, variant, scriptPath, smARN, smEndpoint string) e
 
 // applyLocal mirrors what the TUI emits for a local-bag-only setup:
 // one source of type "local", one secrets table, one mapping that
-// expands the bag.
-func applyLocal(cfg *config.Config, key []byte, scriptPath string) error {
-	foo, err := crypto.EncryptField(key, "value-from-local-foo")
+// expands the bag. fooVal/barVal let the caller produce distinguishable
+// fixtures (used by local-alt to differentiate before/after a reload).
+func applyLocal(cfg *config.Config, key []byte, scriptPath, fooVal, barVal string) error {
+	foo, err := crypto.EncryptField(key, fooVal)
 	if err != nil {
 		return err
 	}
-	bar, err := crypto.EncryptField(key, "value-from-local-bar")
+	bar, err := crypto.EncryptField(key, barVal)
 	if err != nil {
 		return err
 	}
@@ -105,6 +149,39 @@ func applyLocal(cfg *config.Config, key []byte, scriptPath string) error {
 			Path: scriptPath,
 			Vars: []config.VarRef{
 				// Empty Name + empty Key = expand all keys in the bag.
+				{Source: "vault", Ref: "demo"},
+			},
+		},
+	}
+	return nil
+}
+
+// applyLocalGlob covers two features in one fixture: a Glob mapping
+// (instead of an exact Path) and a bag with three keys that all expand
+// via a single empty-Name VarRef.
+func applyLocalGlob(cfg *config.Config, key []byte, globPath string) error {
+	foo, err := crypto.EncryptField(key, "value-from-local-foo")
+	if err != nil {
+		return err
+	}
+	bar, err := crypto.EncryptField(key, "value-from-local-bar")
+	if err != nil {
+		return err
+	}
+	baz, err := crypto.EncryptField(key, "value-from-local-baz")
+	if err != nil {
+		return err
+	}
+	cfg.Sources = map[string]config.SourceConfig{
+		"vault": {Type: "local"},
+	}
+	cfg.Secrets = map[string]map[string]string{
+		"demo": {"FOO": foo, "BAR": bar, "BAZ": baz},
+	}
+	cfg.Mappings = []config.Mapping{
+		{
+			Glob: globPath,
+			Vars: []config.VarRef{
 				{Source: "vault", Ref: "demo"},
 			},
 		},


### PR DESCRIPTION
Closes part of #41 (Phase 2). Vault, Arch, and cross-distro variants of the new behaviour scenarios remain — noted at the bottom.

## Summary

Three things in one PR:

1. **\`.github/workflows/e2e.yml\`** — runs the full e2e harness on every PR and on \`main\`/\`release/**\` pushes. Slow tests now block PRs.
2. **Three missing scenarios** from the original #41 spec — \`locked-agent-warning\`, \`glob-and-bag-expansion\`, \`mid-session-reload\`. All run against \`debian\`.
3. **One zsh scenario** — \`zsh-hook-injects-env\`. Exercises \`__jitenv_accept_line\`'s buffer rewrite end-to-end with a stubbed \`zle\`.

## CI workflow shape

- Single ubuntu-latest job, 30-min timeout, concurrency-gated on \`github.ref\`.
- Sets up Go 1.25.x, goreleaser via \`goreleaser/goreleaser-action@v6\` (matches \`release.yml\`'s pin pattern).
- \`make e2e-build-artifacts && make e2e-up\` then loops every \`e2e/scenarios/*.yaml\` accumulating failures.
- On any failure, uploads \`e2e/runs/\` as a named artefact (14-day retention) — the harness's diagnosable run-dir layout surfaces to the CI UI.
- \`make e2e-down\` in an \`if: always()\` cleanup step.
- No interpolation of untrusted input. \`actionlint\` clean.

## New scenarios

### \`e2e/scenarios/locked-agent-warning.yaml\`
- \`jitenv lock\` then \`jitenv run\` a mapped script.
- Asserts exit 0, stderr contains \"agent is not loaded\", stdout is the script's normal output (i.e. the script ran with parent env).
- Then sets \`JITENV_CONFIG\` to a non-existent file and runs \`jitenv is-mapped\` — asserts exit code 2.

### \`e2e/scenarios/glob-and-bag-expansion.yaml\`
- A \`glob\` mapping (\`/some/glob/*.sh\`) matches a script.
- A \`local\` bag with three keys (\`FOO\`, \`BAR\`, \`BAZ\`).
- One \`VarRef\` with empty \`Name\` expands the whole bag.
- Asserts all three keys land in the script's env.

### \`e2e/scenarios/mid-session-reload.yaml\`
- Seed config A → unlock → run mapped script → assert A's values.
- Save config B (different bag values) via the seed helper's new \`-preserve-meta\` flag → ping the agent via \`OpReload\`.
- Run the same script → assert B's values.

Required two small additions:
- **\`e2e/cmd/reload/main.go\`** (new) → \`jitenv-e2e-reload\` binary; wraps \`agent.Client.Reload\`.
- **\`e2e/seed/seed.go\`** — two new variants (\`local-alt\`, \`local-glob\`) and a \`-preserve-meta\` flag. Without preserve-meta, reseeding picks a new salt and the running agent can't decrypt — the reload scenario depends on preserving meta.

### \`e2e/scenarios/zsh-hook-injects-env.yaml\`
- Shims \`zle\` as a no-op function, invokes \`__jitenv_accept_line\` directly.
- Asserts the buffer rewrite to \`jitenv run \"…\"\`, then eval-executes the rewritten buffer.
- Asserts env injection lands in the wrapped script.

(See \"Rough edges\" below for why the scenario doesn't drive a real PTY.)

## Dockerfile updates

All four images (\`debian\`, \`fedora\`, \`alpine\`, \`alpine-source\`) build and ship \`/usr/local/bin/jitenv-e2e-reload\`.

## Verification

- \`make e2e-build-artifacts\` — succeeded.
- \`docker compose build\` — all 4 images clean.
- \`make e2e-up\` — full stack healthy.
- All 9 scenarios pass green on a cold build: \`glob-and-bag-expansion\`, \`install-layout-alpine\`, \`install-layout-debian\`, \`install-layout-fedora\`, \`localstack-fetch\`, \`locked-agent-warning\`, \`mid-session-reload\`, \`unlock-and-run-local\`, \`zsh-hook-injects-env\`.
- \`make e2e-down\` — clean teardown.
- \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))\"\` — parses.
- \`actionlint .github/workflows/e2e.yml\` — clean.
- \`go test ./...\` green on both main module and \`e2e/harness\`.

The CI workflow itself only runs once the PR opens — stating that explicitly.

## Rough edges

- **zsh scenario doesn't drive real \`zle\`.** PTY-allocated zsh hit the same input-timing class of bug the README warns about for the original \`jitenv unlock\` work; multiple \`script(1)\` variants tried, all flaky. The scenario shims \`zle\` as a no-op and invokes \`__jitenv_accept_line\` directly — covers the load-bearing transformation (resolve path → call \`is-mapped\` → rewrite \`BUFFER\`) and eval-executes the result to assert end-to-end env injection. The final \`zle .accept-line\` is shell plumbing, not jitenv logic.
- **\`mid-session-reload\` requires \`-preserve-meta\`.** Without it the agent's derived key fails to decrypt the new file. The flag is commented but a future \"edit secrets in place\" seed mode would be cleaner.
- **Single-distro coverage** of behaviour scenarios. Per scope, the four new scenarios all target debian; install-layout already covers cross-distro packaging.

## Out of scope (deferred)

- Vault dev-mode service — needs a Vault source backend, doesn't exist in jitenv yet.
- Arch distro variant.
- Multi-distro variants of the new behaviour scenarios.
- Go-based PTY driver step in the harness (would unlock real \`zle\` / interactive-shell scenarios).
- Asserting the no-\`-preserve-meta\` failure mode in \`mid-session-reload\`.

## Test plan

- [x] \`docker compose build\` succeeds for all 4 images.
- [x] \`make e2e-up && make e2e-run SCENARIO=...\` passes for all 9 scenarios.
- [x] \`go test ./...\` green.
- [x] \`actionlint\` clean on the new workflow.
- [x] Reviewer: confirm the new CI run lands green on this PR. Inspect the artefact upload behaviour by deliberately breaking a scenario locally and confirming the artefact path matches.