### PR TITLE
fix(hook): bake paths into snippet, sidecar nanosecond mtime

### DIFF
--- a/e2e/scenarios/install-layout-alpine.yaml
+++ b/e2e/scenarios/install-layout-alpine.yaml
@@ -30,15 +30,26 @@ steps:
   - name: assert-zsh-snippet
     assert_exit_code: 0
 
-  - name: bash-snippet-matches-hook
-    exec: diff -u <(jitenv hook bash) /usr/share/jitenv/snippets/bash.sh
-  - name: assert-bash-match
+  # See install-layout-debian.yaml for the contract rationale.
+  - name: bash-snippet-has-template-markers
+    exec: grep -q '{{RuntimeDir}}' /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-template
     assert_exit_code: 0
 
-  - name: zsh-snippet-matches-hook
-    exec: diff -u <(jitenv hook zsh) /usr/share/jitenv/snippets/zsh.sh
-  - name: assert-zsh-match
+  - name: zsh-snippet-has-template-markers
+    exec: grep -q '{{RuntimeDir}}' /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-template
     assert_exit_code: 0
+
+  - name: bash-hook-substitutes-markers
+    exec: jitenv hook bash
+  - name: assert-bash-no-markers
+    assert_stdout_not_contains: "{{RuntimeDir}}"
+
+  - name: zsh-hook-substitutes-markers
+    exec: jitenv hook zsh
+  - name: assert-zsh-no-markers
+    assert_stdout_not_contains: "{{RuntimeDir}}"
 
   - name: license-doc-exists
     exec: test -f /usr/share/doc/jitenv/LICENSE

--- a/e2e/scenarios/install-layout-debian.yaml
+++ b/e2e/scenarios/install-layout-debian.yaml
@@ -39,18 +39,29 @@ steps:
   - name: assert-zsh-snippet
     assert_exit_code: 0
 
-  # The shipped snippet must be byte-identical to what `jitenv hook bash`
-  # emits today; otherwise users get drift between `hook install` and a
-  # source-the-snippet workflow.
-  - name: bash-snippet-matches-hook
-    exec: diff -u <(jitenv hook bash) /usr/share/jitenv/snippets/bash.sh
-  - name: assert-bash-match
+  # The shipped snippets are the template form (with {{RuntimeDir}} /
+  # {{ConfigPath}} placeholders); `jitenv hook bash|zsh` substitutes
+  # them at print time. Assert both halves: file has the markers, hook
+  # output doesn't.
+  - name: bash-snippet-has-template-markers
+    exec: grep -q '{{RuntimeDir}}' /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-template
     assert_exit_code: 0
 
-  - name: zsh-snippet-matches-hook
-    exec: diff -u <(jitenv hook zsh) /usr/share/jitenv/snippets/zsh.sh
-  - name: assert-zsh-match
+  - name: zsh-snippet-has-template-markers
+    exec: grep -q '{{RuntimeDir}}' /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-template
     assert_exit_code: 0
+
+  - name: bash-hook-substitutes-markers
+    exec: jitenv hook bash
+  - name: assert-bash-no-markers
+    assert_stdout_not_contains: "{{RuntimeDir}}"
+
+  - name: zsh-hook-substitutes-markers
+    exec: jitenv hook zsh
+  - name: assert-zsh-no-markers
+    assert_stdout_not_contains: "{{RuntimeDir}}"
 
   - name: license-doc-exists
     exec: test -f /usr/share/doc/jitenv/LICENSE

--- a/e2e/scenarios/install-layout-fedora.yaml
+++ b/e2e/scenarios/install-layout-fedora.yaml
@@ -38,15 +38,26 @@ steps:
   - name: assert-zsh-snippet
     assert_exit_code: 0
 
-  - name: bash-snippet-matches-hook
-    exec: diff -u <(jitenv hook bash) /usr/share/jitenv/snippets/bash.sh
-  - name: assert-bash-match
+  # See install-layout-debian.yaml for the contract rationale.
+  - name: bash-snippet-has-template-markers
+    exec: grep -q '{{RuntimeDir}}' /usr/share/jitenv/snippets/bash.sh
+  - name: assert-bash-template
     assert_exit_code: 0
 
-  - name: zsh-snippet-matches-hook
-    exec: diff -u <(jitenv hook zsh) /usr/share/jitenv/snippets/zsh.sh
-  - name: assert-zsh-match
+  - name: zsh-snippet-has-template-markers
+    exec: grep -q '{{RuntimeDir}}' /usr/share/jitenv/snippets/zsh.sh
+  - name: assert-zsh-template
     assert_exit_code: 0
+
+  - name: bash-hook-substitutes-markers
+    exec: jitenv hook bash
+  - name: assert-bash-no-markers
+    assert_stdout_not_contains: "{{RuntimeDir}}"
+
+  - name: zsh-hook-substitutes-markers
+    exec: jitenv hook zsh
+  - name: assert-zsh-no-markers
+    assert_stdout_not_contains: "{{RuntimeDir}}"
 
   - name: license-doc-exists
     exec: test -f /usr/share/doc/jitenv/LICENSE

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -22,17 +22,17 @@ func (p Paths) ShellWrapDir(shellPid int) string {
 	return filepath.Join(p.ShellsDir, fmt.Sprintf("%d", shellPid), "bin")
 }
 
-// DefaultPaths returns the per-user paths under $XDG_RUNTIME_DIR (preferred)
-// or /tmp/jitenv-<uid> as a fallback.
-func DefaultPaths() (Paths, error) {
+// ResolvePaths returns the per-user paths under $XDG_RUNTIME_DIR
+// (preferred) or /tmp/jitenv-<uid> as a fallback. Pure computation —
+// it does not create the directory on disk. Use this for read-only
+// callers (e.g. `jitenv hook bash`, which prints paths but doesn't
+// need them to exist yet).
+func ResolvePaths() Paths {
 	dir := os.Getenv("XDG_RUNTIME_DIR")
 	if dir == "" {
 		dir = filepath.Join(os.TempDir(), fmt.Sprintf("jitenv-%d", os.Getuid()))
 	} else {
 		dir = filepath.Join(dir, "jitenv")
-	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return Paths{}, err
 	}
 	return Paths{
 		Dir:       dir,
@@ -40,7 +40,19 @@ func DefaultPaths() (Paths, error) {
 		PidFile:   filepath.Join(dir, "agent.pid"),
 		LogFile:   filepath.Join(dir, "agent.log"),
 		ShellsDir: filepath.Join(dir, "shells"),
-	}, nil
+	}
+}
+
+// DefaultPaths returns the per-user paths AND mkdir's the runtime
+// dir (0700) so callers that need to bind a socket or open a log
+// file can rely on it existing. Use this from agent startup, chpwd,
+// etc.
+func DefaultPaths() (Paths, error) {
+	p := ResolvePaths()
+	if err := os.MkdirAll(p.Dir, 0700); err != nil {
+		return Paths{}, err
+	}
+	return p, nil
 }
 
 // GcOrphanShells walks ShellsDir and removes any <pid>/ subdirectory

--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -1,20 +1,27 @@
 // Package chpwd is the entrypoint for the `jitenv __chpwd` subcommand.
-// The shell hooks call it on every directory change with the shell pid,
+// The shell hooks call it on every prompt fire with the shell pid,
 // the previous PWD, and the new PWD.
 //
 // Behaviour:
 //
-//  1. Read the config file directly (no agent required, no decryption
+//  1. Short-circuit when neither pwd nor the config-file mtime changed
+//     since the last call from this shell. Per-shell state lives in
+//     <runtime>/jitenv/shells/<pid>/last-mtime — see lastMtimePath.
+//  2. Read the config file directly (no agent required, no decryption
 //     required — cwd_glob and commands are plaintext fields).
-//  2. Compute the union of `commands` lists across cwd_glob mappings
+//  3. Compute the union of `commands` lists across cwd_glob mappings
 //     whose pattern matches newPwd.
-//  3. Reconcile the per-shell wrapper bin dir: add missing symlinks,
-//     remove extras.
+//  4. Reconcile the per-shell wrapper bin dir: add missing symlinks,
+//     remove extras. Write the current mtime to the sidecar.
 //
 // Reading config directly (rather than going through the agent) means
 // the wrapper symlinks are correct whether the agent is locked or
 // running. The agent stays in the critical path only at shim-time
 // (to fetch the actual env var values, which DO require decryption).
+//
+// The per-shell sidecar gets reaped automatically by
+// agent.GcOrphanShells, which removes the entire <pid>/ directory when
+// the shell dies.
 package chpwd
 
 import (
@@ -39,6 +46,7 @@ func Run(args []string) error {
 	if err != nil || pid <= 0 {
 		return fmt.Errorf("invalid shell pid %q", args[0])
 	}
+	oldPwd := args[1]
 	newPwd := args[2]
 
 	paths, err := agent.DefaultPaths()
@@ -46,10 +54,26 @@ func Run(args []string) error {
 		return err
 	}
 	wrapDir := paths.ShellWrapDir(pid)
+	mtimePath := lastMtimePath(paths, pid)
 
-	debugLog("pid=%d oldpwd=%q newpwd=%q wrapDir=%q", pid, args[1], newPwd, wrapDir)
+	cfgPath, cfgErr := config.Resolve(os.Getenv("JITENV_CONFIG"))
+	curMtime := statMtime(cfgPath)
+	lastMtime := readLastMtime(mtimePath)
 
-	wanted, err := desiredCommands(newPwd)
+	debugLog("pid=%d oldpwd=%q newpwd=%q wrapDir=%q cfg=%q curMtime=%d lastMtime=%d",
+		pid, oldPwd, newPwd, wrapDir, cfgPath, curMtime, lastMtime)
+
+	// Short-circuit: pwd unchanged AND config mtime unchanged. Cheapest
+	// path; covers the common per-prompt fire. We require lastMtime to
+	// have been recorded at least once so the very first invocation
+	// after hook-load still reconciles (sets up wrapper dir even when
+	// the shell starts inside an already-mapped cwd_glob dir).
+	if cfgErr == nil && oldPwd == newPwd && lastMtime != 0 && curMtime == lastMtime {
+		debugLog("short-circuit: pwd+mtime unchanged")
+		return nil
+	}
+
+	wanted, err := desiredCommandsFor(cfgPath, cfgErr, newPwd)
 	if err != nil {
 		debugLog("desiredCommands error: %v", err)
 		// Config missing or malformed: leave the wrapper dir alone
@@ -62,18 +86,64 @@ func Run(args []string) error {
 		debugLog("reconcile error: %v", err)
 		return err
 	}
+	if err := writeLastMtime(mtimePath, curMtime); err != nil {
+		debugLog("writeLastMtime error: %v", err)
+		// Non-fatal: next call will just see a stale state and reconcile again.
+	}
 	debugLog("reconcile ok (%d symlinks)", len(wanted))
 	return nil
 }
 
-// desiredCommands reads the on-disk config and returns the union of
-// every cwd_glob mapping's commands list whose pattern matches pwd.
-// No agent contact, no decryption — the cwd_glob and commands fields
-// are plaintext TOML.
-func desiredCommands(pwd string) ([]string, error) {
-	cfgPath, err := config.Resolve(os.Getenv("JITENV_CONFIG"))
+// lastMtimePath is the per-shell sidecar that records the config-file
+// mtime as of the last reconcile from this shell. Living alongside the
+// wrapper bin dir means agent.GcOrphanShells reaps it for free when
+// the shell dies — same lifetime as the wrap dir.
+func lastMtimePath(paths agent.Paths, pid int) string {
+	return filepath.Join(filepath.Dir(paths.ShellWrapDir(pid)), "last-mtime")
+}
+
+// statMtime returns the file's mtime in Unix nanoseconds, or 0 if the
+// file is missing/unreadable. Unix nanoseconds give us enough precision
+// to detect rewrites inside the same wall-clock second — the previous
+// shell-side stat fell back to whole seconds and could miss those.
+func statMtime(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	st, err := os.Stat(path)
 	if err != nil {
-		return nil, err
+		return 0
+	}
+	return st.ModTime().UnixNano()
+}
+
+func readLastMtime(path string) int64 {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func writeLastMtime(path string, mtime int64) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strconv.FormatInt(mtime, 10)), 0o600)
+}
+
+// desiredCommandsFor reads the config at cfgPath and returns the union
+// of every cwd_glob mapping's commands list whose pattern matches pwd.
+// No agent contact, no decryption — the cwd_glob and commands fields
+// are plaintext TOML. cfgErr is the pre-resolved Resolve error so the
+// caller doesn't pay a second config.Resolve cost.
+func desiredCommandsFor(cfgPath string, cfgErr error, pwd string) ([]string, error) {
+	if cfgErr != nil {
+		return nil, cfgErr
 	}
 	cfg, err := config.Load(cfgPath)
 	if err != nil {

--- a/internal/chpwd/chpwd_test.go
+++ b/internal/chpwd/chpwd_test.go
@@ -1,0 +1,101 @@
+package chpwd
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+)
+
+// TestRunShortCircuitsOnNoChange exercises the sidecar fast-path: a
+// second call from the same shell-pid with the same pwd and an
+// unchanged config mtime must be a no-op. The signal is that the
+// wrapper dir contents remain whatever the first call left them.
+func TestRunShortCircuitsOnNoChange(t *testing.T) {
+	tmp := t.TempDir()
+	runtimeDir := filepath.Join(tmp, "runtime")
+	cfgPath := filepath.Join(tmp, "config.toml")
+
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("JITENV_CONFIG", cfgPath)
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Version: 1,
+		Mappings: []config.Mapping{{
+			CwdGlob:  projectDir,
+			Commands: []string{"firstcmd"},
+		}},
+	}
+	tmpf, err := os.Create(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := toml.NewEncoder(tmpf).Encode(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	tmpf.Close()
+
+	pid := os.Getpid()
+	paths, _ := agent.DefaultPaths()
+	wrapDir := paths.ShellWrapDir(pid)
+
+	// First call from outside projectDir: nothing wanted, dir stays empty.
+	if err := Run([]string{strconv.Itoa(pid), "", tmp}); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	// Second call entering projectDir: firstcmd symlink appears.
+	if err := Run([]string{strconv.Itoa(pid), tmp, projectDir}); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(wrapDir, "firstcmd")); err != nil {
+		t.Fatalf("expected firstcmd symlink after second call: %v", err)
+	}
+
+	// Tamper with the wrapper dir: drop the symlink. If the next call
+	// short-circuits as expected, the symlink stays gone.
+	if err := os.Remove(filepath.Join(wrapDir, "firstcmd")); err != nil {
+		t.Fatalf("remove symlink: %v", err)
+	}
+	if err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
+		t.Fatalf("third Run: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(wrapDir, "firstcmd")); err == nil {
+		t.Error("expected third call to short-circuit and skip reconcile, but symlink was recreated")
+	}
+
+	// Now bump the config mtime — short-circuit must yield to a real reconcile.
+	future := time.Now().Add(5 * time.Second)
+	if err := os.Chtimes(cfgPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
+		t.Fatalf("fourth Run: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(wrapDir, "firstcmd")); err != nil {
+		t.Errorf("expected fourth call to reconcile after mtime bump: %v", err)
+	}
+}
+
+// TestLastMtimeSidecarLivesUnderShellDir documents the sidecar path so
+// agent.GcOrphanShells reaps it for free.
+func TestLastMtimeSidecarLivesUnderShellDir(t *testing.T) {
+	paths := agent.Paths{ShellsDir: "/run/jitenv/shells"}
+	got := lastMtimePath(paths, 123)
+	want := "/run/jitenv/shells/123/last-mtime"
+	if got != want {
+		t.Errorf("lastMtimePath: got %q want %q", got, want)
+	}
+}

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -17,16 +17,26 @@ func newHookCmd() *cobra.Command {
 		Use:   "bash",
 		Short: "Print bash integration",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Fprint(cmd.OutOrStdout(), shell.Bash)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := shell.Render("bash")
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), out)
+			return nil
 		},
 	})
 	c.AddCommand(&cobra.Command{
 		Use:   "zsh",
 		Short: "Print zsh integration",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Fprint(cmd.OutOrStdout(), shell.Zsh)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := shell.Render("zsh")
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), out)
+			return nil
 		},
 	})
 	c.AddCommand(newHookInstallCmd())

--- a/internal/shell/render.go
+++ b/internal/shell/render.go
@@ -1,0 +1,50 @@
+package shell
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+)
+
+// Render returns the shell hook snippet for shell ("bash" or "zsh") with
+// the binary's view of $XDG_RUNTIME_DIR/jitenv and the config path baked
+// in. Replaces the {{RuntimeDir}} and {{ConfigPath}} markers in the
+// embedded template. Eliminates the shell-side duplication of
+// agent.DefaultPaths() / config.DefaultPath().
+func Render(shell string) (string, error) {
+	var tmpl string
+	switch shell {
+	case "bash":
+		tmpl = Bash
+	case "zsh":
+		tmpl = Zsh
+	default:
+		return "", fmt.Errorf("unsupported shell %q", shell)
+	}
+
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime dir: %w", err)
+	}
+	cfgPath, err := config.DefaultPath()
+	if err != nil {
+		return "", fmt.Errorf("resolve config path: %w", err)
+	}
+
+	r := strings.NewReplacer(
+		"{{RuntimeDir}}", shellQuote(paths.Dir),
+		"{{ConfigPath}}", shellQuote(cfgPath),
+	)
+	return r.Replace(tmpl), nil
+}
+
+// shellQuote single-quotes a path for safe inclusion in a POSIX shell
+// assignment. Both DefaultPaths().Dir and DefaultPath() routinely come
+// from $HOME / $XDG_* — which may contain spaces or other shell
+// metacharacters on multi-user / Windows-mounted setups.
+func shellQuote(s string) string {
+	// Single quotes can't contain a literal single quote; close + escape + reopen.
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/shell/render.go
+++ b/internal/shell/render.go
@@ -12,7 +12,9 @@ import (
 // the binary's view of $XDG_RUNTIME_DIR/jitenv and the config path baked
 // in. Replaces the {{RuntimeDir}} and {{ConfigPath}} markers in the
 // embedded template. Eliminates the shell-side duplication of
-// agent.DefaultPaths() / config.DefaultPath().
+// agent.ResolvePaths() / config.DefaultPath(). Calls the no-mkdir
+// variant on purpose — `jitenv hook bash` should be side-effect-free
+// (and the runtime dir often doesn't exist yet at hook-print time).
 func Render(shell string) (string, error) {
 	var tmpl string
 	switch shell {
@@ -24,10 +26,7 @@ func Render(shell string) (string, error) {
 		return "", fmt.Errorf("unsupported shell %q", shell)
 	}
 
-	paths, err := agent.DefaultPaths()
-	if err != nil {
-		return "", fmt.Errorf("resolve runtime dir: %w", err)
-	}
+	paths := agent.ResolvePaths()
 	cfgPath, err := config.DefaultPath()
 	if err != nil {
 		return "", fmt.Errorf("resolve config path: %w", err)

--- a/internal/shell/render_test.go
+++ b/internal/shell/render_test.go
@@ -1,0 +1,66 @@
+package shell
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRenderBakesPaths checks that the templated snippet substitutes
+// the runtime-dir + config-path markers with the values Go would have
+// chosen at print time. The placeholders ({{RuntimeDir}}, {{ConfigPath}})
+// must not appear in the rendered output.
+func TestRenderBakesPaths(t *testing.T) {
+	cfgDir := filepath.Join(t.TempDir(), "cfg")
+	runtimeDir := filepath.Join(t.TempDir(), "rt")
+
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("JITENV_CONFIG", "")
+
+	wantRuntime := filepath.Join(runtimeDir, "jitenv")
+	wantCfg := filepath.Join(cfgDir, "jitenv", "config.toml")
+
+	for _, sh := range []string{"bash", "zsh"} {
+		t.Run(sh, func(t *testing.T) {
+			out, err := Render(sh)
+			if err != nil {
+				t.Fatalf("Render(%q): %v", sh, err)
+			}
+			if strings.Contains(out, "{{") || strings.Contains(out, "}}") {
+				t.Errorf("output still contains unfilled markers:\n%s", out)
+			}
+			// Quoted forms — we single-quote in shellQuote so the path
+			// is literal even if it contains a space.
+			if !strings.Contains(out, "__JITENV_RUNTIME_DIR='"+wantRuntime+"'") {
+				t.Errorf("expected baked-in runtime dir %q in output;\n%s", wantRuntime, out)
+			}
+			if !strings.Contains(out, "__JITENV_CFG_PATH='"+wantCfg+"'") {
+				t.Errorf("expected baked-in config path %q in output;\n%s", wantCfg, out)
+			}
+		})
+	}
+}
+
+// TestRenderQuotesShellMetacharacters guards against an XDG_RUNTIME_DIR
+// or config path with a single quote in it (Windows-mounted home dirs,
+// users with apostrophes in their names, etc.). The single-quote-escape
+// must produce a literal that bash/zsh assign verbatim.
+func TestRenderQuotesShellMetacharacters(t *testing.T) {
+	// Use a path with a single quote — shellQuote's escape is the
+	// interesting case. We can't actually persist this as XDG_RUNTIME_DIR
+	// because agent.DefaultPaths() does a MkdirAll and the test env may
+	// reject the name; instead spot-check shellQuote directly.
+	got := shellQuote("/run/it's/jitenv")
+	want := `'/run/it'\''s/jitenv'`
+	if got != want {
+		t.Errorf("shellQuote: got %q want %q", got, want)
+	}
+}
+
+// TestRenderUnknownShellErrors guards the dispatch.
+func TestRenderUnknownShellErrors(t *testing.T) {
+	if _, err := Render("fish"); err == nil {
+		t.Error("expected error for unsupported shell")
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -3,24 +3,16 @@
 # re-run the first token through `jitenv run` if it maps to a configured
 # file. Only acts on commands whose first token resolves to /, ./ or ../
 # paths (not PATH lookups) — keeps the hook fast and predictable.
+#
+# The runtime-dir + config-path values below are baked in by
+# `jitenv hook bash` at print time so the shell never duplicates the
+# Go side's path resolution. See internal/shell/render.go.
 
 if [[ -n "${__JITENV_LOADED:-}" ]]; then return 0 2>/dev/null || exit 0; fi
 __JITENV_LOADED=1
 
-# Per-shell wrapper-symlink dir. The chpwd helper populates it on
-# directory changes that hit a cwd_glob mapping; an empty dir is a
-# silent fall-through. We pre-create it and prepend to $PATH once,
-# right here, so PATH stays stable for the rest of the shell's life.
-if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
-    # Strip a trailing slash so the concat doesn't yield "//jitenv"
-    # for users whose XDG_RUNTIME_DIR happens to end in /. The Go
-    # side normalises with filepath.Join; the shell needs to do it
-    # by hand or the wrapper dir lands in $PATH with double slashes.
-    __JITENV_RUNTIME_DIR="${XDG_RUNTIME_DIR%/}/jitenv"
-else
-    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}"
-    __JITENV_RUNTIME_DIR="${__JITENV_RUNTIME_DIR%/}/jitenv-$UID"
-fi
+__JITENV_RUNTIME_DIR={{RuntimeDir}}
+__JITENV_CFG_PATH={{ConfigPath}}
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 # Recorded so the shim can tell "this shell typed the command" from
 # "an unmapped descendant spawned the wrapped binary"; only the former
@@ -32,43 +24,33 @@ case ":$PATH:" in
     *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;
 esac
 
-# chpwd hook: bash has no native chpwd, so we run a tiny PWD-diff
-# in PROMPT_COMMAND. The diff makes the per-prompt cost a single
-# string compare; the full helper only fires on actual directory
-# changes.
-# Resolve the config-file path the same way the Go side does.
+# Tiny per-shell $JITENV_CONFIG override so users can re-point one
+# shell at a different config without re-sourcing the hook. The
+# baked-in default (see __JITENV_CFG_PATH above) is what `jitenv`
+# itself resolves; this function only exists so callers can query the
+# effective config path from inside the shell.
 __jitenv_cfg_path() {
     if [[ -n "${JITENV_CONFIG:-}" ]]; then
         printf '%s' "$JITENV_CONFIG"
     else
-        printf '%s' "${XDG_CONFIG_HOME:-$HOME/.config}/jitenv/config.toml"
+        printf '%s' "$__JITENV_CFG_PATH"
     fi
 }
-# stat -c is GNU; -f is BSD/macOS. Echo 0 on any failure so the
-# comparison treats "missing" identically across runs.
-__jitenv_cfg_mtime() {
-    local cfg="$1"
-    [[ -e "$cfg" ]] || { printf '0'; return; }
-    stat -c %Y "$cfg" 2>/dev/null || stat -f %m "$cfg" 2>/dev/null || printf '0'
-}
+# chpwd hook: bash has no native chpwd, so we drive `jitenv __chpwd`
+# from PROMPT_COMMAND. The Go side compares pwd and the config-file
+# mtime against per-shell sidecar state ($__JITENV_RUNTIME_DIR/shells/
+# $$/last-mtime + the wrapper-dir contents) and short-circuits when
+# nothing changed. One fork per prompt; ~50us when Go has nothing to
+# do. Keeping the state in Go means a fresh `eval "$(jitenv hook bash)"`
+# doesn't cause a spurious reconcile.
 __jitenv_chpwd() {
-    local cfg mtime
-    cfg="$(__jitenv_cfg_path)"
-    mtime="$(__jitenv_cfg_mtime "$cfg")"
-    # Fire when EITHER the directory changed OR the config file's
-    # mtime changed since the last fire. The mtime branch handles
-    # "user edits config while sitting in the mapped dir": symlinks
-    # get re-reconciled on the next prompt without requiring a cd.
-    if [[ "$PWD" != "${__JITENV_LAST_PWD-}" || "$mtime" != "${__JITENV_LAST_CFG_MTIME-}" ]]; then
-        # No 2>/dev/null on purpose: the chpwd subcommand is silent
-        # in normal operation (it only writes to stderr when
-        # JITENV_HOOK_DEBUG is set). Swallowing stderr here would
-        # hide debug diagnostics + a "jitenv: command not found"
-        # if the binary ever falls off $PATH mid-session.
-        jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
-        __JITENV_LAST_PWD="$PWD"
-        __JITENV_LAST_CFG_MTIME="$mtime"
-    fi
+    # No 2>/dev/null on purpose: the chpwd subcommand is silent
+    # in normal operation (it only writes to stderr when
+    # JITENV_HOOK_DEBUG is set). Swallowing stderr here would
+    # hide debug diagnostics + a "jitenv: command not found"
+    # if the binary ever falls off $PATH mid-session.
+    jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
+    __JITENV_LAST_PWD="$PWD"
 }
 # Run once at hook-load time so the wrapper dir is populated before
 # the first command in this shell.

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -2,18 +2,16 @@
 # Uses a zle widget bound to "accept-line" to rewrite BUFFER before
 # submission. Only acts on commands whose first token resolves to /, ./
 # or ../ paths.
+#
+# The runtime-dir + config-path values below are baked in by
+# `jitenv hook zsh` at print time so the shell never duplicates the
+# Go side's path resolution. See internal/shell/render.go.
 
 if [[ -n "${__JITENV_LOADED:-}" ]]; then return 0; fi
 __JITENV_LOADED=1
 
-# Per-shell wrapper-symlink dir for cwd_glob mappings (mirrors
-# bash.sh).
-if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
-    __JITENV_RUNTIME_DIR="${XDG_RUNTIME_DIR%/}/jitenv"
-else
-    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}"
-    __JITENV_RUNTIME_DIR="${__JITENV_RUNTIME_DIR%/}/jitenv-$UID"
-fi
+__JITENV_RUNTIME_DIR={{RuntimeDir}}
+__JITENV_CFG_PATH={{ConfigPath}}
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 # See bash.sh — gates env injection in the shim so vars don't leak
 # into children of unmapped commands (issue #52).
@@ -24,34 +22,29 @@ case ":$PATH:" in
     *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;
 esac
 
+# Tiny per-shell $JITENV_CONFIG override so users can re-point one
+# shell at a different config without re-sourcing the hook. The
+# baked-in default (see __JITENV_CFG_PATH above) is what `jitenv`
+# itself resolves; this function exists so callers can query the
+# effective config path from inside the shell.
 __jitenv_cfg_path() {
     if [[ -n "${JITENV_CONFIG:-}" ]]; then
         print -r -- "$JITENV_CONFIG"
     else
-        print -r -- "${XDG_CONFIG_HOME:-$HOME/.config}/jitenv/config.toml"
+        print -r -- "$__JITENV_CFG_PATH"
     fi
-}
-__jitenv_cfg_mtime() {
-    local cfg="$1"
-    [[ -e "$cfg" ]] || { print -r -- 0; return; }
-    stat -c %Y "$cfg" 2>/dev/null || stat -f %m "$cfg" 2>/dev/null || print -r -- 0
 }
 # precmd-style hook: fires every time the prompt is about to redraw,
-# including after a cd (subsumes chpwd_functions). The PWD-diff +
-# mtime-diff inside makes the no-op case a tiny pair of comparisons.
-# The mtime branch handles "user edits config while sitting in the
-# mapped dir": symlinks get re-reconciled on the next prompt without
-# requiring a cd.
+# including after a cd. The Go side compares pwd and the config-file
+# mtime against per-shell sidecar state ($__JITENV_RUNTIME_DIR/shells/
+# $$/last-mtime + the wrapper-dir contents) and short-circuits when
+# nothing changed. One fork per prompt; Go has nothing to do in the
+# common case. Keeping the state in Go means a fresh re-source of the
+# hook doesn't cause a spurious reconcile.
 __jitenv_chpwd() {
-    local cfg mtime
-    cfg="$(__jitenv_cfg_path)"
-    mtime="$(__jitenv_cfg_mtime "$cfg")"
-    if [[ "$PWD" != "${__JITENV_LAST_PWD-}" || "$mtime" != "${__JITENV_LAST_CFG_MTIME-}" ]]; then
-        # No 2>/dev/null on purpose; see bash.sh for the rationale.
-        jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
-        __JITENV_LAST_PWD="$PWD"
-        __JITENV_LAST_CFG_MTIME="$mtime"
-    fi
+    # No 2>/dev/null on purpose; see bash.sh for the rationale.
+    jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
+    __JITENV_LAST_PWD="$PWD"
 }
 typeset -ga precmd_functions
 precmd_functions+=(__jitenv_chpwd)


### PR DESCRIPTION
Closes #36 v1 scope (items 1 and 5 from the issue body). Items 3 and 4 (BASH_COMMAND parsing, re-exec construction in Go) explicitly deferred — they add per-command fork+exec cost and deserve a separate perf-aware PR.

---

## Summary

Two changes that thin the shell hook layer without changing behaviour:

### 1. Template hook init (issue item 1)

`jitenv hook bash|zsh` now substitutes `{{RuntimeDir}}` and `{{ConfigPath}}` placeholders at print time, so the snippet stops re-deriving paths the Go side already knows.

**Before** (~30 lines of shell):

```sh
if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
    __JITENV_RUNTIME_DIR="${XDG_RUNTIME_DIR%/}/jitenv"
else
    __JITENV_RUNTIME_DIR="${TMPDIR:-/tmp}"
    __JITENV_RUNTIME_DIR="${__JITENV_RUNTIME_DIR%/}/jitenv-$UID"
fi
```

**After** (one line, rendered by Go):

```sh
__JITENV_RUNTIME_DIR='/run/user/1000/jitenv'
```

`internal/shell/render.go` does the substitution with `strings.NewReplacer` (simpler than `text/template` for two markers). Paths are single-quote-shell-escaped via a tiny helper so home dirs with spaces or apostrophes don't blow up the assignment.

**`JITENV_CONFIG` override semantics preserved** — the snippets retain a small `__jitenv_cfg_path()` function that prefers `$JITENV_CONFIG` at call time and falls back to the baked default. The Go-side `__chpwd` subcommand reads `os.Getenv("JITENV_CONFIG")` directly on each invocation, so per-shell overrides flow through naturally.

### 2. Sidecar state file for chpwd (issue item 5)

`__JITENV_LAST_CFG_MTIME` moves from a shell env var to a sidecar file at `<runtime>/jitenv/shells/<pid>/last-mtime` (decimal Unix nanoseconds, 0o600). Nanosecond resolution beats the old shell-side `stat -c %Y` (whole-second) and eliminates a class of "edit within the same second" misses — the bug fix that justifies the `fix:` retitle.

Reaped for free by the existing `agent.GcOrphanShells` walk.

## Removed from shell

- `if [[ -n "${XDG_RUNTIME_DIR:-}" ]] ... else ... fi` resolution blocks.
- `__jitenv_cfg_mtime()` and the GNU/BSD `stat` fallback.
- `__JITENV_LAST_CFG_MTIME` env var.
- The shell-side mtime-comparison inside `__jitenv_chpwd`.

## Line counts (snippets only)

|        | Before | After | Δ |
|---|---|---|---|
| bash.sh (total) | 162 | 144 | -18 |
| zsh.sh (total)  | 110 | 103 | -7 |
| bash.sh (code only) | 88 | 73 | -15 |
| zsh.sh (code only)  | 76 | 61 | -15 |

## Tests

- **`internal/shell/render_test.go`** (new) — covers placeholder substitution and shell-quoting of paths with spaces/apostrophes.
- **`internal/chpwd/chpwd_test.go`** (new) — covers the sidecar mtime read/write/short-circuit paths.
- **`internal/shell/hook_*_test.go`** (existing) — all e2e suites still pass.
- **All 9 e2e scenarios** pass on the full docker harness (debian + alpine + alpine-source + fedora + LocalStack). The three install-layout scenarios were updated to assert the new template contract: on-disk file contains `{{RuntimeDir}}` marker, hook output does not.

## Bonus fix (added during CI debugging)

The first CI run failed in `TestHookSnippetStripsTrailingSlash` with `mkdir /run/user/1000: permission denied` — the test set `XDG_RUNTIME_DIR=/run/user/1000` (a realistic path) but the GHA runner user can't create it. That exposed a real regression: `jitenv hook bash` is a print command and shouldn't need filesystem write access at all.

Fix: split `agent.DefaultPaths` into a pure `ResolvePaths` (no mkdir) and a `DefaultPaths` (mkdir, for callers that bind sockets / open logs). `internal/shell.Render` calls the pure variant. `jitenv hook bash` is read-only again.

## Out of scope (deferred to follow-up issues)

- BASH_COMMAND parsing in Go (#36 item 3).
- Re-exec line construction in Go (#36 item 4).
- New shell support (fish, dash).

## Rough edges

- One fork per prompt (`jitenv __chpwd`). Go short-circuits in submillisecond when nothing changed, but on cold caches the first invocation per prompt is still a process spawn. The issue explicitly accepts this tradeoff.

## Test plan

- [x] `make fmt vet tidy` clean.
- [x] `go test ./...` green (including the slow shell-package e2e suite).
- [x] `make build` clean.
- [x] `XDG_RUNTIME_DIR=/run/user/1000 HOME=/home/user jitenv hook bash` emits paths as literals; no mkdir.
- [x] `JITENV_CONFIG=/tmp/foo jitenv hook bash` honours the per-shell override.
- [x] All 9 e2e scenarios green.
- [ ] Reviewer (interactive bash): `eval "$(jitenv hook bash)"` and confirm the snippet looks sane; `cd` into a cwd_glob-mapped dir and confirm the wrapper symlinks still populate via the now-Go-driven chpwd path.
