### PR TITLE
fix(shim): suppress duplicate agent-down warning on execve chains (#71)

### DIFF
--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -41,6 +41,17 @@ import (
 // whether to paint the agent-down warning.
 var errAgentDown = errors.New("agent unreachable")
 
+// warnedMarker is a one-shot env marker that propagates through
+// execve chains so the agent-down warning fires at most once per
+// chain. Set when WarnAndWait returns (user dismissed via Enter or
+// the countdown timed out) and checked on shim re-entry — e.g.
+// `npm` (wrapper) → real npm → `#!/usr/bin/env node` → `node`
+// (wrapper) → shim again, same pid+ppid as the first entry, see
+// issue #71. The marker may leak into the final user program but
+// the alternative (stripping it before execReal) buys complexity
+// without value.
+const warnedMarker = "__JITENV_AGENT_WARNED"
+
 // Main is the shim entrypoint. invokedAs is filepath.Base(os.Args[0]),
 // args is os.Args[1:] (everything after argv[0]).
 func Main(invokedAs string, args []string) {
@@ -68,13 +79,21 @@ func run(invokedAs string, args []string) error {
 
 	env := os.Environ()
 	injected := 0
-	if shouldInject() {
+	// If a previous shim entry in this execve chain already showed the
+	// agent-down countdown (and the user dismissed it), skip fetch and
+	// warn entirely — see warnedMarker doc and issue #71.
+	alreadyWarned := os.Getenv(warnedMarker) == "1"
+	if shouldInject() && !alreadyWarned {
 		extra, fetchErr := fetchEnv(invokedAs)
 		switch {
 		case errors.Is(fetchErr, errAgentDown):
 			if agentwarn.WarnAndWait(invokedAs) {
 				return errors.New("aborted")
 			}
+			// User chose to continue without env. Propagate the marker
+			// so chained shim entries (e.g. npm → node via shebang)
+			// don't re-prompt.
+			env = append(env, warnedMarker+"=1")
 		case fetchErr != nil:
 			// Other error (config parse, fetch failure). Surface to
 			// stderr but don't block — the user explicitly invoked the

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -1,0 +1,131 @@
+package shim_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// buildBinary compiles the jitenv binary into the test's temp dir so
+// we can drop wrapper symlinks pointing at it. Mirrors the helper in
+// internal/run and internal/shell.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "jitenv")
+	cmd := exec.Command("go", "build", "-o", out, "../../cmd/jitenv")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return out
+}
+
+// TestShimSuppressesWarningWithMarker is the regression test for
+// issue #71: a `cwd_glob` mapping that lists both a command and its
+// interpreter (e.g. npm + node) used to render the agent-down
+// countdown twice because os.Getppid() is unchanged across the
+// execve chain. The fix propagates __JITENV_AGENT_WARNED=1 after the
+// first warning so subsequent shim entries short-circuit.
+//
+// We can't fake an execve chain inside the test runner cheaply, so
+// we exercise the suppression directly: invoke the shim symlink
+// twice. The first call (no marker, agent down) must print the
+// warning; the second call (marker set, agent still down) must NOT.
+// Both calls must exec the real binary either way.
+func TestShimSuppressesWarningWithMarker(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	// Real "fakecmd" the wrapper should execve into. Print a stable
+	// token so we can confirm the exec completed in each call.
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrapper symlink "fakecmd" -> jitenv. main.go dispatches into
+	// shim.Main because filepath.Base(argv[0]) != "jitenv".
+	wrapDir := filepath.Join(dir, "wrap")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty runtime dir → no agent socket → shim hits the warn path.
+	runtimeDir := filepath.Join(dir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// PATH puts the real fakecmd dir on the search path so the shim's
+	// lookPathExcluding finds it after skipping wrapDir.
+	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
+
+	// The shim's shouldInject() requires ppid (or pid) to equal
+	// __JITENV_SHELL_PID. The exec.Command child has ppid = this test
+	// process's pid, so set the marker to that.
+	shellPID := strconv.Itoa(os.Getpid())
+
+	baseEnv := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"__JITENV_WRAP_DIR=" + wrapDir,
+		"__JITENV_SHELL_PID=" + shellPID,
+		"JITENV_HOOK_DELAY=0",
+	}
+	// Inherit HOME so the binary's startup doesn't choke on a missing
+	// home dir on hermetic CI runners.
+	if home := os.Getenv("HOME"); home != "" {
+		baseEnv = append(baseEnv, "HOME="+home)
+	}
+
+	run := func(env []string) (string, error) {
+		cmd := exec.Command(wrapper)
+		cmd.Env = env
+		// Detach stdin from a TTY (pipe by default) so WarnAndWait
+		// takes the non-TTY fast path — no spinning on the countdown
+		// in tests; see issue #64.
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		err := cmd.Run()
+		return buf.String(), err
+	}
+
+	// 1. No marker → warning expected.
+	out1, err := run(baseEnv)
+	if err != nil {
+		t.Fatalf("first run: %v\noutput=%s", err, out1)
+	}
+	if !strings.Contains(out1, "agent is not loaded") {
+		t.Errorf("first run: expected 'agent is not loaded' warning;\noutput=%s", out1)
+	}
+	if !strings.Contains(out1, "RAN") {
+		t.Errorf("first run: expected fakecmd to exec ('RAN');\noutput=%s", out1)
+	}
+
+	// 2. Marker set → no warning, but the real binary still runs.
+	out2, err := run(append(baseEnv, "__JITENV_AGENT_WARNED=1"))
+	if err != nil {
+		t.Fatalf("second run: %v\noutput=%s", err, out2)
+	}
+	if strings.Contains(out2, "agent is not loaded") {
+		t.Errorf("second run: warning fired despite __JITENV_AGENT_WARNED=1;\noutput=%s", out2)
+	}
+	if !strings.Contains(out2, "RAN") {
+		t.Errorf("second run: expected fakecmd to exec ('RAN');\noutput=%s", out2)
+	}
+}


### PR DESCRIPTION
## Summary

A `cwd_glob` mapping that lists both a command and its interpreter (e.g. `commands = ["npm", "node"]`) used to render the agent-down countdown twice — `os.Getppid()` doesn't change across an `execve` chain (npm wrapper -> real npm -> `#!/usr/bin/env node` -> node wrapper all share the original pid+ppid), so `shouldInject()` re-fired and `WarnAndWait` re-prompted. The two banners stacked back-to-back looked like one prompt that needed two Enter presses.

Fix: after `WarnAndWait` returns, append `__JITENV_AGENT_WARNED=1` to the env passed to `syscall.Exec`. On shim re-entry the marker short-circuits both the fetch and the warning.

Closes #71.

- Adds `internal/shim/shim_test.go::TestShimSuppressesWarningWithMarker` — builds the binary, drops a wrapper symlink, runs it twice with no agent socket: first call must show the banner, second call (with the marker set) must not.