### PR TITLE
feat(tui): bulk-import KEY=VALUE pairs into a local bag (#70)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
@@ -34,6 +36,8 @@ github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
 github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/tui/bag_bulk_import.go
+++ b/internal/tui/bag_bulk_import.go
@@ -1,0 +1,334 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// bagBulkImportScreen lets the user paste a block of dotenv-style
+// KEY=VALUE lines and merge them into an existing bag in one shot.
+//
+// State machine:
+//
+//	phaseEdit    — textarea + Parse/Back buttons. Submitting runs the
+//	               parser. Parse errors stay on this screen so the user
+//	               can fix and resubmit.
+//	phasePreview — read-only preview of parsed pairs + a list of name
+//	               collisions with the existing bag. From here Apply
+//	               either commits directly (no collisions) or opens a
+//	               small "Overwrite all / Skip all / Back" confirm.
+//
+// On Apply with no collisions or after the user picks "Overwrite all" /
+// "Skip all", the pairs are merged into r.cfg.Secrets[bag] and the
+// screen pops back to the bag-detail view. The existing TUI Ctrl+S
+// flow re-encrypts and writes; the user still has to press Ctrl+S to
+// persist (same as every other in-TUI edit).
+type bagBulkImportScreen struct {
+	root *rootModel
+	bag  string
+
+	phase    int
+	area     textarea.Model
+	btnFocus int
+	buttons  []button
+
+	parseErrs  []dotenvError
+	pairs      []dotenvPair // last parse result (in input order, dedup'd)
+	collisions []string     // keys present in both pairs and existing bag
+}
+
+const (
+	phaseEdit = iota
+	phasePreview
+)
+
+func newBagBulkImportScreen(r *rootModel, bag string) screen {
+	ta := textarea.New()
+	ta.Placeholder = "KEY=VALUE\nQUOTED=\"value with spaces\"\nexport ANOTHER=value\n# comments and blank lines ignored"
+	ta.ShowLineNumbers = true
+	ta.Prompt = "│ "
+	ta.SetWidth(72)
+	ta.SetHeight(14)
+	ta.CharLimit = 0
+	ta.Focus()
+	return &bagBulkImportScreen{
+		root:     r,
+		bag:      bag,
+		phase:    phaseEdit,
+		area:     ta,
+		btnFocus: -1,
+		buttons:  []button{newButton("Parse"), newButton("Back")},
+	}
+}
+
+func (s *bagBulkImportScreen) Title() string {
+	return "bulk import: " + s.bag
+}
+
+func (s *bagBulkImportScreen) Status() string { return defaultFormStatus }
+
+func (s *bagBulkImportScreen) Init() tea.Cmd { return textarea.Blink }
+
+func (s *bagBulkImportScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	if s.phase == phasePreview {
+		return s.updatePreview(msg)
+	}
+	return s.updateEdit(msg)
+}
+
+// ----- edit phase --------------------------------------------------
+
+func (s *bagBulkImportScreen) updateEdit(msg tea.Msg) (screen, tea.Cmd) {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		switch k.String() {
+		case "esc":
+			return s, emit(popMsg{})
+		case "tab":
+			s.advance(+1)
+			return s, nil
+		case "shift+tab":
+			s.advance(-1)
+			return s, nil
+		case "enter":
+			if s.btnFocus >= 0 {
+				label := s.buttons[s.btnFocus].label
+				switch label {
+				case "Parse":
+					return s, s.runParse()
+				case "Back":
+					return s, emit(popMsg{})
+				}
+				return s, nil
+			}
+			// Inside the textarea: pass enter through so it inserts a newline.
+		}
+	}
+	if s.btnFocus < 0 {
+		var cmd tea.Cmd
+		s.area, cmd = s.area.Update(msg)
+		return s, cmd
+	}
+	return s, nil
+}
+
+func (s *bagBulkImportScreen) advance(dir int) {
+	if dir > 0 {
+		if s.btnFocus < 0 {
+			s.btnFocus = 0
+			s.area.Blur()
+			return
+		}
+		if s.btnFocus < len(s.buttons)-1 {
+			s.btnFocus++
+			return
+		}
+		s.btnFocus = -1
+		s.area.Focus()
+		return
+	}
+	if s.btnFocus < 0 {
+		s.btnFocus = len(s.buttons) - 1
+		s.area.Blur()
+		return
+	}
+	if s.btnFocus > 0 {
+		s.btnFocus--
+		return
+	}
+	s.btnFocus = -1
+	s.area.Focus()
+}
+
+// runParse parses the textarea contents. On success it advances to the
+// preview phase; on parse errors it stays on the edit screen and lets
+// the user see / fix the errors.
+func (s *bagBulkImportScreen) runParse() tea.Cmd {
+	pairs, errs := parseDotenv(s.area.Value())
+	s.parseErrs = errs
+	if len(errs) > 0 {
+		s.pairs = nil
+		s.collisions = nil
+		return emit(errorMsg(fmt.Sprintf("%d parse error(s) — fix and retry", len(errs))))
+	}
+	if len(pairs) == 0 {
+		s.pairs = nil
+		s.collisions = nil
+		return emit(errorMsg("nothing to import — input is empty"))
+	}
+
+	// Deduplicate: later occurrences of the same key win, matching
+	// shell `set -a; source .env` semantics.
+	dedup := make(map[string]int, len(pairs))
+	for i, p := range pairs {
+		dedup[p.Key] = i
+	}
+	kept := make([]dotenvPair, 0, len(dedup))
+	for i, p := range pairs {
+		if dedup[p.Key] == i {
+			kept = append(kept, p)
+		}
+	}
+	s.pairs = kept
+
+	// Detect collisions with the existing bag.
+	s.collisions = s.collisions[:0]
+	existing := s.root.cfg.Secrets[s.bag]
+	for _, p := range s.pairs {
+		if _, hit := existing[p.Key]; hit {
+			s.collisions = append(s.collisions, p.Key)
+		}
+	}
+	sort.Strings(s.collisions)
+
+	s.phase = phasePreview
+	s.btnFocus = 0
+	s.buttons = []button{newButton("Apply"), newButton("Back to edit")}
+	return nil
+}
+
+// ----- preview phase -----------------------------------------------
+
+func (s *bagBulkImportScreen) updatePreview(msg tea.Msg) (screen, tea.Cmd) {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		switch k.String() {
+		case "esc":
+			return s, emit(popMsg{})
+		case "tab", "right":
+			if s.btnFocus < len(s.buttons)-1 {
+				s.btnFocus++
+			} else {
+				s.btnFocus = 0
+			}
+			return s, nil
+		case "shift+tab", "left":
+			if s.btnFocus > 0 {
+				s.btnFocus--
+			} else {
+				s.btnFocus = len(s.buttons) - 1
+			}
+			return s, nil
+		case "enter":
+			label := s.buttons[s.btnFocus].label
+			switch label {
+			case "Apply":
+				return s, s.apply()
+			case "Back to edit":
+				s.phase = phaseEdit
+				s.btnFocus = -1
+				s.buttons = []button{newButton("Parse"), newButton("Back")}
+				s.area.Focus()
+				return s, nil
+			}
+		}
+	}
+	return s, nil
+}
+
+// apply commits the parsed pairs to the bag. When the pasted block
+// contains keys that already exist in the bag we surface a small
+// "Overwrite all / Skip all / Back" confirm popup so the user can pick
+// a single policy that applies to every collision.
+func (s *bagBulkImportScreen) apply() tea.Cmd {
+	if len(s.collisions) == 0 {
+		return s.commitMerge(true)
+	}
+	prompt := fmt.Sprintf("%d existing key(s) collide. How do you want to handle them?", len(s.collisions))
+	cb := func(choice string) tea.Cmd {
+		switch choice {
+		case "Overwrite all":
+			return tea.Sequence(emit(popMsg{}), s.commitMerge(true))
+		case "Skip all":
+			return tea.Sequence(emit(popMsg{}), s.commitMerge(false))
+		}
+		return emit(popMsg{})
+	}
+	return emit(pushMsg{s: newConfirmScreen(s.root, prompt, cb,
+		"Overwrite all", "Skip all", "Back",
+	)})
+}
+
+// commitMerge writes the parsed pairs into the bag, honouring the
+// caller's policy for keys that already exist. It returns the
+// tea.Cmd sequence that pops this screen and surfaces a status flash.
+func (s *bagBulkImportScreen) commitMerge(overwrite bool) tea.Cmd {
+	bag := s.root.cfg.Secrets[s.bag]
+	if bag == nil {
+		bag = map[string]string{}
+		s.root.cfg.Secrets[s.bag] = bag
+	}
+	added, replaced, skipped := 0, 0, 0
+	for _, p := range s.pairs {
+		if _, hit := bag[p.Key]; hit {
+			if !overwrite {
+				skipped++
+				continue
+			}
+			bag[p.Key] = p.Value
+			replaced++
+			continue
+		}
+		bag[p.Key] = p.Value
+		added++
+	}
+	msg := fmt.Sprintf("bulk import: %d added, %d overwritten, %d skipped", added, replaced, skipped)
+	return tea.Sequence(
+		emit(popMsg{}),
+		emit(dirtyMsg{}),
+		emit(secretChangedMsg{}),
+		emit(statusMsg(msg)),
+	)
+}
+
+// ----- view --------------------------------------------------------
+
+func (s *bagBulkImportScreen) View() string {
+	if s.phase == phasePreview {
+		return s.viewPreview()
+	}
+	return s.viewEdit()
+}
+
+func (s *bagBulkImportScreen) viewEdit() string {
+	var b strings.Builder
+	b.WriteString(labelStyle.Render("Paste KEY=VALUE pairs to import into "+s.bag) + "\n")
+	b.WriteString(dimText("Supported: KEY=value, KEY=\"quoted\", KEY='single', export KEY=value, # comments.") + "\n")
+	b.WriteString(dimText("Tab moves to the buttons. Use Parse to validate, then Apply to merge.") + "\n\n")
+	b.WriteString(s.area.View() + "\n\n")
+	if len(s.parseErrs) > 0 {
+		b.WriteString(errorStyle.Render(fmt.Sprintf("%d parse error(s):", len(s.parseErrs))) + "\n")
+		for _, e := range s.parseErrs {
+			b.WriteString("  " + errorStyle.Render(e.Error()) + "\n")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(renderButtonRow(s.buttons, s.btnFocus) + "\n")
+	return b.String()
+}
+
+func (s *bagBulkImportScreen) viewPreview() string {
+	var b strings.Builder
+	b.WriteString(labelStyle.Render(fmt.Sprintf("Preview — %d key(s) to import into %s", len(s.pairs), s.bag)) + "\n\n")
+	for _, p := range s.pairs {
+		marker := "  "
+		key := p.Key
+		if _, hit := s.root.cfg.Secrets[s.bag][p.Key]; hit {
+			marker = warnStyle.Render("⚠ ")
+			key = warnStyle.Render(p.Key)
+		}
+		row := fmt.Sprintf("%s%-24s = %s", marker, key, maskValue(p.Value))
+		b.WriteString(row + "\n")
+	}
+	if len(s.collisions) > 0 {
+		b.WriteString("\n" + warnStyle.Render(fmt.Sprintf("%d key(s) already exist in this bag:", len(s.collisions))) + "\n")
+		b.WriteString("  " + dimText(strings.Join(s.collisions, ", ")) + "\n")
+		b.WriteString(dimText("On Apply you'll be asked whether to overwrite or skip them.") + "\n")
+	} else {
+		b.WriteString("\n" + okStyle.Render("No collisions — Apply will add every key.") + "\n")
+	}
+	b.WriteString("\n" + renderButtonRow(s.buttons, s.btnFocus) + "\n")
+	return b.String()
+}

--- a/internal/tui/dotenv.go
+++ b/internal/tui/dotenv.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// dotenvPair is one KEY = VALUE pair parsed from a dotenv-style block.
+type dotenvPair struct {
+	Key   string
+	Value string
+	Line  int // 1-based source line for error reporting
+}
+
+// dotenvError is a single parse error tied to a source line. It exists
+// as its own type so callers can render line numbers cleanly.
+type dotenvError struct {
+	Line int
+	Msg  string
+}
+
+func (e dotenvError) Error() string {
+	return fmt.Sprintf("line %d: %s", e.Line, e.Msg)
+}
+
+// parseDotenv parses dotenv-style content into pairs. Recognised syntax:
+//
+//	KEY=VALUE                   bare value, no surrounding whitespace required
+//	KEY="quoted value"          double-quoted; supports \n \r \t \\ \" escapes
+//	KEY='single quoted'         single-quoted; no escape processing
+//	export KEY=VALUE            optional shell-style export prefix
+//	# comment                   ignored
+//	(blank line)                ignored
+//
+// Lines without an '=' separator (after stripping the optional 'export'
+// prefix) are reported as parse errors. The caller is expected to
+// surface the errors to the user and refuse to import on any error.
+//
+// On a duplicate key inside the same input the later value wins; the
+// caller decides what to do with collisions against the existing bag.
+func parseDotenv(input string) ([]dotenvPair, []dotenvError) {
+	var pairs []dotenvPair
+	var errs []dotenvError
+
+	// Normalise line endings so a Windows-style \r\n paste behaves like
+	// a Unix one. We split on \n then strip a trailing \r per line.
+	lines := strings.Split(input, "\n")
+	for i, raw := range lines {
+		lineNo := i + 1
+		line := strings.TrimRight(raw, "\r")
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Strip an optional "export " prefix.
+		if rest, ok := stripExport(line); ok {
+			line = rest
+		}
+
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			errs = append(errs, dotenvError{Line: lineNo, Msg: "no '=' separator"})
+			continue
+		}
+
+		key := strings.TrimSpace(line[:eq])
+		if key == "" {
+			errs = append(errs, dotenvError{Line: lineNo, Msg: "empty key"})
+			continue
+		}
+		if !isValidEnvKey(key) {
+			errs = append(errs, dotenvError{Line: lineNo, Msg: fmt.Sprintf("invalid key %q", key)})
+			continue
+		}
+
+		rawVal := strings.TrimLeft(line[eq+1:], " \t")
+		val, err := unquoteValue(rawVal)
+		if err != nil {
+			errs = append(errs, dotenvError{Line: lineNo, Msg: err.Error()})
+			continue
+		}
+		pairs = append(pairs, dotenvPair{Key: key, Value: val, Line: lineNo})
+	}
+	return pairs, errs
+}
+
+// stripExport returns (rest, true) if line begins with the shell
+// "export " prefix. The check requires at least one trailing whitespace
+// character so we don't accidentally strip a key that happens to start
+// with "export" (e.g. "exported=1").
+func stripExport(line string) (string, bool) {
+	const p = "export"
+	if !strings.HasPrefix(line, p) {
+		return line, false
+	}
+	if len(line) == len(p) {
+		return line, false
+	}
+	c := line[len(p)]
+	if c != ' ' && c != '\t' {
+		return line, false
+	}
+	return strings.TrimLeft(line[len(p):], " \t"), true
+}
+
+// unquoteValue strips surrounding quotes (single or double) and, for
+// double quotes only, processes a small set of backslash escapes. A
+// trailing inline comment (` # ...`) is dropped from bare values; this
+// matches the behaviour most dotenv readers settle on.
+func unquoteValue(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	switch s[0] {
+	case '"':
+		// Find the matching closing quote, honouring backslash escapes.
+		var b strings.Builder
+		i := 1
+		for i < len(s) {
+			c := s[i]
+			if c == '\\' && i+1 < len(s) {
+				switch s[i+1] {
+				case 'n':
+					b.WriteByte('\n')
+				case 'r':
+					b.WriteByte('\r')
+				case 't':
+					b.WriteByte('\t')
+				case '\\':
+					b.WriteByte('\\')
+				case '"':
+					b.WriteByte('"')
+				default:
+					b.WriteByte(s[i+1])
+				}
+				i += 2
+				continue
+			}
+			if c == '"' {
+				// Closing quote. Anything after is ignored (typically
+				// whitespace or an inline comment).
+				return b.String(), nil
+			}
+			b.WriteByte(c)
+			i++
+		}
+		return "", fmt.Errorf("unterminated double quote")
+	case '\'':
+		end := strings.IndexByte(s[1:], '\'')
+		if end < 0 {
+			return "", fmt.Errorf("unterminated single quote")
+		}
+		return s[1 : 1+end], nil
+	default:
+		// Bare value: strip an inline ` # comment` then trim trailing
+		// whitespace.
+		if idx := strings.Index(s, " #"); idx >= 0 {
+			s = s[:idx]
+		}
+		return strings.TrimRight(s, " \t"), nil
+	}
+}
+
+// isValidEnvKey enforces the conservative POSIX-ish rule used elsewhere
+// in this codebase: identifiers must start with a letter or underscore
+// and contain only letters, digits or underscores.
+func isValidEnvKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/dotenv_test.go
+++ b/internal/tui/dotenv_test.go
@@ -1,0 +1,224 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseDotenv_Simple(t *testing.T) {
+	pairs, errs := parseDotenv("FOO=bar\nBAZ=qux\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(pairs) != 2 {
+		t.Fatalf("want 2 pairs, got %d (%v)", len(pairs), pairs)
+	}
+	if pairs[0].Key != "FOO" || pairs[0].Value != "bar" {
+		t.Errorf("pair0 = %+v", pairs[0])
+	}
+	if pairs[1].Key != "BAZ" || pairs[1].Value != "qux" {
+		t.Errorf("pair1 = %+v", pairs[1])
+	}
+}
+
+func TestParseDotenv_DoubleQuoted(t *testing.T) {
+	pairs, errs := parseDotenv(`FOO="hello world"` + "\n" + `BAR="line1\nline2"` + "\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Value != "hello world" {
+		t.Errorf("FOO value = %q", pairs[0].Value)
+	}
+	if pairs[1].Value != "line1\nline2" {
+		t.Errorf("BAR value = %q (want escape-processed)", pairs[1].Value)
+	}
+}
+
+func TestParseDotenv_DoubleQuoted_EscapedQuote(t *testing.T) {
+	pairs, errs := parseDotenv(`KEY="he said \"hi\""` + "\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Value != `he said "hi"` {
+		t.Errorf("value = %q", pairs[0].Value)
+	}
+}
+
+func TestParseDotenv_SingleQuoted_NoEscape(t *testing.T) {
+	pairs, errs := parseDotenv(`FOO='no \n escape here'` + "\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Value != `no \n escape here` {
+		t.Errorf("value = %q (single-quoted must not process escapes)", pairs[0].Value)
+	}
+}
+
+func TestParseDotenv_ExportPrefix(t *testing.T) {
+	pairs, errs := parseDotenv("export FOO=bar\nexport\tBAZ=qux\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Key != "FOO" || pairs[0].Value != "bar" {
+		t.Errorf("pair0 = %+v", pairs[0])
+	}
+	if pairs[1].Key != "BAZ" || pairs[1].Value != "qux" {
+		t.Errorf("pair1 = %+v", pairs[1])
+	}
+}
+
+func TestParseDotenv_ExportLookalike(t *testing.T) {
+	// A key literally named "exported" is not the export prefix.
+	pairs, errs := parseDotenv("exported=1\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Key != "exported" || pairs[0].Value != "1" {
+		t.Errorf("pair0 = %+v", pairs[0])
+	}
+}
+
+func TestParseDotenv_CommentsAndBlanks(t *testing.T) {
+	input := `# a comment
+   # indented comment
+
+FOO=bar
+
+# trailing comment
+BAZ=qux
+`
+	pairs, errs := parseDotenv(input)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(pairs) != 2 {
+		t.Fatalf("want 2 pairs, got %d", len(pairs))
+	}
+}
+
+func TestParseDotenv_InlineCommentOnBareValue(t *testing.T) {
+	pairs, errs := parseDotenv("FOO=bar # trailing\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Value != "bar" {
+		t.Errorf("value = %q (inline comment should be stripped)", pairs[0].Value)
+	}
+}
+
+func TestParseDotenv_HashInsideQuotes(t *testing.T) {
+	pairs, errs := parseDotenv(`FOO="a # not a comment"` + "\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Value != "a # not a comment" {
+		t.Errorf("value = %q (# inside quotes must be preserved)", pairs[0].Value)
+	}
+}
+
+func TestParseDotenv_Malformed_NoEquals(t *testing.T) {
+	_, errs := parseDotenv("FOO=bar\nthis is not a pair\nBAZ=qux\n")
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %d (%v)", len(errs), errs)
+	}
+	if errs[0].Line != 2 {
+		t.Errorf("err line = %d, want 2", errs[0].Line)
+	}
+	if !strings.Contains(errs[0].Msg, "no '='") {
+		t.Errorf("err msg = %q", errs[0].Msg)
+	}
+}
+
+func TestParseDotenv_Malformed_EmptyKey(t *testing.T) {
+	_, errs := parseDotenv("=value\n")
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %d", len(errs))
+	}
+	if !strings.Contains(errs[0].Msg, "empty key") {
+		t.Errorf("err msg = %q", errs[0].Msg)
+	}
+}
+
+func TestParseDotenv_Malformed_InvalidKey(t *testing.T) {
+	_, errs := parseDotenv("9FOO=bar\n")
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %d", len(errs))
+	}
+	if !strings.Contains(errs[0].Msg, "invalid key") {
+		t.Errorf("err msg = %q", errs[0].Msg)
+	}
+}
+
+func TestParseDotenv_UnterminatedQuote(t *testing.T) {
+	_, errs := parseDotenv(`FOO="oops` + "\n")
+	if len(errs) != 1 {
+		t.Fatalf("want 1 err, got %d", len(errs))
+	}
+	if !strings.Contains(errs[0].Msg, "unterminated") {
+		t.Errorf("err msg = %q", errs[0].Msg)
+	}
+}
+
+func TestParseDotenv_Empty(t *testing.T) {
+	pairs, errs := parseDotenv("")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(pairs) != 0 {
+		t.Fatalf("want 0 pairs, got %d", len(pairs))
+	}
+}
+
+func TestParseDotenv_WhitespaceOnly(t *testing.T) {
+	pairs, errs := parseDotenv("   \n\t\n\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(pairs) != 0 {
+		t.Fatalf("want 0 pairs, got %d", len(pairs))
+	}
+}
+
+func TestParseDotenv_CRLFEndings(t *testing.T) {
+	pairs, errs := parseDotenv("FOO=bar\r\nBAZ=qux\r\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(pairs) != 2 || pairs[0].Value != "bar" || pairs[1].Value != "qux" {
+		t.Errorf("pairs = %v", pairs)
+	}
+}
+
+func TestParseDotenv_TrimsTrailingWhitespaceOnBare(t *testing.T) {
+	pairs, errs := parseDotenv("FOO=bar   \n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Value != "bar" {
+		t.Errorf("value = %q", pairs[0].Value)
+	}
+}
+
+func TestParseDotenv_DuplicateKeyLaterWins(t *testing.T) {
+	pairs, errs := parseDotenv("FOO=one\nFOO=two\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(pairs) != 2 {
+		t.Fatalf("want 2 pairs, got %d", len(pairs))
+	}
+	// Parser keeps both; the caller decides the merge policy.
+	if pairs[0].Value != "one" || pairs[1].Value != "two" {
+		t.Errorf("pairs = %v", pairs)
+	}
+}
+
+func TestParseDotenv_EmptyValueAllowed(t *testing.T) {
+	pairs, errs := parseDotenv("FOO=\n")
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if pairs[0].Key != "FOO" || pairs[0].Value != "" {
+		t.Errorf("pair = %+v", pairs[0])
+	}
+}

--- a/internal/tui/secrets_screen.go
+++ b/internal/tui/secrets_screen.go
@@ -223,9 +223,9 @@ func newRenameBagScreen(r *rootModel, oldName string) screen {
 // ----- bag detail (key/value rows) ---------------------------------
 
 // secretDetailScreen mirrors the bag list pattern: a single list whose
-// top row is "< Create New Key >" and whose remaining rows are the
-// bag's keys. Selecting a key opens a popup with Edit / Rename /
-// Delete / Reveal-Hide / Back.
+// top rows are sentinels — "< Create New Key >" and "< Bulk Import
+// (paste KEY=VALUE) >" — followed by the bag's keys. Selecting a key
+// opens a popup with Edit / Delete / Back.
 type secretDetailScreen struct {
 	root   *rootModel
 	bag    string
@@ -233,6 +233,11 @@ type secretDetailScreen struct {
 	cursor int
 	reveal map[string]bool
 }
+
+// secretDetailSentinelCount is the number of action sentinel rows
+// rendered above the bag's keys. cursor in [0, sentinelCount) selects a
+// sentinel; cursor >= sentinelCount selects a key at index cursor-N.
+const secretDetailSentinelCount = 2
 
 func newSecretDetailScreen(r *rootModel, bag string) screen {
 	s := &secretDetailScreen{
@@ -251,7 +256,7 @@ func (s *secretDetailScreen) refresh() {
 		s.keys = append(s.keys, k)
 	}
 	sort.Strings(s.keys)
-	maxRow := len(s.keys)
+	maxRow := len(s.keys) + secretDetailSentinelCount - 1
 	if s.cursor > maxRow {
 		s.cursor = maxRow
 	}
@@ -294,7 +299,7 @@ func (s *secretDetailScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 		return s, nil
 	}
 	if k, ok := msg.(tea.KeyMsg); ok {
-		total := len(s.keys) + 1 // sentinel + keys
+		total := len(s.keys) + secretDetailSentinelCount
 		switch k.String() {
 		case "up", "k":
 			if s.cursor > 0 {
@@ -305,8 +310,11 @@ func (s *secretDetailScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				s.cursor++
 			}
 		case "enter":
-			if s.cursor == 0 {
+			switch s.cursor {
+			case 0:
 				return s, emit(pushMsg{s: newKeyValueEditor(s.root, s.bag, "")})
+			case 1:
+				return s, emit(pushMsg{s: newBagBulkImportScreen(s.root, s.bag)})
 			}
 			return s, s.openMenu()
 		case "r":
@@ -321,10 +329,14 @@ func (s *secretDetailScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 }
 
 func (s *secretDetailScreen) selectedKey() string {
-	if s.cursor == 0 || len(s.keys) == 0 {
+	if s.cursor < secretDetailSentinelCount || len(s.keys) == 0 {
 		return ""
 	}
-	return s.keys[s.cursor-1]
+	idx := s.cursor - secretDetailSentinelCount
+	if idx < 0 || idx >= len(s.keys) {
+		return ""
+	}
+	return s.keys[idx]
 }
 
 func (s *secretDetailScreen) openMenu() tea.Cmd {
@@ -363,11 +375,16 @@ func (s *secretDetailScreen) View() string {
 	var b strings.Builder
 	b.WriteString(labelStyle.Render("Keys in "+s.bag) + "\n\n")
 
-	sentinel := "< Create New Key >"
-	if s.cursor == 0 {
-		b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(sentinel) + "\n")
-	} else {
-		b.WriteString("   " + listItemStyle.Render(sentinel) + "\n")
+	sentinels := []string{
+		"< Create New Key >",
+		"< Bulk Import (paste KEY=VALUE) >",
+	}
+	for i, label := range sentinels {
+		if s.cursor == i {
+			b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(label) + "\n")
+		} else {
+			b.WriteString("   " + listItemStyle.Render(label) + "\n")
+		}
 	}
 
 	for i, k := range s.keys {
@@ -377,7 +394,7 @@ func (s *secretDetailScreen) View() string {
 			shown = v
 		}
 		row := fmt.Sprintf("%-24s = %s", k, shown)
-		if i+1 == s.cursor {
+		if i+secretDetailSentinelCount == s.cursor {
 			b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(row) + "\n")
 		} else {
 			b.WriteString("   " + listItemStyle.Render(row) + "\n")


### PR DESCRIPTION
## Summary

Adds a "< Bulk Import (paste KEY=VALUE) >" entry to the bag-detail screen so users can migrate a `.env` file into a local bag in one paste instead of one key at a time. The new screen runs a dotenv-style parser, previews the parsed pairs (warning on existing-key collisions), and on Apply merges them into `cfg.Secrets[bag]` via the existing TUI save path — values round-trip through `crypto.EncryptString` and the agent is pinged for reload exactly like every other secret edit.

On collisions the user is offered a single uniform choice — **Overwrite all / Skip all / Back** — rather than a per-key prompt, matching the simpler UX called out in the issue.

Parser handles: `KEY=VALUE`, `"double-quoted"` (with `\n \r \t \\ \"` escapes), `'single-quoted'` (no escape processing), `export KEY=value`, `#` comments, blank lines, CRLF endings, and inline `# comment` on bare values. Lines without an `=` separator surface as line-numbered parse errors and the import refuses to proceed.

- Parser test coverage: 19 unit tests in `internal/tui/dotenv_test.go` covering simple, double/single quoted, escaped quote, `export` prefix, `export`-lookalike key, inline `#` comment, `#` inside quotes, malformed/empty/invalid key, unterminated quote, empty input, whitespace-only input, CRLF, trailing whitespace, duplicate-key-later-wins, empty value.

Closes #70.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make build`
- [x] Manual TUI smoke: open a bag, pick `< Bulk Import (paste KEY=VALUE) >`, paste a `.env` block, Parse → Apply, Ctrl+S, verify keys land in `config.toml` as `enc:v1:` envelopes
- [x] Manual TUI smoke: paste a block where a key already exists in the bag, verify the Overwrite-all / Skip-all popup fires and both branches behave