### PR TITLE
fix(tui): drop dup help-text + remove unsafe AWS profile field (#76)

### DIFF
--- a/internal/sources/aws/aws.go
+++ b/internal/sources/aws/aws.go
@@ -30,7 +30,7 @@ func schema() []source.ParamField {
 	return []source.ParamField{
 		{Key: "region", Label: "AWS region", Required: true, Help: "e.g. us-east-1"},
 		{Key: "access_key_id", Label: "Access key ID",
-			Help: "Leave all credential fields empty to fall back to the AWS default chain (env vars / shared config / instance role)."},
+			Help: "Leave credential fields empty to use the AWS default chain."},
 		{Key: "secret_access_key", Label: "Secret access key", Sensitive: true,
 			Help: "Encrypted at rest under the master key."},
 		{Key: "session_token", Label: "Session token", Sensitive: true,
@@ -43,10 +43,15 @@ func schema() []source.ParamField {
 			Help: "Optional; default: jitenv"},
 		{Key: "endpoint_override", Label: "Endpoint URL override",
 			Help: "Optional: override STS / Secrets Manager endpoints (e.g. http://localhost:4566 for LocalStack)."},
-		{Key: "profile", Label: "Shared-config profile",
-			Help: "Optional: AWS_PROFILE name when falling back to the default chain. Ignored if Access key ID is set."},
 	}
 }
+
+// errProfileRemoved is returned by New when a stored config still
+// carries a non-empty `profile` value. Falling silently back to the
+// default credential chain risks loading the wrong AWS account, so we
+// fail hard and tell the user how to migrate.
+const errProfileRemoved = `the "profile" field has been removed from the AWS source.
+Clear it from your config and set AWS_PROFILE in your environment instead.`
 
 // New constructs an AWS Secrets Manager source.
 //
@@ -55,8 +60,7 @@ func schema() []source.ParamField {
 //   - access_key_id non-empty → static credentials from the UI fields
 //     (secret_access_key required; session_token optional).
 //   - access_key_id empty     → AWS default credential chain
-//     (env vars, shared config, instance/IRSA), optionally scoped to
-//     `profile`.
+//     (env vars, shared config, instance/IRSA).
 //
 // In either case, if `role_arn` is set, the source assumes that role via
 // STS using the resolved base credentials. `endpoint_override`, when
@@ -66,7 +70,15 @@ func schema() []source.ParamField {
 // source is allowed to read. The TUI surfaces them as bags in the
 // var-tree picker; the agent only ever Fetches IDs the user explicitly
 // added.
+//
+// The legacy `profile` field is no longer accepted; a non-empty value
+// in stored config trips a hard error so credential resolution never
+// silently drifts to the wrong account. Migrate by clearing the field
+// and exporting AWS_PROFILE in the environment.
 func New(cfg map[string]any) (source.Source, error) {
+	if p := asString(cfg["profile"]); p != "" {
+		return nil, errors.New(errProfileRemoved)
+	}
 	s := &awsSource{
 		region:           asString(cfg["region"]),
 		accessKeyID:      asString(cfg["access_key_id"]),
@@ -76,7 +88,6 @@ func New(cfg map[string]any) (source.Source, error) {
 		roleExternalID:   asString(cfg["role_external_id"]),
 		roleSessionName:  asString(cfg["role_session_name"]),
 		endpointOverride: asString(cfg["endpoint_override"]),
-		profile:          asString(cfg["profile"]),
 		arns:             asStringList(cfg["arns"]),
 	}
 	if s.accessKeyID != "" && s.secretAccessKey == "" {
@@ -119,7 +130,6 @@ type awsSource struct {
 	roleExternalID   string
 	roleSessionName  string
 	endpointOverride string
-	profile          string
 	arns             []string
 }
 
@@ -136,13 +146,10 @@ func (a *awsSource) loadAwsCfg(ctx context.Context) (awsv2.Config, error) {
 		opts = append(opts, config.WithRegion(a.region))
 	}
 
-	switch {
-	case a.accessKeyID != "":
+	if a.accessKeyID != "" {
 		opts = append(opts, config.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(a.accessKeyID, a.secretAccessKey, a.sessionToken),
 		))
-	case a.profile != "":
-		opts = append(opts, config.WithSharedConfigProfile(a.profile))
 	}
 
 	cfg, err := config.LoadDefaultConfig(ctx, opts...)

--- a/internal/sources/aws/aws_test.go
+++ b/internal/sources/aws/aws_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -44,7 +45,6 @@ func TestSchemaHasRequiredFields(t *testing.T) {
 		"role_external_id":  false,
 		"role_session_name": false,
 		"endpoint_override": false,
-		"profile":           false,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("schema fields: got %d, want %d", len(got), len(want))
@@ -58,6 +58,40 @@ func TestSchemaHasRequiredFields(t *testing.T) {
 		if f.Required != req {
 			t.Errorf("field %q required: got %v, want %v", f.Key, f.Required, req)
 		}
+	}
+}
+
+func TestSchemaDoesNotIncludeProfile(t *testing.T) {
+	for _, f := range schema() {
+		if f.Key == "profile" {
+			t.Fatalf("schema still exposes removed %q field", f.Key)
+		}
+	}
+}
+
+func TestNewRejectsLegacyProfileField(t *testing.T) {
+	_, err := New(map[string]any{
+		"region":  "us-east-1",
+		"profile": "default",
+	})
+	if err == nil {
+		t.Fatalf("expected error when legacy profile field is set")
+	}
+	const wantSub = `the "profile" field has been removed`
+	if !strings.Contains(err.Error(), wantSub) {
+		t.Fatalf("error message missing %q: got %q", wantSub, err.Error())
+	}
+	if !strings.Contains(err.Error(), "AWS_PROFILE") {
+		t.Fatalf("error message should point to AWS_PROFILE: got %q", err.Error())
+	}
+}
+
+func TestNewIgnoresEmptyProfileField(t *testing.T) {
+	if _, err := New(map[string]any{
+		"region":  "us-east-1",
+		"profile": "",
+	}); err != nil {
+		t.Fatalf("unexpected error for empty profile: %v", err)
 	}
 }
 

--- a/internal/tui/form.go
+++ b/internal/tui/form.go
@@ -29,6 +29,10 @@ func newForm(schema []source.ParamField, initial map[string]string) *form {
 	f := &form{}
 	for _, sf := range schema {
 		ti := textinput.New()
+		// Placeholder mirrors Help only when the field is blurred. The
+		// focused field gets its hint from the dedicated hint line in
+		// View(), so showing the same text inside the input as well is
+		// just noise. See focus() / focusFirst() for the swap.
 		ti.Placeholder = sf.Help
 		ti.Prompt = ""
 		ti.CharLimit = 4096
@@ -43,6 +47,7 @@ func newForm(schema []source.ParamField, initial map[string]string) *form {
 	}
 	if len(f.fields) > 0 {
 		f.fields[0].input.Focus()
+		f.fields[0].input.Placeholder = ""
 	}
 	return f
 }
@@ -123,9 +128,16 @@ func (f *form) focus(i int) {
 	if i >= len(f.fields) {
 		i = len(f.fields) - 1
 	}
-	f.fields[f.cursor].input.Blur()
+	prev := f.fields[f.cursor]
+	prev.input.Blur()
+	// Restore the blurred field's placeholder so the help text appears
+	// inside its (empty) input again.
+	prev.input.Placeholder = prev.Help
 	f.cursor = i
 	f.fields[i].input.Focus()
+	// Suppress the focused field's placeholder — the hint line below
+	// the input already shows the same text.
+	f.fields[i].input.Placeholder = ""
 }
 
 func (f *form) View() string {


### PR DESCRIPTION
## Summary

- Suppress the duplicate placeholder text on the focused form field in `internal/tui/form.go` so the hint line below the input is no longer mirrored inside it — much quieter on the 8-field AWS form.
- Remove the `profile` field from the AWS source: ParamField, struct field, and the `case a.profile != "":` branch in `loadAwsCfg` are all gone. The legacy field is migrated via **validate-and-error**: `New()` hard-fails on a non-empty `profile` so credential resolution can never silently drift to the default chain.
- Update the `access_key_id` help text to `Leave credential fields empty to use the AWS default chain.` now that the profile reference is obsolete.

Closes #76.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make build`
- [x] New unit tests cover the legacy-profile error path and the absence of `profile` from the schema.
- [x] Manual TUI eyeball of placeholder/hint behaviour (best done locally — non-tractable in CI).