### PR TITLE
fix(shim): suppress duplicate env injection on execve chains (#77)

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -20,6 +20,15 @@ import (
 	"github.com/gv/jitenv/internal/runnotice"
 )
 
+// injectedMarker mirrors the one in internal/shim: a one-shot env
+// flag that short-circuits subsequent shim/run entries within the
+// same execve chain so a single user-typed command can't be injected
+// into twice. Less common via this path (`jitenv run` is keyed on
+// absolute file paths from the bash/zsh hook, not on PATH lookups),
+// but the symmetry matters if an absolute-path mapping ever
+// execve-chains into another mapped command. See issue #77.
+const injectedMarker = "__JITENV_INJECTED"
+
 // Run resolves file, asks the agent for any mapped env vars, then
 // replaces the current process with file+args+merged-env.
 //
@@ -39,6 +48,13 @@ func Run(ctx context.Context, file string, args []string) error {
 		return err
 	}
 
+	// If a previous shim/run entry in this execve chain already
+	// injected, pass through transparently — no agent dial, no notice,
+	// no warn. See injectedMarker doc and issue #77.
+	if os.Getenv(injectedMarker) == "1" {
+		return replaceProcess(abs, args, os.Environ())
+	}
+
 	paths, err := agent.DefaultPaths()
 	if err != nil {
 		return err
@@ -46,13 +62,21 @@ func Run(ctx context.Context, file string, args []string) error {
 
 	env := os.Environ()
 	injected := 0
-	if extra, err := fetchOrWarn(ctx, paths.Socket, abs); err != nil {
+	extra, fetched, err := fetchOrWarn(ctx, paths.Socket, abs)
+	if err != nil {
 		return err
-	} else {
-		for k, v := range extra {
-			env = append(env, k+"="+v)
-		}
-		injected = len(extra)
+	}
+	for k, v := range extra {
+		env = append(env, k+"="+v)
+	}
+	injected = len(extra)
+	if fetched {
+		// Agent answered. Stamp the one-shot marker so a chained
+		// shim/run entry in this execve chain skips its own fetch
+		// (issue #77). Only set on the fetch-success branch — the
+		// agent-down warn path uses __JITENV_AGENT_WARNED instead,
+		// which the shim handles independently.
+		env = append(env, injectedMarker+"=1")
 	}
 
 	if injected > 0 && runnotice.Enabled() {
@@ -65,13 +89,16 @@ func Run(ctx context.Context, file string, args []string) error {
 // fetchOrWarn tries to fetch env vars from the agent. On agent-down
 // it paints the warning + countdown; the returned map is nil (caller
 // should run with the parent env). Returns an error only when the
-// user aborted via Ctrl+C.
-func fetchOrWarn(ctx context.Context, socket, abs string) (map[string]string, error) {
+// user aborted via Ctrl+C. The second return value reports whether
+// the agent actually answered (true = fetch succeeded, possibly with
+// zero vars; false = agent was down and the user dismissed the
+// warning).
+func fetchOrWarn(ctx context.Context, socket, abs string) (map[string]string, bool, error) {
 	if _, err := os.Stat(socket); err != nil {
 		if agentwarn.WarnAndWait(abs) {
-			return nil, errors.New("aborted")
+			return nil, false, errors.New("aborted")
 		}
-		return nil, nil
+		return nil, false, nil
 	}
 	cli := agent.NewClient(socket)
 	dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -79,11 +106,11 @@ func fetchOrWarn(ctx context.Context, socket, abs string) (map[string]string, er
 	extra, err := cli.FetchEnv(dctx, abs)
 	if err != nil {
 		if agentwarn.WarnAndWait(abs) {
-			return nil, errors.New("aborted")
+			return nil, false, errors.New("aborted")
 		}
-		return nil, nil
+		return nil, false, nil
 	}
-	return extra, nil
+	return extra, true, nil
 }
 
 // replaceProcess substitutes the current process image with the given

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -407,3 +407,59 @@ func TestRunPreRunNotice(t *testing.T) {
 		t.Fatalf("notice should be silent when disabled; got %q", stderr.String())
 	}
 }
+
+// TestRunRespectsInjectedMarker is the regression test for issue #77's
+// run.go branch: when __JITENV_INJECTED=1 is already in the env (set
+// by a prior shim/run in the same execve chain), `jitenv run` must
+// short-circuit — no agent dial, no notice, no warning, no second
+// injection — and just exec the script with the inherited env.
+//
+// To prove "no agent dial", we point XDG_RUNTIME_DIR at an empty dir
+// (no socket). Without the marker, run.go would paint the agent-down
+// warning. With the marker, the script must exec cleanly: no warning,
+// no injection, just whatever env we passed in.
+func TestRunRespectsInjectedMarker(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	// Print FOO so we can confirm no injection happened. The agent is
+	// down here, so even without the marker the *value* would be empty
+	// — but with the marker we also expect no "agent is not loaded"
+	// warning on stderr, which is the proof-of-short-circuit.
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"$FOO\"\nprintf 'MARKER=%s\\n' \"$__JITENV_INJECTED\"\n"), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	// No agent socket — empty runtime dir.
+	runtimeDir := shortRuntimeDir(t)
+
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"__JITENV_INJECTED=1",
+		"JITENV_HOOK_DELAY=0",
+	)
+
+	cmd := exec.Command(bin, "run", scriptPath)
+	cmd.Env = subprocEnv
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	// Detach stdin from a TTY so any rogue WarnAndWait would
+	// fast-path (it shouldn't fire here at all, but be defensive).
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v\nstderr=%s", err, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "agent is not loaded") {
+		t.Fatalf("agent-down warning fired despite __JITENV_INJECTED=1; stderr=%q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "jitenv: injected") {
+		t.Fatalf("pre-run notice fired despite __JITENV_INJECTED=1; stderr=%q", stderr.String())
+	}
+	// Script must have run, and the marker must have propagated through
+	// the syscall.Exec so the script sees it.
+	got := string(out)
+	if !strings.Contains(got, "MARKER=1") {
+		t.Fatalf("expected MARKER=1 to propagate through exec; output=%q", got)
+	}
+}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -52,6 +52,19 @@ var errAgentDown = errors.New("agent unreachable")
 // without value.
 const warnedMarker = "__JITENV_AGENT_WARNED"
 
+// injectedMarker is the agent-UP analogue of warnedMarker. After a
+// successful fetch+append (or even an empty-but-successful agent
+// response), the first shim in the chain stamps this on the env it
+// hands to syscall.Exec. Subsequent shim entries in the same chain
+// short-circuit on entry: no fetch, no notice, no warn — just
+// transparently exec the real binary. This implements the
+// "first-wrapped-command-in-an-exec-chain wins" policy that matches
+// what the user typed (issue #77). Orthogonal to warnedMarker; they
+// coexist as two independent one-shot flags. Same leak caveat:
+// the marker may be visible to the user's final program, but
+// stripping it before execReal isn't worth the complexity.
+const injectedMarker = "__JITENV_INJECTED"
+
 // Main is the shim entrypoint. invokedAs is filepath.Base(os.Args[0]),
 // args is os.Args[1:] (everything after argv[0]).
 func Main(invokedAs string, args []string) {
@@ -75,6 +88,14 @@ func run(invokedAs string, args []string) error {
 	realPath, err := lookPathExcluding(invokedAs, selfDir)
 	if err != nil {
 		return err
+	}
+
+	// If a previous shim entry in this execve chain already injected
+	// (or attempted to), short-circuit — skip fetch, skip notice, skip
+	// warn. The first hop wins; chained interpreters pass through.
+	// See injectedMarker doc and issue #77.
+	if os.Getenv(injectedMarker) == "1" {
+		return execReal(realPath, invokedAs, args, os.Environ())
 	}
 
 	env := os.Environ()
@@ -104,6 +125,12 @@ func run(invokedAs string, args []string) error {
 				env = append(env, k+"="+v)
 			}
 			injected = len(extra)
+			// Stamp the one-shot marker so chained interpreters
+			// (e.g. npm execve-ing into node via shebang) short-circuit
+			// instead of re-fetching and double-injecting (issue #77).
+			// Set unconditionally on the fetch-success branch: even an
+			// empty result means "agent answered, decision is final".
+			env = append(env, injectedMarker+"=1")
 		}
 	}
 
@@ -111,6 +138,12 @@ func run(invokedAs string, args []string) error {
 		runnotice.Write(os.Stderr, injected, term.IsTerminal(int(os.Stderr.Fd())))
 	}
 
+	return execReal(realPath, invokedAs, args, env)
+}
+
+// execReal replaces the current process with the real binary,
+// preserving argv[0] as the command name the shell typed.
+func execReal(realPath, invokedAs string, args, env []string) error {
 	argv := append([]string{invokedAs}, args...)
 	if execErr := syscall.Exec(realPath, argv, env); execErr != nil {
 		if errors.Is(execErr, syscall.ENOEXEC) {

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -129,3 +129,95 @@ func TestShimSuppressesWarningWithMarker(t *testing.T) {
 		t.Errorf("second run: expected fakecmd to exec ('RAN');\noutput=%s", out2)
 	}
 }
+
+// TestShimSuppressesInjectionWithMarker is the regression test for
+// issue #77: when a cwd_glob mapping lists both a command and its
+// interpreter (e.g. npm + node), env vars used to be fetched and
+// appended twice because os.Getppid() doesn't change across execve.
+// The fix propagates __JITENV_INJECTED=1 after the first successful
+// fetch so subsequent shim entries short-circuit — no fetch attempt,
+// no notice, no warn — just execReal transparently.
+//
+// We don't fake an execve chain inside the test runner; instead we
+// invoke the shim twice and assert that the second call (marker set)
+// produces no warning, no notice, and still execs the real binary.
+// The agent is intentionally down here (empty runtime dir): call 1
+// would normally hit the agent-down warn path, call 2 with the
+// marker must bypass *everything* — including the warn — and just
+// pass through.
+func TestShimSuppressesInjectionWithMarker(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	// Print the env we received so we can assert the marker propagated
+	// through execve and that no notice/warning was printed on call 2.
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\nenv\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	wrapDir := filepath.Join(dir, "wrap")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
+	shellPID := strconv.Itoa(os.Getpid())
+
+	baseEnv := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"__JITENV_WRAP_DIR=" + wrapDir,
+		"__JITENV_SHELL_PID=" + shellPID,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		baseEnv = append(baseEnv, "HOME="+home)
+	}
+
+	run := func(env []string) (string, error) {
+		cmd := exec.Command(wrapper)
+		cmd.Env = env
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		err := cmd.Run()
+		return buf.String(), err
+	}
+
+	// Marker set on call: shim must short-circuit. No warning even
+	// though the agent is down; the real binary still runs.
+	out, err := run(append(baseEnv, "__JITENV_INJECTED=1"))
+	if err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, out)
+	}
+	if strings.Contains(out, "agent is not loaded") {
+		t.Errorf("warning fired despite __JITENV_INJECTED=1;\noutput=%s", out)
+	}
+	if strings.Contains(out, "jitenv: injected") {
+		t.Errorf("notice fired despite __JITENV_INJECTED=1;\noutput=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+	// The marker propagates transparently through execReal — the real
+	// binary sees it in its env. Confirms the short-circuit path
+	// (return execReal(...os.Environ()...)) preserved it.
+	if !strings.Contains(out, "__JITENV_INJECTED=1") {
+		t.Errorf("expected __JITENV_INJECTED=1 to propagate to child env;\noutput=%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #77. Sibling of #71 / PR #74 (already merged): same execve-chain root cause, agent-UP analogue instead of agent-down.

When a `cwd_glob` mapping lists both a command and its interpreter (e.g. `commands = ["npm", "node"]`), env vars were fetched and appended twice because `os.Getppid()` doesn't change across `execve` and `shouldInject()` fires at every level of the chain. If npm and node mapped to disjoint bags with overlapping keys, node's values silently won.

Fix: one-shot `__JITENV_INJECTED=1` env marker stamped on the env handed to `syscall.Exec` after a successful fetch. Subsequent shim/run entries in the same chain short-circuit on entry  no fetch, no notice, no warn  and just transparently exec the real binary. Same mechanism applied to `internal/run/run.go` for the absolute-path hook path.

- Marker is orthogonal to `__JITENV_AGENT_WARNED` from #74; they coexist as two independent one-shot flags.
- Same documented leak as #74: the marker may be visible to the user's final program; stripping it isn't worth the complexity.

## Test plan

- [x] New `TestShimSuppressesInjectionWithMarker` in `internal/shim/shim_test.go` extends the #74 pattern: invoke the wrapper symlink with `__JITENV_INJECTED=1` and assert no warning, no notice, real binary execs, marker propagates through.
- [x] New `TestRunRespectsInjectedMarker` in `internal/run/run_e2e_test.go` confirms `jitenv run` short-circuits without contacting the agent when the marker is set.
- [x] `go vet ./...` clean
- [x] `go test ./internal/shim/... ./internal/run/... ./internal/agent/... -count=1` passes
- [x] `go test ./...` whole suite passes
- [x] `make build` succeeds