### PR TITLE
build(windows): compile-time scaffolding for native Windows support (#39 stage 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,48 @@ jobs:
         # the macOS runner image. The peer-cred / agent / run paths
         # are the macOS-specific surface we actually want covered here.
         run: go test -race -covermode=atomic ./internal/agent/... ./internal/agentwarn/... ./internal/cli/... ./internal/config/... ./internal/crypto/... ./internal/run/... ./internal/runnotice/... ./internal/sources/... ./internal/tui/... ./internal/version/...
+
+  test-windows:
+    # Stage 1 of native Windows support (#39): exercise the
+    # cross-platform compile of the agent + shim + run paths against a
+    # real Windows toolchain. Most platform-specific stubs return
+    # "not yet implemented" errors at runtime, so the e2e/agent test
+    # suites are constrained out via `//go:build !windows` — what runs
+    # here is the config/crypto/version surface plus anything else
+    # that's already platform-clean. The job is mandatory so a
+    # regression in the Windows build (a new Unix-only syscall slipped
+    # into a shared file) fails CI immediately rather than being
+    # discovered when Stage 2 starts.
+    name: test (windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Download modules
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Build
+        run: go build ./...
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: Test
+        # All tests that need a Unix socket, fork+exec, symlinks, or
+        # bash/zsh are gated behind `//go:build !windows` so they
+        # compile-skip here. What remains is the cross-platform surface
+        # (config, crypto, version, sources, tui, runnotice, agentwarn,
+        # the agent's pure-Go bits) — green on Windows means the
+        # compile-time scaffolding from #39 stage 1 is still intact.
+        run: go test -covermode=atomic ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ go test ./internal/run -run TestRunInjectsEnvAndExecs -v
 
 Go 1.22+ (go.mod declares 1.25.6). Linux and macOS. Peer-cred check is platform-split (`SO_PEERCRED` on Linux in `peer_linux.go`, `LOCAL_PEERCRED` on Darwin in `peer_darwin.go`); runtime dir is `$XDG_RUNTIME_DIR/jitenv/` on Linux and `os.TempDir()/jitenv-<uid>/` (typically `/var/folders/.../T/jitenv-<uid>`) on macOS. The `Setsid` double-fork is portable.
 
+The codebase compiles for `GOOS=windows` (`peer_windows.go`, `socket_windows.go`, `daemonize_windows.go`, `paths_windows.go`, `run_windows.go`, `shim_windows.go` keep the build green) but the agent/shim/run paths return "not yet implemented" errors at runtime — see [#39](https://github.com/gv/jitenv/issues/39). Real Windows support (named pipes, token-based peer check, PowerShell hook) is Stage 2+.
+
 The e2e tests under `internal/run` and `internal/shell` shell out to `go build` to produce a real binary against a temp config; they're slow but exercise the unlock → daemonize → hook → run loop end-to-end.
 
 ## Big-picture architecture

--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ jitenv hook status         Show whether the hook is wired up
 
 - Linux + macOS only. Linux uses `SO_PEERCRED` + `XDG_RUNTIME_DIR`;
   macOS uses `LOCAL_PEERCRED` + `$TMPDIR`. The agent's `Setsid`
-  double-fork is portable to both. Windows is not supported.
+  double-fork is portable to both. Windows is not yet supported —
+  the codebase compiles for `GOOS=windows` but the agent, shim, and
+  `jitenv run` paths return "not yet implemented" at runtime.
+  Tracking in [#39](https://github.com/gv/jitenv/issues/39).
 - macOS release binaries are not Apple-notarized; first run requires
   `xattr -d com.apple.quarantine ./jitenv` or right-click → Open.
 - The shell hook only intercepts commands whose first token is an

--- a/e2e/cmd/unlock/main.go
+++ b/e2e/cmd/unlock/main.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Command jitenv-e2e-unlock is a test-only replacement for `jitenv
 // unlock` that takes the passphrase non-interactively. It exists
 // because `jitenv unlock` reads from /dev/tty and we cannot reliably

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package agent
 
 import (

--- a/internal/agent/daemonize.go
+++ b/internal/agent/daemonize.go
@@ -1,12 +1,8 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"syscall"
-	"time"
 
 	"github.com/gv/jitenv/internal/crypto"
 )
@@ -15,78 +11,14 @@ import (
 // passing the derived key over an inherited pipe. It returns once the
 // child is running (socket present) or with an error if startup fails.
 //
+// The actual fork/exec implementation is platform-split:
+//   - daemonize_unix.go uses os/exec with syscall.SysProcAttr.Setsid
+//     so the child detaches into its own session.
+//   - daemonize_windows.go returns "not yet implemented" — see #39
+//     stage 2+ for a real Windows daemon model.
+//
 // configFile and idle are forwarded so the child loads the same config
 // the parent verified.
-func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte) error {
-	if existing, _ := ReadPidFile(paths.PidFile); existing > 0 && PidAlive(existing) {
-		return fmt.Errorf("agent already running (pid %d)", existing)
-	}
-	if len(key) != int(crypto.KeyLen) {
-		return errors.New("daemonize: invalid key length")
-	}
-
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer pw.Close()
-
-	exe, err := os.Executable()
-	if err != nil {
-		return err
-	}
-	logF, err := os.OpenFile(paths.LogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
-	if err != nil {
-		return err
-	}
-	defer logF.Close()
-	devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
-	if err != nil {
-		return err
-	}
-	defer devNull.Close()
-
-	args := []string{
-		"__agent",
-		"--key-fd=3",
-		"--config=" + configFile,
-		"--idle=" + idle.String(),
-	}
-	cmd := exec.Command(exe, args...)
-	cmd.Stdin = devNull
-	cmd.Stdout = logF
-	cmd.Stderr = logF
-	cmd.ExtraFiles = []*os.File{pr} // becomes fd 3 in child
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-
-	if err := cmd.Start(); err != nil {
-		pr.Close()
-		return err
-	}
-	pr.Close() // child holds its own copy
-
-	if _, err := pw.Write(key); err != nil {
-		return fmt.Errorf("write key to child: %w", err)
-	}
-	pw.Close()
-
-	// Wait for the socket to appear, indicating Listen succeeded.
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(paths.Socket); err == nil {
-			// Detach from the child completely.
-			_ = cmd.Process.Release()
-			return nil
-		}
-		// If the child died early, surface that.
-		if cmd.ProcessState != nil {
-			return fmt.Errorf("agent exited early: %s", cmd.ProcessState)
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	_ = cmd.Process.Kill()
-	return errors.New("agent did not start within 3s; check ${XDG_RUNTIME_DIR}/jitenv/agent.log")
-}
 
 // ReadKeyFromFd reads exactly KeyLen bytes from the given file descriptor.
 // The caller is responsible for zeroing the returned slice.

--- a/internal/agent/daemonize_test.go
+++ b/internal/agent/daemonize_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package agent
 
 import (

--- a/internal/agent/daemonize_unix.go
+++ b/internal/agent/daemonize_unix.go
@@ -1,0 +1,91 @@
+//go:build !windows
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// SpawnDaemon re-execs the current binary as a detached agent process,
+// passing the derived key over an inherited pipe. It returns once the
+// child is running (socket present) or with an error if startup fails.
+//
+// configFile and idle are forwarded so the child loads the same config
+// the parent verified.
+func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte) error {
+	if existing, _ := ReadPidFile(paths.PidFile); existing > 0 && PidAlive(existing) {
+		return fmt.Errorf("agent already running (pid %d)", existing)
+	}
+	if len(key) != int(crypto.KeyLen) {
+		return errors.New("daemonize: invalid key length")
+	}
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer pw.Close()
+
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	logF, err := os.OpenFile(paths.LogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	defer logF.Close()
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer devNull.Close()
+
+	args := []string{
+		"__agent",
+		"--key-fd=3",
+		"--config=" + configFile,
+		"--idle=" + idle.String(),
+	}
+	cmd := exec.Command(exe, args...)
+	cmd.Stdin = devNull
+	cmd.Stdout = logF
+	cmd.Stderr = logF
+	cmd.ExtraFiles = []*os.File{pr} // becomes fd 3 in child
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := cmd.Start(); err != nil {
+		pr.Close()
+		return err
+	}
+	pr.Close() // child holds its own copy
+
+	if _, err := pw.Write(key); err != nil {
+		return fmt.Errorf("write key to child: %w", err)
+	}
+	pw.Close()
+
+	// Wait for the socket to appear, indicating Listen succeeded.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(paths.Socket); err == nil {
+			// Detach from the child completely.
+			_ = cmd.Process.Release()
+			return nil
+		}
+		// If the child died early, surface that.
+		if cmd.ProcessState != nil {
+			return fmt.Errorf("agent exited early: %s", cmd.ProcessState)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = cmd.Process.Kill()
+	return errors.New("agent did not start within 3s; check ${XDG_RUNTIME_DIR}/jitenv/agent.log")
+}

--- a/internal/agent/daemonize_windows.go
+++ b/internal/agent/daemonize_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+	"time"
+)
+
+// SpawnDaemon on Windows refuses to spawn. The Unix double-fork +
+// Setsid pattern doesn't translate cleanly to Windows; a real port
+// will likely use DETACHED_PROCESS / CREATE_NEW_PROCESS_GROUP plus a
+// named-pipe transport. Tracking in #39 stage 2+.
+//
+// Callers (cmd/jitenv/internal/cli/unlock.go) wrap this error with a
+// user-facing message before printing.
+func SpawnDaemon(_ Paths, _ string, _ time.Duration, _ []byte) error {
+	return errors.New("jitenv: daemonization on Windows not yet implemented; tracking in #39")
+}

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -22,18 +22,19 @@ func (p Paths) ShellWrapDir(shellPid int) string {
 	return filepath.Join(p.ShellsDir, fmt.Sprintf("%d", shellPid), "bin")
 }
 
-// ResolvePaths returns the per-user paths under $XDG_RUNTIME_DIR
-// (preferred) or /tmp/jitenv-<uid> as a fallback. Pure computation —
-// it does not create the directory on disk. Use this for read-only
-// callers (e.g. `jitenv hook bash`, which prints paths but doesn't
-// need them to exist yet).
+// ResolvePaths returns the per-user paths under the platform's runtime
+// base directory. Pure computation — it does not create the directory
+// on disk. Use this for read-only callers (e.g. `jitenv hook bash`,
+// which prints paths but doesn't need them to exist yet).
+//
+// The base directory is platform-split in paths_unix.go /
+// paths_windows.go:
+//   - Unix: $XDG_RUNTIME_DIR/jitenv, fallback /tmp/jitenv-<uid>.
+//   - Windows: %LOCALAPPDATA%\jitenv (os.UserConfigDir fallback).
+//     os.Getuid() returns -1 on Windows, so the per-uid suffix used on
+//     Unix doesn't apply.
 func ResolvePaths() Paths {
-	dir := os.Getenv("XDG_RUNTIME_DIR")
-	if dir == "" {
-		dir = filepath.Join(os.TempDir(), fmt.Sprintf("jitenv-%d", os.Getuid()))
-	} else {
-		dir = filepath.Join(dir, "jitenv")
-	}
+	dir := runtimeBaseDir()
 	return Paths{
 		Dir:       dir,
 		Socket:    filepath.Join(dir, "agent.sock"),

--- a/internal/agent/paths_unix.go
+++ b/internal/agent/paths_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// runtimeBaseDir returns the per-user runtime directory for the agent
+// on Unix-likes: $XDG_RUNTIME_DIR/jitenv when set, falling back to
+// /tmp/jitenv-<uid>. The fallback embeds the uid so multiple users on
+// the same host don't collide in a shared $TMPDIR.
+func runtimeBaseDir() string {
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		return filepath.Join(dir, "jitenv")
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("jitenv-%d", os.Getuid()))
+}

--- a/internal/agent/paths_windows.go
+++ b/internal/agent/paths_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// runtimeBaseDir returns the per-user runtime directory for the agent
+// on Windows. os.Getuid() returns -1 on Windows so the Unix-style
+// /tmp/jitenv-<uid> layout doesn't apply; instead we sit under
+// %LOCALAPPDATA%\jitenv. os.UserConfigDir() resolves to %AppData%
+// (Roaming) on Windows, which is a reasonable second-choice; the
+// final fallback is os.TempDir() so we never return an empty path.
+//
+// The agent itself does not start on Windows today (see SpawnDaemon
+// in daemonize_windows.go) but ResolvePaths is reachable from
+// `jitenv hook` and other read-only commands, so it has to return
+// _something_ sensible.
+func runtimeBaseDir() string {
+	if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
+		return filepath.Join(dir, "jitenv")
+	}
+	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "jitenv")
+	}
+	return filepath.Join(os.TempDir(), "jitenv")
+}

--- a/internal/agent/peer_windows.go
+++ b/internal/agent/peer_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+	"net"
+)
+
+// checkPeerUid is a Windows stub. Stage 1 of #39 keeps the codebase
+// compiling for GOOS=windows; a real implementation will go through a
+// Windows-native transport (named pipes) and use token-based peer
+// authentication. Until that lands the agent itself never starts on
+// Windows (see SpawnDaemon / listenSocket), so this stub should never
+// be invoked at runtime.
+func checkPeerUid(_ *net.UnixConn) error {
+	return errors.New("jitenv agent: peer-credential check not implemented on windows; tracking in #39")
+}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -76,6 +76,10 @@ func (a *Agent) currentResolver() Resolver {
 //
 // Also runs a one-time GC pass over ShellsDir, removing wrapper dirs
 // for shell pids that aren't alive anymore. Cheap, idempotent.
+//
+// The actual socket-binding step is platform-split into socket_unix.go
+// (real net.ListenUnix) and socket_windows.go (returns "not yet
+// implemented"). See #39 stage 1.
 func (a *Agent) Listen() error {
 	_ = GcOrphanShells(a.paths.ShellsDir)
 	if existing, _ := ReadPidFile(a.paths.PidFile); existing > 0 && PidAlive(existing) {
@@ -83,12 +87,8 @@ func (a *Agent) Listen() error {
 	}
 	_ = os.Remove(a.paths.Socket)
 
-	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: a.paths.Socket, Net: "unix"})
+	ln, err := listenSocket(a.paths.Socket)
 	if err != nil {
-		return fmt.Errorf("listen %s: %w", a.paths.Socket, err)
-	}
-	if err := os.Chmod(a.paths.Socket, 0600); err != nil {
-		ln.Close()
 		return err
 	}
 	a.listener = ln

--- a/internal/agent/socket_unix.go
+++ b/internal/agent/socket_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package agent
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// listenSocket binds the per-user Unix socket at path and chmods it
+// 0600. The 0600 mode is load-bearing: peer-credential checks happen
+// in checkPeerUid, but the filesystem permission is the first line of
+// defence against an unrelated uid even attempting to connect.
+//
+// On Windows the named-pipe transport will replace this — see
+// socket_windows.go (#39 stage 2+).
+func listenSocket(path string) (*net.UnixListener, error) {
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("listen %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		ln.Close()
+		return nil, err
+	}
+	return ln, nil
+}

--- a/internal/agent/socket_windows.go
+++ b/internal/agent/socket_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+	"net"
+)
+
+// listenSocket on Windows refuses to bind. The Unix-socket transport
+// isn't appropriate on Windows because there's no SO_PEERCRED-style
+// peer-uid check available over AF_UNIX, so a future port will switch
+// to a named pipe (\\.\pipe\jitenv-<sid>) with token-based peer
+// authentication. Tracking in #39 stage 2+.
+//
+// Returning an error here keeps `jitenv unlock` from accidentally
+// spinning up a transport with no auth.
+func listenSocket(_ string) (*net.UnixListener, error) {
+	return nil, errors.New("jitenv agent: Windows named-pipe transport not yet implemented; tracking in #39")
+}

--- a/internal/chpwd/chpwd_test.go
+++ b/internal/chpwd/chpwd_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package chpwd
 
 import (

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -21,6 +22,11 @@ func newUnlockCmd() *cobra.Command {
 		Short: "Unlock the agent (prompts passphrase, starts background agent)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if runtime.GOOS == "windows" {
+				return fmt.Errorf("jitenv: Windows is not yet supported. " +
+					"The codebase compiles for GOOS=windows but the agent/shim/run paths " +
+					"are stubs. Track progress in https://github.com/gv/jitenv/issues/39.")
+			}
 			cfgPath, err := config.Resolve(configPath)
 			if err != nil {
 				return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -11,6 +12,15 @@ import (
 )
 
 func TestIndexExactAndGlob(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The glob "/tmp/jitenv-demo/**/*.sh" doesn't match the
+		// Windows-normalised exact path produced by filepath.Abs on
+		// Windows (backslash separators, drive letter prefix). The
+		// underlying mapping logic isn't Windows-aware yet — that's
+		// part of #39 stage 2+. Skip rather than mark the file
+		// !windows so the validation-only tests still run.
+		t.Skip("windows: cwd_glob/path matching not yet supported; tracking in #39")
+	}
 	abs, _ := filepath.Abs("/tmp/jitenv-demo/show.sh")
 	idx := NewIndex([]Mapping{
 		{

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -37,6 +38,14 @@ func TestInitAndDeriveKey(t *testing.T) {
 }
 
 func TestResolveDefaultPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Hardcoded Unix-style "/tmp/..." paths get rewritten by
+		// filepath.Join on Windows to use backslashes, so the literal
+		// string comparison fails. Real Windows path resolution lives
+		// behind #39 stage 2+; for now skip rather than rewrite the
+		// expected value, which would weaken the Unix assertion.
+		t.Skip("windows: Unix-style /tmp paths in fixtures; tracking in #39")
+	}
 	t.Setenv("JITENV_CONFIG", "/tmp/explicit.toml")
 	got, err := Resolve("")
 	if err != nil {

--- a/internal/config/mapping_test.go
+++ b/internal/config/mapping_test.go
@@ -3,10 +3,25 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
+// skipOnWindows centralises the reason text so the four cwd_glob
+// tests below don't repeat it. The underlying matcher
+// (bmatcuk/doublestar) is forward-slash-only, and the ancestor-walk
+// uses filepath.Dir which on Windows produces backslash-separated
+// segments that never match. Wiring up a Windows-aware matcher is
+// part of #39 stage 2+, not the compile-time scaffolding shipped here.
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("windows: cwd_glob matching uses forward-slash globs; tracking in #39")
+	}
+}
+
 func TestIndex_LookupCwd_AncestorWalk(t *testing.T) {
+	skipOnWindows(t)
 	tmp := t.TempDir()
 	deeper := filepath.Join(tmp, "acme", "service", "src")
 	if err := os.MkdirAll(deeper, 0o755); err != nil {
@@ -38,6 +53,7 @@ func TestIndex_LookupCwd_AncestorWalk(t *testing.T) {
 }
 
 func TestIndex_LookupCwd_RequiresExplicitCommand(t *testing.T) {
+	skipOnWindows(t)
 	tmp := t.TempDir()
 	idx := NewIndex([]Mapping{{
 		CwdGlob:  tmp,
@@ -57,6 +73,7 @@ func TestIndex_LookupCwd_RequiresExplicitCommand(t *testing.T) {
 }
 
 func TestIndex_CwdCommands_Union(t *testing.T) {
+	skipOnWindows(t)
 	tmp := t.TempDir()
 	idx := NewIndex([]Mapping{
 		{CwdGlob: tmp, Commands: []string{"npm", "yarn"}, Vars: []VarRef{{Source: "x"}}},
@@ -75,6 +92,7 @@ func TestIndex_CwdCommands_Union(t *testing.T) {
 }
 
 func TestIndex_LookupCwd_TildeExpansion(t *testing.T) {
+	skipOnWindows(t)
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		t.Skip("no $HOME")

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -7,10 +7,8 @@ package run
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"golang.org/x/term"
@@ -87,14 +85,7 @@ func fetchOrWarn(ctx context.Context, socket, abs string) (map[string]string, er
 }
 
 // replaceProcess substitutes the current process image with the given
-// file using syscall.Exec so secrets live only in the child process tree.
-func replaceProcess(path string, args []string, env []string) error {
-	argv := append([]string{path}, args...)
-	if err := syscall.Exec(path, argv, env); err != nil {
-		if errors.Is(err, syscall.ENOEXEC) {
-			return fmt.Errorf("%s: file is not directly executable (missing shebang?)", path)
-		}
-		return fmt.Errorf("exec syscall on %s: %w", path, err)
-	}
-	return nil
-}
+// file using syscall.Exec so secrets live only in the child process
+// tree. The actual exec is platform-split into run_unix.go (the real
+// thing) and run_windows.go (a "not yet supported" stub) — see #39
+// stage 2+ for the planned Windows model.

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package run_test
 
 import (

--- a/internal/run/run_unix.go
+++ b/internal/run/run_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package run
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+func replaceProcess(path string, args []string, env []string) error {
+	argv := append([]string{path}, args...)
+	if err := syscall.Exec(path, argv, env); err != nil {
+		if errors.Is(err, syscall.ENOEXEC) {
+			return fmt.Errorf("%s: file is not directly executable (missing shebang?)", path)
+		}
+		return fmt.Errorf("exec syscall on %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/run/run_windows.go
+++ b/internal/run/run_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package run
+
+import "errors"
+
+// replaceProcess on Windows refuses to exec. Windows has no exec-in-
+// place primitive that drops the current process image, so a real
+// port will need a different model (spawn + wait, or token-stuffed
+// CreateProcess). Tracking in #39 stage 2+.
+func replaceProcess(_ string, _ []string, _ []string) error {
+	return errors.New("jitenv run: not yet supported on windows; tracking in #39")
+}

--- a/internal/shell/hook_e2e_test.go
+++ b/internal/shell/hook_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package shell_test
 
 import (

--- a/internal/shell/hook_path_normalization_test.go
+++ b/internal/shell/hook_path_normalization_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package shell_test
 
 import (

--- a/internal/shell/hook_unlock_lock_test.go
+++ b/internal/shell/hook_unlock_lock_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package shell_test
 
 import (

--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package shell_test
 
 import (

--- a/internal/shell/install_test.go
+++ b/internal/shell/install_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package shell
 
 import (

--- a/internal/shell/render_test.go
+++ b/internal/shell/render_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package shell
 
 import (

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"golang.org/x/term"
@@ -112,13 +111,7 @@ func run(invokedAs string, args []string) error {
 	}
 
 	argv := append([]string{invokedAs}, args...)
-	if execErr := syscall.Exec(realPath, argv, env); execErr != nil {
-		if errors.Is(execErr, syscall.ENOEXEC) {
-			return fmt.Errorf("%s: file is not directly executable", realPath)
-		}
-		return fmt.Errorf("exec %s: %w", realPath, execErr)
-	}
-	return nil
+	return execReal(realPath, argv, env)
 }
 
 // shouldInject decides whether the shim should pull in mapped env

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package shim_test
 
 import (

--- a/internal/shim/shim_unix.go
+++ b/internal/shim/shim_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package shim
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// execReal replaces the shim's process image with the real command at
+// realPath. Using syscall.Exec keeps the secret-bearing env confined
+// to the child process tree we're about to become.
+func execReal(realPath string, argv []string, env []string) error {
+	if execErr := syscall.Exec(realPath, argv, env); execErr != nil {
+		if errors.Is(execErr, syscall.ENOEXEC) {
+			return fmt.Errorf("%s: file is not directly executable", realPath)
+		}
+		return fmt.Errorf("exec %s: %w", realPath, execErr)
+	}
+	return nil
+}

--- a/internal/shim/shim_windows.go
+++ b/internal/shim/shim_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package shim
+
+import "errors"
+
+// execReal on Windows refuses to run. The cwd_glob wrapper-symlink
+// model assumes a POSIX exec-in-place primitive (so argv[0] survives
+// and the parent shell's pid is inherited); Windows has no equivalent.
+// A real port will need spawn-and-wait or a different invocation
+// model entirely. Tracking in #39 stage 2+.
+func execReal(_ string, _ []string, _ []string) error {
+	return errors.New("jitenv shim: not yet supported on windows; tracking in #39")
+}


### PR DESCRIPTION
## Summary

Stage 1 of #39: make jitenv compile cleanly for `GOOS=windows` and add a mandatory Windows CI build job. The agent, shim, and `jitenv run` paths return "not yet implemented" errors at runtime so Windows users get a clear, actionable message instead of either a link error or a confusing core dump. Real Windows runtime support (named-pipe transport, token-based peer check, PowerShell hook, `%LOCALAPPDATA%` file modes) is intentionally deferred to Stage 2+.

The split follows the existing `peer_linux.go` / `peer_darwin.go` convention — every Unix-only syscall now lives in a `*_unix.go` (build-constrained `!windows`) companion next to a `*_windows.go` stub that returns a tracked error. The Windows CI job (`test-windows` on `windows-latest`) runs `go build`, `go vet`, and `go test ./...` and is mandatory: any future change that drops a fresh `syscall.Setsid` into a shared file will fail CI immediately.

Files split with build constraints (new on the right):

- `internal/agent/server.go` -> `socket_unix.go`, `socket_windows.go` (listener bind)
- `internal/agent/daemonize.go` -> `daemonize_unix.go`, `daemonize_windows.go` (SpawnDaemon)
- `internal/agent/paths.go` -> `paths_unix.go`, `paths_windows.go` (`runtimeBaseDir` helper; `%LOCALAPPDATA%\jitenv` on Windows since `os.Getuid()` returns -1)
- `internal/agent/peer_linux.go`/`peer_darwin.go` -> `peer_windows.go` (stub)
- `internal/run/run.go` -> `run_unix.go`, `run_windows.go` (`replaceProcess`)
- `internal/shim/shim.go` -> `shim_unix.go`, `shim_windows.go` (`execReal`)
- `internal/cli/unlock.go` gets an early `runtime.GOOS == "windows"` guard so the user sees a friendly message rather than the raw stub error
- `e2e/cmd/unlock/main.go` marked `!windows` (Linux-only e2e helper by design)

Tests that need Unix sockets, fork+exec, symlinks, or bash/zsh now carry `//go:build !windows` constraints so the Windows test job exercises the cross-platform surface (config, crypto, version, sources, tui, runnotice, agentwarn, agent's pure-Go bits) without trying to run the e2e suites.

Not in scope, tracked for Stage 2+ (#39): named pipes, token-based peer authentication, PowerShell hook installer, and adding `windows` to `.goreleaser.yaml`. Shipping a release artifact that prints "not supported" would just mislead users, so the release matrix stays Linux + darwin until the runtime paths actually work.

Closes part of #39 (stage 1 only).

## Test plan

- [x] `make build` on Linux (dev box)
- [x] `GOOS=windows GOARCH=amd64 go build ./...` succeeds
- [x] `GOOS=windows GOARCH=amd64 go vet ./...` succeeds
- [x] `go test ./...` on Linux — full suite still passes
- [x] `gofmt -l .` clean
- [x] New `test-windows` CI job lights up green on `windows-latest`