### PR TITLE
fix(shim): collapse duplicate execReal after #79/#80 merge race

### DIFF
--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -89,12 +89,14 @@ func run(invokedAs string, args []string) error {
 		return err
 	}
 
+	argv := append([]string{invokedAs}, args...)
+
 	// If a previous shim entry in this execve chain already injected
 	// (or attempted to), short-circuit — skip fetch, skip notice, skip
 	// warn. The first hop wins; chained interpreters pass through.
 	// See injectedMarker doc and issue #77.
 	if os.Getenv(injectedMarker) == "1" {
-		return execReal(realPath, invokedAs, args, os.Environ())
+		return execReal(realPath, argv, os.Environ())
 	}
 
 	env := os.Environ()
@@ -137,13 +139,6 @@ func run(invokedAs string, args []string) error {
 		runnotice.Write(os.Stderr, injected, term.IsTerminal(int(os.Stderr.Fd())))
 	}
 
-	return execReal(realPath, invokedAs, args, env)
-}
-
-// execReal replaces the current process with the real binary,
-// preserving argv[0] as the command name the shell typed.
-func execReal(realPath, invokedAs string, args, env []string) error {
-	argv := append([]string{invokedAs}, args...)
 	return execReal(realPath, argv, env)
 }
 


### PR DESCRIPTION
## Summary

Main is currently broken — `go build ./...` fails on commit \`f95385f\` (PR #80 merged) with:

\`\`\`
internal/shim/shim_unix.go:14:6: execReal redeclared in this block
        internal/shim/shim.go:145:6: other declaration of execReal
internal/shim/shim.go:147:34: not enough arguments in call to execReal
\`\`\`

PR #79 (merged 13:30 UTC) added a 4-arg \`execReal\` wrapper in \`shim.go\` that called a 3-arg helper of the same name. PR #80 (merged 13:31 UTC) extracted that 3-arg helper into \`shim_unix.go\` for the Windows platform split. Each PR was internally consistent against its own base; combined, main has two definitions named \`execReal\` and the 4-arg wrapper is itself broken (it would have recursed infinitely if it compiled).

Classic merge race: both PRs CI-green on their own branch, both green on \`pull_request\`, but neither was re-tested against the post-#79 main before #80 merged.

## Fix

Inline the \`argv := append([]string{invokedAs}, args...)\` construction at the two call sites in \`run()\` and delete the 4-arg wrapper. The remaining \`execReal\` is the platform-split one from \`shim_unix.go\` / \`shim_windows.go\`.

## Verification

- \`go build ./...\` — clean.
- \`go vet ./...\` — clean.
- \`go test ./... -count=1\` — full suite passes.
- \`GOOS=windows GOARCH=amd64 go build ./...\` — Windows cross-compile clean.

## Follow-up (separate)

A repeat of this race is likely whenever two PRs touching the same area land back-to-back. Branch-protection \"require branches to be up to date before merging\" would have caught it. Worth turning on, but tracked separately.