### PR TITLE
test(e2e): add Vault dev-mode service + KV v1/v2 fetch scenario (#73)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -11,6 +11,7 @@ backends and surface failures from rich on-disk diagnostics.
 make e2e-up                                  # build images, start stack, wait for healthchecks
 make e2e-run SCENARIO=unlock-and-run-local.yaml
 make e2e-run SCENARIO=localstack-fetch.yaml
+make e2e-run SCENARIO=vault-fetch.yaml
 make e2e-down                                # tear stack down (keeps volumes)
 make e2e-down-hard                           # tear stack down + drop volumes
 ```
@@ -30,6 +31,7 @@ Failed runs leave a self-contained artefact directory under
 | `alpine`         | Alpine 3.20 (musl); extracts `dist/*.tar.gz` into the deb/rpm layout (covers archive contents)        |
 | `alpine-source`  | Alpine 3.20 (musl); builds jitenv from `HEAD` so the source build path against musl stays exercised   |
 | `localstack`     | LocalStack 3.x with Secrets Manager, seeded with one JSON secret                                      |
+| `vault`          | HashiCorp Vault in dev mode (deterministic root token `dev-root`, no host port, KV v2 at `secret/`)   |
 
 The three install-from-artefact services (`debian`, `fedora`, `alpine`)
 depend on `dist/` being populated by `make e2e-build-artifacts`, which
@@ -175,21 +177,39 @@ useful for "does it even compile" smoke tests.
 
 ## Adding a new source backend
 
-The fixture generator is `e2e/seed/seed.go`. Today it knows two
-variants (`local`, `localstack`). To add another:
+The fixture generator is `e2e/seed/seed.go`. Today it knows the
+`local`, `localstack`, and `vault` variants. To add another:
 
 1. Add a new `apply<Source>` function that mirrors the TUI's save
-   shape for that source — see `applyLocalstack` for the
-   encrypted-params pattern (use `crypto.EncryptField` for any
+   shape for that source — see `applyLocalstack` / `applyVault` for
+   the encrypted-params pattern (use `crypto.EncryptField` for any
    `Sensitive` schema field).
-2. Add a case in the `switch *variant` block.
+2. Add a case in the `switch variant` block.
 3. If the source needs a backing service (Vault, mock GitHub, …):
    - add it to `docker-compose.yml` with a healthcheck;
-   - put init scripts under `e2e/seed/<service>-init/`;
+   - put init scripts under `e2e/seed/<service>-init/` if the image
+     supports a ready-hook (LocalStack does);
+   - alternatively, drive setup inline from the scenario via `curl`
+     against the service's HTTP API — `vault-fetch.yaml` does this
+     because the runner images don't ship a `vault` CLI;
    - add the service as a `depends_on: condition: service_healthy`
      for the distro services that need it.
 4. Add a scenario under `e2e/scenarios/` that drives unlock + run
    against a mapped script using the new source.
+
+### Vault scenario notes
+
+The `vault` compose service runs `hashicorp/vault` in dev mode with
+a fixed root token (`dev-root`) on the internal compose network only
+— no host port mapping. KV v2 is the default mount (`secret/`); the
+`vault-fetch.yaml` scenario also enables KV v1 at `kv/` inline via
+`POST /v1/sys/mounts/kv` so a single scenario covers both KV
+versions. Secrets are pre-seeded by the scenario itself with `curl`
+against the Vault HTTP API, keeping seed and assertions
+co-located. The seed binary's `vault` variant writes two
+`[sources.vault]` blocks (one per KV version) and round-trips the
+token through `crypto.EncryptField`, exercising the agent's
+`DecryptStringsInPlace` walk over the params block.
 
 ## Driving `jitenv unlock` non-interactively
 
@@ -235,7 +255,7 @@ When a scenario fails, look at these files in order:
 
 ## Out of scope (deferred to follow-ups)
 
-- Vault, mock GitHub, OIDC services
+- Mock GitHub, OIDC services
 - Arch distro (fedora is now covered)
 - Multi-distro coverage of functional scenarios beyond what
   `install-layout-*` already gives — debian is the canonical

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -25,9 +25,13 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
+      vault:
+        condition: service_healthy
     environment:
       JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
       LOCALSTACK_HOSTNAME: localstack
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
 
   fedora:
     build:
@@ -41,9 +45,13 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
+      vault:
+        condition: service_healthy
     environment:
       JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
       LOCALSTACK_HOSTNAME: localstack
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
 
   alpine:
     build:
@@ -57,9 +65,13 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
+      vault:
+        condition: service_healthy
     environment:
       JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
       LOCALSTACK_HOSTNAME: localstack
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
 
   alpine-source:
     build:
@@ -73,9 +85,13 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
+      vault:
+        condition: service_healthy
     environment:
       JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
       LOCALSTACK_HOSTNAME: localstack
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
 
   localstack:
     image: localstack/localstack:3.8
@@ -98,3 +114,29 @@ services:
       # Init scripts run on first boot. /etc/localstack/init/ready.d
       # fires after services are listening.
       - ./seed/localstack-init:/etc/localstack/init/ready.d:ro
+
+  # HashiCorp Vault in dev mode. The root token is deterministic
+  # (`dev-root`) and listens on 0.0.0.0:8200 inside the compose
+  # network. The image's entrypoint runs `vault server -dev` when
+  # VAULT_DEV_ROOT_TOKEN_ID is set, so no command override is needed.
+  # No host port mapping: scenarios reach Vault via http://vault:8200.
+  vault:
+    image: hashicorp/vault:1.18
+    container_name: jitenv-e2e-vault
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: dev-root
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+      VAULT_ADDR: http://127.0.0.1:8200
+    # Dev mode runs in-memory and unseals automatically; IPC_LOCK would
+    # be required for production storage backends, but not here.
+    cap_add:
+      - IPC_LOCK
+    healthcheck:
+      # `vault status` exits 0 when initialised & unsealed (the dev
+      # default). Probe inside the container so we don't rely on host
+      # port mapping.
+      test: ["CMD-SHELL", "VAULT_ADDR=http://127.0.0.1:8200 vault status >/dev/null 2>&1 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 3s

--- a/e2e/scenarios/vault-fetch.yaml
+++ b/e2e/scenarios/vault-fetch.yaml
@@ -1,0 +1,165 @@
+name: vault-fetch
+description: |
+  End-to-end Vault source coverage against a dev-mode Vault server.
+  Exercises both KV versions in one scenario:
+
+    - KV v2 (default mount `secret/`) with whole-bag expansion: the
+      mapping has an empty-Name VarRef so every key in the secret
+      becomes its own env var.
+    - KV v1 (custom mount `kv/`) with single-key extraction: the
+      mapping has Name=LEGACY_TOKEN/Key=LEGACY_TOKEN, exercising the
+      ref.Key path through vault.Fetch.
+
+  Vault is pre-seeded via its HTTP API (no `vault` CLI in the runner
+  image, no extra package install). The config carries an encrypted
+  root token round-tripped through the same envelope mechanism the
+  TUI uses, so this also covers the agent's DecryptStringsInPlace
+  walk over the [sources.vault.params] block.
+
+service: debian
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  # Enable a second KV mount at kv/ for the v1 leg. The default
+  # `secret/` mount is already KV v2 (dev mode default), so we only
+  # have to mount a v1 backend explicitly. The Vault dev server
+  # persists across `make e2e-run` invocations within one `e2e-up`
+  # cycle, so we treat "already mounted" (HTTP 400 with
+  # "path is already in use") as a no-op to keep the scenario
+  # rerunnable without an intervening `e2e-down`.
+  - name: vault-enable-kv1
+    exec: |
+      body=$(mktemp)
+      code=$(curl -sS -o "$body" -w '%{http_code}' -X POST \
+        -H "X-Vault-Token: dev-root" \
+        -H "Content-Type: application/json" \
+        --data '{"type":"kv","options":{"version":"1"}}' \
+        http://vault:8200/v1/sys/mounts/kv)
+      if [ "$code" = "204" ] || [ "$code" = "200" ]; then
+        rm -f "$body"
+        exit 0
+      fi
+      if [ "$code" = "400" ] && grep -q 'path is already in use' "$body"; then
+        rm -f "$body"
+        exit 0
+      fi
+      echo "kv mount failed: HTTP $code" >&2
+      cat "$body" >&2
+      rm -f "$body"
+      exit 1
+  - name: assert-kv1-mount-ok
+    assert_exit_code: 0
+
+  - name: vault-seed-kv2
+    exec: |
+      curl -sf -X POST \
+        -H "X-Vault-Token: dev-root" \
+        -H "Content-Type: application/json" \
+        --data '{"data":{"FOO":"value-from-vault-foo","BAR":"value-from-vault-bar"}}' \
+        http://vault:8200/v1/secret/data/myapp/prod
+  - name: assert-kv2-seed-ok
+    assert_exit_code: 0
+
+  - name: vault-seed-kv1
+    exec: |
+      curl -sf -X POST \
+        -H "X-Vault-Token: dev-root" \
+        -H "Content-Type: application/json" \
+        --data '{"LEGACY_TOKEN":"value-from-vault-kv1-token","OTHER":"unused"}' \
+        http://vault:8200/v1/kv/apps/legacy
+  - name: assert-kv1-seed-ok
+    assert_exit_code: 0
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed \
+        -out "$JITENV_CONFIG" \
+        -variant vault \
+        -script /home/jitenv/scripts/show.sh \
+        -vault-v1-script /home/jitenv/scripts/show-v1.sh
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: validate-config
+    exec: jitenv config validate
+  - name: assert-validate-ok
+    assert_exit_code: 0
+
+  - name: write-test-script-v2
+    exec: |
+      cat > /home/jitenv/scripts/show.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      EOF
+      chmod +x /home/jitenv/scripts/show.sh
+  - name: assert-write-v2-ok
+    assert_exit_code: 0
+
+  - name: write-test-script-v1
+    exec: |
+      cat > /home/jitenv/scripts/show-v1.sh <<'EOF'
+      #!/bin/sh
+      printf 'LEGACY_TOKEN=%s\n' "$LEGACY_TOKEN"
+      printf 'OTHER=%s\n' "$OTHER"
+      EOF
+      chmod +x /home/jitenv/scripts/show-v1.sh
+  - name: assert-write-v1-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  - name: agent-status
+    exec: jitenv status
+  - name: assert-status-ok
+    assert_exit_code: 0
+
+  # KV v2: whole-bag expansion lands FOO and BAR in the child.
+  - name: run-v2
+    exec: jitenv run /home/jitenv/scripts/show.sh
+    timeout: 30s
+  - name: assert-v2-foo
+    assert_stdout_contains: "FOO=value-from-vault-foo"
+  - name: assert-v2-bar
+    assert_stdout_contains: "BAR=value-from-vault-bar"
+
+  # KV v1: only the picked key reaches the child; OTHER stays empty
+  # because the mapping does not reference it.
+  - name: run-v1
+    exec: jitenv run /home/jitenv/scripts/show-v1.sh
+    timeout: 30s
+  - name: assert-v1-legacy-token
+    assert_stdout_contains: "LEGACY_TOKEN=value-from-vault-kv1-token"
+  - name: assert-v1-other-empty
+    target: run-v1
+    assert_stdout_contains: "OTHER="
+  - name: assert-v1-no-other-leak
+    target: run-v1
+    assert_stdout_not_contains: "OTHER=unused"
+
+  # Bare execution (no jitenv run) must not see Vault secrets — they
+  # only live in the agent and the child it execs.
+  - name: run-bare
+    exec: /home/jitenv/scripts/show.sh
+  - name: assert-bare-no-foo-leak
+    target: run-bare
+    assert_stdout_not_contains: "value-from-vault-foo"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/seed/seed.go
+++ b/e2e/seed/seed.go
@@ -23,6 +23,10 @@
 //   - localstack   an aws-source fixture pointing at LocalStack with
 //     static dummy creds; mapping on .../show.sh fetches
 //     one key from the seeded SM secret.
+//   - vault        a vault-source fixture pointing at the dev-mode
+//     Vault server with the deterministic root token; one
+//     mapping per KV version (v2 expands the whole bag at
+//     myapp/prod; v1 picks a single key at apps/legacy).
 package main
 
 import (
@@ -36,14 +40,19 @@ import (
 
 func main() {
 	var (
-		out          = flag.String("out", "", "output path for config.toml (required)")
-		passphrase   = flag.String("passphrase", "e2e-test-pass", "passphrase for the encrypted config")
-		variant      = flag.String("variant", "local", "fixture variant: local | local-alt | local-glob | localstack")
-		scriptPath   = flag.String("script", "/home/jitenv/scripts/show.sh", "absolute path used in the mapping (path variants)")
-		globPath     = flag.String("glob", "/home/jitenv/scripts/*.sh", "glob pattern used in the mapping (local-glob variant)")
-		smARN        = flag.String("sm-arn", "arn:aws:secretsmanager:us-east-1:000000000000:secret:jitenv/demo", "SM secret ARN (localstack variant)")
-		smEndpoint   = flag.String("sm-endpoint", "http://localstack:4566", "SM endpoint URL (localstack variant)")
-		preserveMeta = flag.Bool("preserve-meta", false, "preserve the existing config's Meta (salt + verify sentinel) so a running agent's derived key still decrypts the new file")
+		out           = flag.String("out", "", "output path for config.toml (required)")
+		passphrase    = flag.String("passphrase", "e2e-test-pass", "passphrase for the encrypted config")
+		variant       = flag.String("variant", "local", "fixture variant: local | local-alt | local-glob | localstack | vault")
+		scriptPath    = flag.String("script", "/home/jitenv/scripts/show.sh", "absolute path used in the mapping (path variants)")
+		globPath      = flag.String("glob", "/home/jitenv/scripts/*.sh", "glob pattern used in the mapping (local-glob variant)")
+		smARN         = flag.String("sm-arn", "arn:aws:secretsmanager:us-east-1:000000000000:secret:jitenv/demo", "SM secret ARN (localstack variant)")
+		smEndpoint    = flag.String("sm-endpoint", "http://localstack:4566", "SM endpoint URL (localstack variant)")
+		vaultAddr     = flag.String("vault-address", "http://vault:8200", "Vault address (vault variant)")
+		vaultToken    = flag.String("vault-token", "dev-root", "Vault root token (vault variant)")
+		vaultV2Path   = flag.String("vault-v2-path", "myapp/prod", "KV v2 path under the secret/ mount (vault variant)")
+		vaultV1Path   = flag.String("vault-v1-path", "apps/legacy", "KV v1 path under the kv/ mount (vault variant)")
+		vaultV1Script = flag.String("vault-v1-script", "/home/jitenv/scripts/show-v1.sh", "absolute path used in the KV v1 mapping (vault variant)")
+		preserveMeta  = flag.Bool("preserve-meta", false, "preserve the existing config's Meta (salt + verify sentinel) so a running agent's derived key still decrypts the new file")
 	)
 	flag.Parse()
 
@@ -51,14 +60,51 @@ func main() {
 		fmt.Fprintln(os.Stderr, "seed: -out is required")
 		os.Exit(2)
 	}
-	if err := run(*out, []byte(*passphrase), *variant, *scriptPath, *globPath, *smARN, *smEndpoint, *preserveMeta); err != nil {
+	opts := runOpts{
+		out:           *out,
+		pw:            []byte(*passphrase),
+		variant:       *variant,
+		scriptPath:    *scriptPath,
+		globPath:      *globPath,
+		smARN:         *smARN,
+		smEndpoint:    *smEndpoint,
+		vaultAddr:     *vaultAddr,
+		vaultToken:    *vaultToken,
+		vaultV2Path:   *vaultV2Path,
+		vaultV1Path:   *vaultV1Path,
+		vaultV1Script: *vaultV1Script,
+		preserveMeta:  *preserveMeta,
+	}
+	if err := run(opts); err != nil {
 		fmt.Fprintf(os.Stderr, "seed: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stdout, "wrote %s (variant=%s)\n", *out, *variant)
 }
 
-func run(out string, pw []byte, variant, scriptPath, globPath, smARN, smEndpoint string, preserveMeta bool) error {
+// runOpts bundles the seed flags so the run() signature stays
+// manageable as new source variants accumulate.
+type runOpts struct {
+	out           string
+	pw            []byte
+	variant       string
+	scriptPath    string
+	globPath      string
+	smARN         string
+	smEndpoint    string
+	vaultAddr     string
+	vaultToken    string
+	vaultV2Path   string
+	vaultV1Path   string
+	vaultV1Script string
+	preserveMeta  bool
+}
+
+func run(o runOpts) error {
+	out := o.out
+	pw := o.pw
+	variant := o.variant
+	preserveMeta := o.preserveMeta
 	if err := os.MkdirAll(dirOf(out), 0700); err != nil {
 		return fmt.Errorf("mkdir parent: %w", err)
 	}
@@ -103,23 +149,27 @@ func run(out string, pw []byte, variant, scriptPath, globPath, smARN, smEndpoint
 
 	switch variant {
 	case "local":
-		if err := applyLocal(cfg, key, scriptPath, "value-from-local-foo", "value-from-local-bar"); err != nil {
+		if err := applyLocal(cfg, key, o.scriptPath, "value-from-local-foo", "value-from-local-bar"); err != nil {
 			return err
 		}
 	case "local-alt":
-		if err := applyLocal(cfg, key, scriptPath, "value-from-local-foo-v2", "value-from-local-bar-v2"); err != nil {
+		if err := applyLocal(cfg, key, o.scriptPath, "value-from-local-foo-v2", "value-from-local-bar-v2"); err != nil {
 			return err
 		}
 	case "local-glob":
-		if err := applyLocalGlob(cfg, key, globPath); err != nil {
+		if err := applyLocalGlob(cfg, key, o.globPath); err != nil {
 			return err
 		}
 	case "localstack":
-		if err := applyLocalstack(cfg, key, scriptPath, smARN, smEndpoint); err != nil {
+		if err := applyLocalstack(cfg, key, o.scriptPath, o.smARN, o.smEndpoint); err != nil {
+			return err
+		}
+	case "vault":
+		if err := applyVault(cfg, key, o); err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown variant %q (want: local | local-alt | local-glob | localstack)", variant)
+		return fmt.Errorf("unknown variant %q (want: local | local-alt | local-glob | localstack | vault)", variant)
 	}
 
 	return config.AtomicSave(out, cfg)
@@ -217,6 +267,65 @@ func applyLocalstack(cfg *config.Config, key []byte, scriptPath, smARN, smEndpoi
 			Path: scriptPath,
 			Vars: []config.VarRef{
 				{Name: "FOO", Source: "awssm", Ref: smARN, Key: "FOO"},
+			},
+		},
+	}
+	return nil
+}
+
+// applyVault wires two Vault sources at the dev-mode server:
+//
+//	vault-kv2  → KV v2 at mount=secret, expand whole bag at <v2Path>
+//	vault-kv1  → KV v1 at mount=kv,     pick a single key at <v1Path>
+//
+// Both sources reuse the same root token (encrypted at rest), so a
+// scenario only has to assert that the seeded values land in the
+// child's env. The v1 mount is created by the scenario via the Vault
+// HTTP API; the seed itself only writes config.toml.
+func applyVault(cfg *config.Config, key []byte, o runOpts) error {
+	tokV2, err := crypto.EncryptField(key, o.vaultToken)
+	if err != nil {
+		return err
+	}
+	tokV1, err := crypto.EncryptField(key, o.vaultToken)
+	if err != nil {
+		return err
+	}
+	cfg.Sources = map[string]config.SourceConfig{
+		"vault-kv2": {
+			Type: "vault",
+			Params: map[string]any{
+				"address":     o.vaultAddr,
+				"auth_method": "token",
+				"token":       tokV2,
+				"mount":       "secret",
+				"kv_version":  "v2",
+			},
+		},
+		"vault-kv1": {
+			Type: "vault",
+			Params: map[string]any{
+				"address":     o.vaultAddr,
+				"auth_method": "token",
+				"token":       tokV1,
+				"mount":       "kv",
+				"kv_version":  "v1",
+			},
+		},
+	}
+	cfg.Mappings = []config.Mapping{
+		{
+			Path: o.scriptPath,
+			Vars: []config.VarRef{
+				// Empty Name + empty Key → expand whole bag.
+				{Source: "vault-kv2", Ref: o.vaultV2Path},
+			},
+		},
+		{
+			Path: o.vaultV1Script,
+			Vars: []config.VarRef{
+				// KV v1: pick a single key out of the path's body.
+				{Name: "LEGACY_TOKEN", Source: "vault-kv1", Ref: o.vaultV1Path, Key: "LEGACY_TOKEN"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds `vault` service to `e2e/docker-compose.yml`: `hashicorp/vault:1.18` in dev mode on the internal compose network only (no host port), deterministic root token `dev-root`, healthcheck via `vault status`.
- Adds a `vault` variant to `e2e/seed/seed.go` that emits two `[sources.vault]` blocks (KV v2 at `secret/`, KV v1 at `kv/`) and round-trips the token through `crypto.EncryptField` so the agent's `DecryptStringsInPlace` walk over the params block is exercised.
- New scenario `e2e/scenarios/vault-fetch.yaml` covering both KV versions in one run:
  - Pre-seeds Vault via curl against the HTTP API (no `vault` CLI in the runner images, keeps seed and assertions co-located).
  - KV v2 path uses whole-bag expansion (empty-Name VarRef) to assert FOO/BAR land in the child.
  - KV v1 path uses single-key extraction (`Name`/`Key=LEGACY_TOKEN`) to exercise the ref.Key branch through `vault.Fetch`.
  - Bare execution (no `jitenv run`) is asserted not to see Vault secrets.
  - Mount setup is idempotent so the scenario re-runs cleanly within one `e2e-up` cycle without a `e2e-down`.
- `e2e/README.md` updated: service table, quick-start example, "Adding a new source backend" guidance (HTTP-seed-in-scenario pattern), and a Vault-specific notes block. Vault removed from "Out of scope".

Closes #73. Builds on the Vault source plugin from #85.

## Test plan

- [x] `make e2e-build-artifacts && make e2e-up` — stack up, all services healthy including `vault`.
- [x] `make e2e-run SCENARIO=vault-fetch.yaml` — all 31 steps green; verified rerun within the same `e2e-up` cycle still passes.
- [x] Full e2e suite (10/10 scenarios green): `glob-and-bag-expansion`, `install-layout-{alpine,debian,fedora}`, `localstack-fetch`, `locked-agent-warning`, `mid-session-reload`, `unlock-and-run-local`, `vault-fetch`, `zsh-hook-injects-env`.
- [x] `go test ./...` clean.
- [x] CI to confirm.