### PR TITLE
feat(agent): named-pipe transport + token-SID peer auth for Windows (#86)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO ?= go
 BIN := jitenv
 PREFIX ?= $(HOME)/.local
 
-.PHONY: build install test fmt vet tidy lint release-snapshot clean \
+.PHONY: build build-windows install test fmt vet tidy lint release-snapshot clean \
 	e2e-up e2e-down e2e-down-hard e2e-build e2e-build-artifacts \
 	e2e-run e2e-runner-build e2e-shell
 
@@ -17,6 +17,14 @@ LDFLAGS := -s -w \
 
 build:
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN) ./cmd/jitenv
+
+# Cross-compile the Windows binary. Stage 1 (#80) made the codebase
+# compile for GOOS=windows; the runtime port lands in #86-91. Useful
+# for reviewers verifying a Windows-touching PR really produces an
+# executable — `go build ./...` is a compile-check only and does not
+# emit a .exe.
+build-windows:
+	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN).exe ./cmd/jitenv
 
 install: build
 	install -Dm0755 bin/$(BIN) $(PREFIX)/bin/$(BIN)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -3,11 +3,13 @@ package agent
 import (
 	"context"
 	"fmt"
-	"net"
 	"time"
 )
 
-// Client talks to a running agent over its unix socket.
+// Client talks to a running agent over its per-user transport. On
+// Unix the socketPath is a filesystem path bound to an AF_UNIX socket;
+// on Windows it is a named-pipe name (e.g. \\.\pipe\jitenv-<sid>). The
+// caller doesn't need to care — dialAgent is platform-split.
 type Client struct {
 	socketPath string
 	timeout    time.Duration
@@ -18,8 +20,7 @@ func NewClient(socketPath string) *Client {
 }
 
 func (c *Client) call(ctx context.Context, req Request) (Response, error) {
-	d := net.Dialer{Timeout: c.timeout}
-	conn, err := d.DialContext(ctx, "unix", c.socketPath)
+	conn, err := dialAgent(ctx, c.socketPath, c.timeout)
 	if err != nil {
 		return Response{}, fmt.Errorf("connect agent: %w", err)
 	}

--- a/internal/agent/dial_unix.go
+++ b/internal/agent/dial_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// dialAgent opens a client connection to the per-user agent. On Unix
+// this is a plain AF_UNIX dial; the Windows counterpart in
+// dial_windows.go uses winio.DialPipe.
+func dialAgent(ctx context.Context, path string, timeout time.Duration) (net.Conn, error) {
+	d := net.Dialer{Timeout: timeout}
+	return d.DialContext(ctx, "unix", path)
+}

--- a/internal/agent/dial_windows.go
+++ b/internal/agent/dial_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package agent
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// dialAgent opens a client connection to the per-user agent over its
+// named pipe. The pipe name is whatever ResolvePaths() put in
+// Paths.Socket — on Windows that is \\.\pipe\jitenv-<sid>.
+//
+// winio.DialPipe respects ctx via a poll-loop internally but also
+// honours the timeout; we pass both so an explicit context deadline
+// short-circuits a long timeout.
+func dialAgent(ctx context.Context, path string, timeout time.Duration) (net.Conn, error) {
+	// Prefer the context deadline if one was set; otherwise fall back to
+	// the per-call timeout the Client was configured with.
+	if dl, ok := ctx.Deadline(); ok {
+		remaining := time.Until(dl)
+		if remaining < timeout && remaining > 0 {
+			timeout = remaining
+		}
+	}
+	return winio.DialPipe(path, &timeout)
+}

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -7,6 +7,14 @@ import (
 )
 
 // Paths describes the per-user runtime locations the agent uses.
+//
+// Socket is overloaded across platforms: on Unix it is the filesystem
+// path of an AF_UNIX socket (e.g. $XDG_RUNTIME_DIR/jitenv/agent.sock);
+// on Windows it is a named-pipe name (e.g. \\.\pipe\jitenv-<sid>) and
+// must not be passed to filesystem APIs other than os.Remove (which
+// is harmless and silently fails). The agent and client both treat it
+// as an opaque transport endpoint string and route it through the
+// platform-split listenSocket / dialAgent functions.
 type Paths struct {
 	Dir       string
 	Socket    string
@@ -37,7 +45,7 @@ func ResolvePaths() Paths {
 	dir := runtimeBaseDir()
 	return Paths{
 		Dir:       dir,
-		Socket:    filepath.Join(dir, "agent.sock"),
+		Socket:    socketEndpoint(dir),
 		PidFile:   filepath.Join(dir, "agent.pid"),
 		LogFile:   filepath.Join(dir, "agent.log"),
 		ShellsDir: filepath.Join(dir, "shells"),

--- a/internal/agent/paths_unix.go
+++ b/internal/agent/paths_unix.go
@@ -18,3 +18,9 @@ func runtimeBaseDir() string {
 	}
 	return filepath.Join(os.TempDir(), fmt.Sprintf("jitenv-%d", os.Getuid()))
 }
+
+// socketEndpoint returns the Paths.Socket value on Unix: the path of
+// the AF_UNIX socket file under the runtime base directory.
+func socketEndpoint(baseDir string) string {
+	return filepath.Join(baseDir, "agent.sock")
+}

--- a/internal/agent/paths_windows.go
+++ b/internal/agent/paths_windows.go
@@ -5,6 +5,8 @@ package agent
 import (
 	"os"
 	"path/filepath"
+
+	"golang.org/x/sys/windows"
 )
 
 // runtimeBaseDir returns the per-user runtime directory for the agent
@@ -14,10 +16,9 @@ import (
 // (Roaming) on Windows, which is a reasonable second-choice; the
 // final fallback is os.TempDir() so we never return an empty path.
 //
-// The agent itself does not start on Windows today (see SpawnDaemon
-// in daemonize_windows.go) but ResolvePaths is reachable from
-// `jitenv hook` and other read-only commands, so it has to return
-// _something_ sensible.
+// Used for the on-disk side of Paths (Dir, PidFile, LogFile,
+// ShellsDir). The pipe transport's Socket field is computed
+// separately in pipeName().
 func runtimeBaseDir() string {
 	if dir := os.Getenv("LOCALAPPDATA"); dir != "" {
 		return filepath.Join(dir, "jitenv")
@@ -26,4 +27,32 @@ func runtimeBaseDir() string {
 		return filepath.Join(dir, "jitenv")
 	}
 	return filepath.Join(os.TempDir(), "jitenv")
+}
+
+// socketEndpoint returns the Paths.Socket value on Windows: the
+// per-user named-pipe name. The baseDir argument is ignored — pipe
+// names live in their own namespace, not on the filesystem.
+func socketEndpoint(_ string) string {
+	return pipeName()
+}
+
+// pipeName returns the per-user named-pipe path the agent listens on.
+// Windows named pipes live in their own namespace (\\.\pipe\...) — not
+// the filesystem — and pipe names are required to be unique
+// system-wide, so the per-user SID is folded into the name to keep
+// multiple users on the same box from colliding. The pipe is further
+// ACL-restricted to that SID in socket_windows.go.
+//
+// If the current user's SID cannot be resolved (extremely unusual on a
+// healthy Windows install), fall back to a static name. The agent will
+// then fail at Listen with a clearer error message than panicking
+// inside Paths construction.
+func pipeName() string {
+	tok := windows.GetCurrentProcessToken()
+	tu, err := tok.GetTokenUser()
+	if err != nil {
+		return `\\.\pipe\jitenv-unknown`
+	}
+	sid := tu.User.Sid.String()
+	return `\\.\pipe\jitenv-` + sid
 }

--- a/internal/agent/peer_darwin.go
+++ b/internal/agent/peer_darwin.go
@@ -14,8 +14,15 @@ import (
 // Darwin: read LOCAL_PEERCRED via getsockopt, returning the peer's
 // effective uid in xucred.Uid (xucred.Cr_ngroups + Groups[0..N] also
 // available but we don't need them).
-func checkPeerUid(c *net.UnixConn) error {
-	raw, err := c.SyscallConn()
+//
+// The handler passes a net.Conn; on Unix the agent listener always
+// produces *net.UnixConn, so the type assertion is total.
+func checkPeerUid(c net.Conn) error {
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("peer check: unexpected conn type %T", c)
+	}
+	raw, err := uc.SyscallConn()
 	if err != nil {
 		return err
 	}

--- a/internal/agent/peer_linux.go
+++ b/internal/agent/peer_linux.go
@@ -12,8 +12,15 @@ import (
 
 // checkPeerUid enforces that the connecting client runs as the same uid.
 // Linux: read SO_PEERCRED via getsockopt.
-func checkPeerUid(c *net.UnixConn) error {
-	raw, err := c.SyscallConn()
+//
+// The handler passes a net.Conn; on Unix the agent listener always
+// produces *net.UnixConn, so the type assertion is total.
+func checkPeerUid(c net.Conn) error {
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("peer check: unexpected conn type %T", c)
+	}
+	raw, err := uc.SyscallConn()
 	if err != nil {
 		return err
 	}

--- a/internal/agent/peer_windows.go
+++ b/internal/agent/peer_windows.go
@@ -3,16 +3,78 @@
 package agent
 
 import (
-	"errors"
+	"fmt"
 	"net"
+
+	"golang.org/x/sys/windows"
 )
 
-// checkPeerUid is a Windows stub. Stage 1 of #39 keeps the codebase
-// compiling for GOOS=windows; a real implementation will go through a
-// Windows-native transport (named pipes) and use token-based peer
-// authentication. Until that lands the agent itself never starts on
-// Windows (see SpawnDaemon / listenSocket), so this stub should never
-// be invoked at runtime.
-func checkPeerUid(_ *net.UnixConn) error {
-	return errors.New("jitenv agent: peer-credential check not implemented on windows; tracking in #39")
+// fdConn is satisfied by *winio.win32Pipe (the conn type produced by
+// winio.ListenPipe.Accept) via its promoted Fd() method on the
+// underlying win32File. We extract the handle via this interface rather
+// than depending on go-winio internals.
+type fdConn interface {
+	Fd() uintptr
+}
+
+// checkPeerUid enforces that the connecting named-pipe client runs as
+// the same user as the agent.
+//
+// The pipe ACL set in socket_windows.go already restricts the pipe to
+// the current user SID, but that is a perimeter check. We still grab
+// the client's process ID via GetNamedPipeClientProcessId, open its
+// token, and compare the token's user SID against the agent's own. A
+// matching SID is the load-bearing peer-auth guarantee — anything else
+// (the ACL, the pipe path containing the SID) is defence in depth.
+//
+// Note: this comparison is same-user, not same-session. A second
+// process running under the same user account (e.g. another shell
+// session) is treated as authorised, exactly as on Unix where multiple
+// shells of the same uid all pass SO_PEERCRED.
+func checkPeerUid(c net.Conn) error {
+	fc, ok := c.(fdConn)
+	if !ok {
+		return fmt.Errorf("peer check: conn type %T does not expose a handle", c)
+	}
+	pipeHandle := windows.Handle(fc.Fd())
+
+	var clientPID uint32
+	if err := windows.GetNamedPipeClientProcessId(pipeHandle, &clientPID); err != nil {
+		return fmt.Errorf("get pipe client pid: %w", err)
+	}
+
+	// PROCESS_QUERY_LIMITED_INFORMATION (0x1000) is sufficient to call
+	// OpenProcessToken with TOKEN_QUERY, and unlike
+	// PROCESS_QUERY_INFORMATION it works across integrity levels for the
+	// same user.
+	const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+	procHandle, err := windows.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, clientPID)
+	if err != nil {
+		return fmt.Errorf("open client process %d: %w", clientPID, err)
+	}
+	defer windows.CloseHandle(procHandle)
+
+	var clientTok windows.Token
+	if err := windows.OpenProcessToken(procHandle, windows.TOKEN_QUERY, &clientTok); err != nil {
+		return fmt.Errorf("open client process token: %w", err)
+	}
+	defer clientTok.Close()
+
+	clientUser, err := clientTok.GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("get client token user: %w", err)
+	}
+	clientSID := clientUser.User.Sid
+
+	ownTok := windows.GetCurrentProcessToken()
+	ownUser, err := ownTok.GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("get agent token user: %w", err)
+	}
+	ownSID := ownUser.User.Sid
+
+	if !windows.EqualSid(clientSID, ownSID) {
+		return fmt.Errorf("peer sid %s != %s", clientSID, ownSID)
+	}
+	return nil
 }

--- a/internal/agent/peer_windows_test.go
+++ b/internal/agent/peer_windows_test.go
@@ -1,0 +1,116 @@
+//go:build windows
+
+package agent
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
+)
+
+// TestPeerCheckSameUserPipe spins up a real per-user named-pipe
+// listener via listenSocket and connects to it from the same process.
+// checkPeerUid must accept the connection — both sides share the
+// current process's user SID. This exercises the
+// GetNamedPipeClientProcessId -> OpenProcess -> token-SID path against
+// a live OS-managed pipe.
+//
+// Cross-user rejection is the other half of the contract but is
+// impractical to test from a single-process unit test (it requires a
+// second user account and an impersonation token). The same-user path
+// is the regression-catcher: a broken handle extraction, a wrong
+// access mask on OpenProcess, or a missing EqualSid all fail here.
+func TestPeerCheckSameUserPipe(t *testing.T) {
+	sid, err := currentUserSID()
+	if err != nil {
+		t.Fatalf("currentUserSID: %v", err)
+	}
+	// Per-test pipe name so parallel tests don't collide.
+	pipePath := fmt.Sprintf(`\\.\pipe\jitenv-test-%d-%d`, windows.GetCurrentThreadId(), time.Now().UnixNano())
+
+	ln, err := winio.ListenPipe(pipePath, &winio.PipeConfig{
+		SecurityDescriptor: fmt.Sprintf("D:(A;;GA;;;%s)", sid),
+	})
+	if err != nil {
+		t.Fatalf("listen pipe: %v", err)
+	}
+	defer ln.Close()
+
+	var (
+		wg      sync.WaitGroup
+		acceptC = make(chan net.Conn, 1)
+		acceptE = make(chan error, 1)
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c, err := ln.Accept()
+		if err != nil {
+			acceptE <- err
+			return
+		}
+		acceptC <- c
+	}()
+
+	timeout := 5 * time.Second
+	client, err := winio.DialPipe(pipePath, &timeout)
+	if err != nil {
+		t.Fatalf("dial pipe: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case err := <-acceptE:
+		t.Fatalf("accept: %v", err)
+	case server := <-acceptC:
+		defer server.Close()
+		if err := checkPeerUid(server); err != nil {
+			t.Fatalf("checkPeerUid (same-user): %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("accept timed out")
+	}
+	wg.Wait()
+}
+
+// TestPeerCheckRejectsNonPipeConn guards the type assertion in
+// checkPeerUid. A plain TCP conn doesn't expose a pipe handle, so the
+// check must reject it cleanly rather than panicking.
+func TestPeerCheckRejectsNonPipeConn(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("tcp listen: %v", err)
+	}
+	defer ln.Close()
+
+	type accepted struct {
+		c   net.Conn
+		err error
+	}
+	done := make(chan accepted, 1)
+	go func() {
+		c, err := ln.Accept()
+		done <- accepted{c, err}
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("tcp dial: %v", err)
+	}
+	defer client.Close()
+
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("tcp accept: %v", got.err)
+	}
+	defer got.c.Close()
+
+	if err := checkPeerUid(got.c); err == nil {
+		t.Fatalf("expected peer check to reject non-pipe conn")
+	}
+}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -15,7 +15,7 @@ import (
 // Agent is the per-user secret-fetching daemon.
 type Agent struct {
 	paths    Paths
-	listener *net.UnixListener
+	listener net.Listener
 
 	startedAt time.Time
 	hits      atomic.Int64
@@ -72,19 +72,25 @@ func (a *Agent) currentResolver() Resolver {
 	return a.resolver
 }
 
-// Listen creates the unix socket. Caller must call Serve to accept.
+// Listen creates the agent transport endpoint. Caller must call Serve
+// to accept.
 //
 // Also runs a one-time GC pass over ShellsDir, removing wrapper dirs
 // for shell pids that aren't alive anymore. Cheap, idempotent.
 //
-// The actual socket-binding step is platform-split into socket_unix.go
-// (real net.ListenUnix) and socket_windows.go (returns "not yet
-// implemented"). See #39 stage 1.
+// The actual binding step is platform-split into socket_unix.go (real
+// net.ListenUnix at paths.Socket) and socket_windows.go (named-pipe
+// listener at paths.Socket interpreted as a \\.\pipe\... name). The
+// returned listener is just a net.Listener — per-connection peer
+// authentication happens in checkPeerUid, which has its own
+// platform-split implementations.
 func (a *Agent) Listen() error {
 	_ = GcOrphanShells(a.paths.ShellsDir)
 	if existing, _ := ReadPidFile(a.paths.PidFile); existing > 0 && PidAlive(existing) {
 		return fmt.Errorf("agent already running (pid %d)", existing)
 	}
+	// Best-effort cleanup of a stale socket file. No-op on Windows where
+	// Socket is a pipe name, not a filesystem path.
 	_ = os.Remove(a.paths.Socket)
 
 	ln, err := listenSocket(a.paths.Socket)
@@ -114,7 +120,7 @@ func (a *Agent) Serve(ctx context.Context) error {
 	}()
 
 	for {
-		conn, err := a.listener.AcceptUnix()
+		conn, err := a.listener.Accept()
 		if err != nil {
 			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
 				return nil
@@ -157,12 +163,14 @@ func (a *Agent) idleLoop(ctx context.Context) {
 	}
 }
 
-// checkPeerUid lives in peer_linux.go / peer_darwin.go so that each
-// platform uses the right peer-credential syscall (SO_PEERCRED on Linux,
-// LOCAL_PEERCRED on Darwin). The agent only builds for those two
-// platforms — see CLAUDE.md "Big-picture architecture" §agent.
+// checkPeerUid lives in peer_linux.go / peer_darwin.go / peer_windows.go
+// so each platform uses the right peer-credential mechanism: SO_PEERCRED
+// on Linux, LOCAL_PEERCRED on Darwin, and GetNamedPipeClientProcessId +
+// token-SID compare on Windows. The handler takes a net.Conn — each
+// implementation type-asserts to the concrete connection type it expects
+// (*net.UnixConn on Unix, the go-winio pipe conn on Windows).
 
-func (a *Agent) handle(ctx context.Context, c *net.UnixConn) {
+func (a *Agent) handle(ctx context.Context, c net.Conn) {
 	defer c.Close()
 	if err := checkPeerUid(c); err != nil {
 		_ = WriteMessage(c, Response{OK: false, Error: "unauthorized"})

--- a/internal/agent/socket_unix.go
+++ b/internal/agent/socket_unix.go
@@ -13,9 +13,9 @@ import (
 // in checkPeerUid, but the filesystem permission is the first line of
 // defence against an unrelated uid even attempting to connect.
 //
-// On Windows the named-pipe transport will replace this — see
-// socket_windows.go (#39 stage 2+).
-func listenSocket(path string) (*net.UnixListener, error) {
+// Returns a net.Listener so callers stay platform-agnostic; the Windows
+// counterpart in socket_windows.go uses a named-pipe listener instead.
+func listenSocket(path string) (net.Listener, error) {
 	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
 	if err != nil {
 		return nil, fmt.Errorf("listen %s: %w", path, err)

--- a/internal/agent/socket_windows.go
+++ b/internal/agent/socket_windows.go
@@ -3,18 +3,52 @@
 package agent
 
 import (
-	"errors"
+	"fmt"
 	"net"
+
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
 )
 
-// listenSocket on Windows refuses to bind. The Unix-socket transport
-// isn't appropriate on Windows because there's no SO_PEERCRED-style
-// peer-uid check available over AF_UNIX, so a future port will switch
-// to a named pipe (\\.\pipe\jitenv-<sid>) with token-based peer
-// authentication. Tracking in #39 stage 2+.
+// listenSocket binds the per-user named-pipe at path. On Windows path
+// is interpreted as a pipe name (e.g. \\.\pipe\jitenv-<sid>), not a
+// filesystem path.
 //
-// Returning an error here keeps `jitenv unlock` from accidentally
-// spinning up a transport with no auth.
-func listenSocket(_ string) (*net.UnixListener, error) {
-	return nil, errors.New("jitenv agent: Windows named-pipe transport not yet implemented; tracking in #39")
+// The SDDL string restricts the pipe ACL to the current user's SID
+// only: "D:(A;;GA;;;<sid>)" is a Discretionary ACL with a single Access
+// Allowed ACE granting Generic All to that SID. SYSTEM and
+// Administrators are deliberately omitted — an attacker with admin
+// rights on the box can already inject into our process or read our
+// memory, so adding them to the ACL would only obscure that fact. The
+// peer SID is then re-checked per-connection in checkPeerUid so a
+// malicious local admin who somehow opens the pipe still doesn't pass
+// auth.
+func listenSocket(path string) (net.Listener, error) {
+	sid, err := currentUserSID()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current user SID: %w", err)
+	}
+	sddl := fmt.Sprintf("D:(A;;GA;;;%s)", sid)
+	ln, err := winio.ListenPipe(path, &winio.PipeConfig{
+		SecurityDescriptor: sddl,
+		// Message-mode buffering is unnecessary; the agent protocol is
+		// length-prefixed over a byte stream.
+		InputBufferSize:  4096,
+		OutputBufferSize: 4096,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listen pipe %s: %w", path, err)
+	}
+	return ln, nil
+}
+
+// currentUserSID returns the SID string of the process's primary user
+// token, e.g. "S-1-5-21-...".
+func currentUserSID() (string, error) {
+	tok := windows.GetCurrentProcessToken()
+	tu, err := tok.GetTokenUser()
+	if err != nil {
+		return "", err
+	}
+	return tu.User.Sid.String(), nil
 }


### PR DESCRIPTION
## Summary

Replaces the Stage 1 Windows stubs in `socket_windows.go` and `peer_windows.go` with a real `\\.\pipe\jitenv-<sid>` named-pipe listener (SDDL-restricted to the current user SID) and a per-connection peer check via `GetNamedPipeClientProcessId` + token-SID compare. Foundation for #39 Stage 2+; every later sub-issue depends on this.

## Approach

**Transport abstraction.** Replaced `Agent.listener *net.UnixListener` with a plain `net.Listener`. `handle()` now takes `net.Conn` and each platform's `checkPeerUid` type-asserts to its concrete connection type (`*net.UnixConn` on Unix, an `Fd()`-bearing winio pipe conn on Windows via a small `fdConn` interface). New `dial_unix.go` / `dial_windows.go` split the client-side dial — `client.go` no longer hardcodes `"unix"`, it just calls `dialAgent`. `listenSocket` returns `net.Listener` on both platforms.

**`Paths.Socket` overloading.** Per the issue decision, `Paths.Socket` is now a filesystem path on Unix and a named-pipe name on Windows; callers stay platform-agnostic. A new `socketEndpoint(baseDir)` platform helper computes the right shape. `Paths.Dir / PidFile / LogFile / ShellsDir` still live on the filesystem under `%LOCALAPPDATA%\jitenv`. The stale `os.Remove(a.paths.Socket)` in `Listen` / `Shutdown` is a harmless no-op on a pipe name.

**Windows specifics.**
- `socket_windows.go` uses `winio.ListenPipe` with SDDL `D:(A;;GA;;;<sid>)` — a single Access-Allowed ACE granting Generic All to the current user SID only. SYSTEM / Administrators are deliberately omitted; if an attacker already has admin on the box they own the process anyway, so the SID re-check below is the load-bearing guarantee, and adding more SIDs to the ACL would only obscure that.
- `peer_windows.go` does `GetNamedPipeClientProcessId` → `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` → `OpenProcessToken(TOKEN_QUERY)` → `GetTokenUser` → `EqualSid` against the agent's own primary-token user. Same-user, not same-session, matching the SO_PEERCRED semantics on Unix.
- `paths_windows.go` builds the pipe name as `\\.\pipe\jitenv-<sid>` so multiple users on the same host don't collide system-wide.
- Library: `github.com/Microsoft/go-winio v0.6.2` (pure Go, BSD-3, used by Docker/containerd).

## Test coverage

- `peer_windows_test.go` — new. Spins up a real per-user pipe via `winio.ListenPipe`, dials from the same process, and asserts `checkPeerUid` accepts. Also confirms the type assertion rejects a non-pipe (TCP) conn cleanly. Cross-user rejection is documented as out-of-scope for a single-process unit test.
- Existing Linux/macOS agent + peer tests untouched and still green (`go test ./... -count=1` clean locally).
- `GOOS=windows GOARCH=amd64 go vet ./...` clean. **Note:** `go build ./...` is a multi-package compile-check that does **not** emit a `.exe`. Use the new `make build-windows` target to actually produce `bin/jitenv.exe` (a 16 MB PE32+ executable).

Refs #86, #39.

## Test plan
- [x] CI Linux job: existing `internal/agent` tests stay green.
- [ ] CI macOS job (the Darwin peer-cred canary) stays green.
- [x] CI Windows job (added in #80): new `peer_windows_test.go` passes against a same-user pipe client; agent + transport packages build and run on `windows/amd64`.
- [x] Reviewers: `make build` produces the Linux binary; `make build-windows` produces `bin/jitenv.exe`.