### PR TITLE
feat(run,shim): spawn-and-wait Windows runtime for jitenv run + shim (#88)

### DIFF
--- a/internal/run/run_windows.go
+++ b/internal/run/run_windows.go
@@ -2,12 +2,81 @@
 
 package run
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
 
-// replaceProcess on Windows refuses to exec. Windows has no exec-in-
-// place primitive that drops the current process image, so a real
-// port will need a different model (spawn + wait, or token-stuffed
-// CreateProcess). Tracking in #39 stage 2+.
-func replaceProcess(_ string, _ []string, _ []string) error {
-	return errors.New("jitenv run: not yet supported on windows; tracking in #39")
+	"golang.org/x/sys/windows"
+)
+
+// replaceProcess on Windows can't replace the process image — there is
+// no execve equivalent that drops the current image while keeping the
+// pid. Instead we spawn the target with stdio inherited, forward
+// console-control signals, wait synchronously, then os.Exit with the
+// child's code. The jitenv parent stays alive for the child's lifetime
+// (visible in Task Manager) — that is the deliberate trade-off for not
+// having an exec-replace primitive on Windows. The contract with
+// callers therefore differs subtly from the Unix path: on success this
+// function does NOT return (it calls os.Exit); it only returns a Go
+// error when the child failed to start at all. The Unix
+// implementation behaves the same in practice (syscall.Exec replaces
+// the image and never returns on success), so the call sites in run.go
+// are happy with either shape.
+func replaceProcess(realPath string, args []string, env []string) error {
+	cmd := exec.Command(realPath, args...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// CREATE_NEW_PROCESS_GROUP gives the child its own process group so
+	// GenerateConsoleCtrlEvent below can target it specifically. Without
+	// this flag, Ctrl+C delivered to the console reaches both parent and
+	// child anyway; with it, the parent can decide whether and when to
+	// forward the event explicitly.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("run %s: %w", realPath, err)
+	}
+
+	// Forward Ctrl+C / interrupt from the parent to the child's process
+	// group as a CTRL_BREAK_EVENT (CTRL_C_EVENT cannot be sent to a
+	// specific group via GenerateConsoleCtrlEvent — only break can).
+	// Most console programs handle CTRL_BREAK_EVENT the same way as
+	// CTRL_C_EVENT; the few that don't will be killed on parent exit
+	// anyway when their inherited stdio handles close.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-sigCh:
+				if cmd.Process != nil {
+					_ = windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(cmd.Process.Pid))
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	err := cmd.Wait()
+	close(done)
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.ExitCode())
+		}
+		return fmt.Errorf("run %s: %w", realPath, err)
+	}
+	os.Exit(0)
+	return nil // unreachable; satisfies the compiler
 }

--- a/internal/run/run_windows_test.go
+++ b/internal/run/run_windows_test.go
@@ -1,0 +1,141 @@
+//go:build windows
+
+package run_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildJitenv compiles the jitenv binary into the test's temp dir.
+// Mirrors the Unix helper but writes to jitenv.exe; the build command
+// inherits GOOS=windows because tests in this file only compile under
+// //go:build windows.
+func buildJitenv(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "jitenv.exe")
+	cmd := exec.Command("go", "build", "-o", out, "../../cmd/jitenv")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build jitenv: %v", err)
+	}
+	return out
+}
+
+// buildExitChild compiles a tiny helper that exits with the requested
+// code and prints any env markers we care about to stdout. We don't
+// use //go:embed or testdata source: a tiny one-file program in a
+// temp dir compiled via `go build` is the same pattern run_e2e_test.go
+// uses on Unix to produce shell-script targets, just adapted for a
+// Go-binary target (Windows doesn't have a /bin/sh interpreter we can
+// rely on in CI).
+func buildExitChild(t *testing.T) string {
+	t.Helper()
+	src := filepath.Join(t.TempDir(), "exitchild.go")
+	contents := `package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	code := 0
+	if len(os.Args) > 1 {
+		if n, err := strconv.Atoi(os.Args[1]); err == nil {
+			code = n
+		}
+	}
+	// Echo the markers so the test can confirm env propagation.
+	fmt.Println("MARKER=" + os.Getenv("__JITENV_INJECTED"))
+	fmt.Println("WARNED=" + os.Getenv("__JITENV_AGENT_WARNED"))
+	fmt.Println("FOO=" + os.Getenv("FOO"))
+	os.Exit(code)
+}
+`
+	if err := os.WriteFile(src, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "exitchild.exe")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build exitchild: %v", err)
+	}
+	return out
+}
+
+// TestRunWindowsExitCodePropagation is the headline test for the
+// Windows spawn-and-wait path: a child that exits with code 42 must
+// cause `jitenv run` itself to exit with code 42. The Unix path gets
+// this for free because syscall.Exec replaces the process image; on
+// Windows we have to forward the code explicitly via os.Exit.
+//
+// We piggyback on the __JITENV_INJECTED=1 short-circuit so the test
+// doesn't need a running agent (the agent runtime port is #87 and is
+// not done at the time this test was written). The short-circuit
+// branch in run.go reaches replaceProcess directly, exercising the
+// same code path as the steady-state agent-up scenario from
+// replaceProcess's point of view.
+func TestRunWindowsExitCodePropagation(t *testing.T) {
+	bin := buildJitenv(t)
+	child := buildExitChild(t)
+
+	env := append(os.Environ(),
+		"__JITENV_INJECTED=1",
+		"FOO=hello",
+	)
+
+	cmd := exec.Command(bin, "run", child, "42")
+	cmd.Env = env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	// Expect non-nil err, but with exit code 42.
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("jitenv run: expected ExitError with code 42; got err=%v stderr=%s", err, stderr.String())
+	}
+	if ee.ExitCode() != 42 {
+		t.Fatalf("jitenv run: expected exit code 42; got %d stderr=%s", ee.ExitCode(), stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "MARKER=1") {
+		t.Errorf("__JITENV_INJECTED did not propagate through spawn-and-wait; stdout=%q", out)
+	}
+	if !strings.Contains(out, "FOO=hello") {
+		t.Errorf("FOO did not propagate to child; stdout=%q", out)
+	}
+}
+
+// TestRunWindowsZeroExit verifies the happy-path exit-code mapping:
+// child exits 0, jitenv run exits 0.
+func TestRunWindowsZeroExit(t *testing.T) {
+	bin := buildJitenv(t)
+	child := buildExitChild(t)
+
+	env := append(os.Environ(),
+		"__JITENV_INJECTED=1",
+	)
+	cmd := exec.Command(bin, "run", child, "0")
+	cmd.Env = env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("jitenv run: expected exit 0; got %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "MARKER=1") {
+		t.Errorf("marker missing; stdout=%q", stdout.String())
+	}
+}

--- a/internal/shim/shim_windows.go
+++ b/internal/shim/shim_windows.go
@@ -2,13 +2,81 @@
 
 package shim
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
 
-// execReal on Windows refuses to run. The cwd_glob wrapper-symlink
-// model assumes a POSIX exec-in-place primitive (so argv[0] survives
-// and the parent shell's pid is inherited); Windows has no equivalent.
-// A real port will need spawn-and-wait or a different invocation
-// model entirely. Tracking in #39 stage 2+.
-func execReal(_ string, _ []string, _ []string) error {
-	return errors.New("jitenv shim: not yet supported on windows; tracking in #39")
+	"golang.org/x/sys/windows"
+)
+
+// execReal on Windows spawns realPath synchronously: stdio is inherited
+// so the wrapped program is indistinguishable from a direct invocation
+// for the typing user, console-control signals are forwarded to the
+// child's process group, and after Wait() the function calls os.Exit
+// with the child's exit code. The shim parent process stays alive for
+// the child's lifetime (visible in Task Manager) — there is no
+// exec-replace primitive on Windows, so this is the deliberate
+// trade-off.
+//
+// Note the argv parameter: on Unix syscall.Exec uses argv[0] as the
+// program name visible to the child (so wrapped `npm` sees os.Args[0]
+// == "npm" rather than the full symlink path). exec.Cmd does not let
+// us override argv[0] in a portable way — Windows binaries don't have
+// the same convention anyway and most tooling reads its name from
+// GetModuleFileName, not argv[0]. We pass argv[1:] as cmd.Args.
+//
+// Like replaceProcess in internal/run/run_windows.go, this function
+// returns a Go error only when the child failed to start. On a
+// successful spawn + wait it calls os.Exit and never returns.
+func execReal(realPath string, argv []string, env []string) error {
+	// argv[0] is the typed command name; argv[1:] is the rest.
+	var args []string
+	if len(argv) > 1 {
+		args = argv[1:]
+	}
+	cmd := exec.Command(realPath, args...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("exec %s: %w", realPath, err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-sigCh:
+				if cmd.Process != nil {
+					_ = windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(cmd.Process.Pid))
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	err := cmd.Wait()
+	close(done)
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.ExitCode())
+		}
+		return fmt.Errorf("exec %s: %w", realPath, err)
+	}
+	os.Exit(0)
+	return nil // unreachable; satisfies the compiler
 }

--- a/internal/shim/shim_windows_test.go
+++ b/internal/shim/shim_windows_test.go
@@ -1,0 +1,167 @@
+//go:build windows
+
+package shim
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestMain is the entry point used to re-exec ourselves as a subprocess
+// that exercises execReal directly. The Windows execReal calls os.Exit
+// on success (there is no exec-replace on Windows), so it cannot be
+// tested in-process. The subprocess pattern below — go test re-exec
+// with a magic env var — is the standard Go workaround.
+//
+// When JITENV_TEST_EXEC_REAL_TARGET is set, the test binary acts as a
+// driver: it builds nothing, just calls execReal with the target path
+// and any extra args, propagating the child's exit code via os.Exit.
+// When the env var is unset, the test binary behaves normally and runs
+// the test functions.
+func TestMain(m *testing.M) {
+	if target := os.Getenv("JITENV_TEST_EXEC_REAL_TARGET"); target != "" {
+		args := []string{filepath.Base(target)}
+		args = append(args, os.Args[1:]...)
+		// execReal calls os.Exit; this never returns.
+		if err := execReal(target, args, os.Environ()); err != nil {
+			// Failed to start; surface and exit non-zero.
+			_, _ = os.Stderr.WriteString(err.Error() + "\n")
+			os.Exit(127)
+		}
+		os.Exit(0) // unreachable
+	}
+	os.Exit(m.Run())
+}
+
+// buildExitChildExe compiles a tiny helper that prints its env then
+// exits with the requested code. Used as the "real binary" execReal
+// should spawn-and-wait.
+func buildExitChildExe(t *testing.T) string {
+	t.Helper()
+	src := filepath.Join(t.TempDir(), "exitchild.go")
+	contents := `package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	code := 0
+	if len(os.Args) > 1 {
+		if n, err := strconv.Atoi(os.Args[1]); err == nil {
+			code = n
+		}
+	}
+	fmt.Println("RAN")
+	fmt.Println("MARKER=" + os.Getenv("__JITENV_INJECTED"))
+	fmt.Println("WARNED=" + os.Getenv("__JITENV_AGENT_WARNED"))
+	os.Exit(code)
+}
+`
+	if err := os.WriteFile(src, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "exitchild.exe")
+	cmd := exec.Command("go", "build", "-o", out, src)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build exitchild: %v", err)
+	}
+	return out
+}
+
+// TestExecRealExitCodePropagation is the headline test for the Windows
+// shim spawn-and-wait path: a child that exits with code 17 must cause
+// execReal to exit with 17. We re-exec ourselves through TestMain's
+// driver branch so execReal's os.Exit doesn't terminate the test
+// runner. Env markers (__JITENV_INJECTED, __JITENV_AGENT_WARNED) are
+// passed through cmd.Env -> exec.Cmd.Env -> child process.
+func TestExecRealExitCodePropagation(t *testing.T) {
+	child := buildExitChildExe(t)
+
+	cmd := exec.Command(os.Args[0], "17")
+	cmd.Env = append(os.Environ(),
+		"JITENV_TEST_EXEC_REAL_TARGET="+child,
+		"__JITENV_INJECTED=1",
+	)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError; got err=%v output=%s", err, buf.String())
+	}
+	if ee.ExitCode() != 17 {
+		t.Fatalf("expected exit 17; got %d output=%s", ee.ExitCode(), buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("child did not print RAN; output=%s", out)
+	}
+	if !strings.Contains(out, "MARKER=1") {
+		t.Errorf("__JITENV_INJECTED did not propagate through spawn-and-wait; output=%s", out)
+	}
+}
+
+// TestExecRealZeroExit verifies the happy-path exit mapping.
+func TestExecRealZeroExit(t *testing.T) {
+	child := buildExitChildExe(t)
+
+	cmd := exec.Command(os.Args[0], "0")
+	cmd.Env = append(os.Environ(),
+		"JITENV_TEST_EXEC_REAL_TARGET="+child,
+		"__JITENV_AGENT_WARNED=1",
+	)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("expected exit 0; got %v output=%s", err, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("child did not print RAN; output=%s", out)
+	}
+	if !strings.Contains(out, "WARNED=1") {
+		t.Errorf("__JITENV_AGENT_WARNED did not propagate; output=%s", out)
+	}
+}
+
+// TestExecRealMissingBinary verifies the error path: when the target
+// doesn't exist, execReal must return an error (not os.Exit) so the
+// caller can surface it. We use a unique non-existent path so the
+// failure mode is unambiguous.
+func TestExecRealMissingBinary(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist-"+strconv.Itoa(os.Getpid())+".exe")
+
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		"JITENV_TEST_EXEC_REAL_TARGET="+missing,
+	)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected non-zero exit when target is missing; output=%s", buf.String())
+	}
+	// Exit code 127 (our driver's wrapper) confirms execReal returned
+	// an error rather than os.Exit-ing.
+	ee, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError; got %v", err)
+	}
+	if ee.ExitCode() != 127 {
+		t.Fatalf("expected exit 127 (error path); got %d output=%s", ee.ExitCode(), buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Implements the Windows runtime for `replaceProcess` (in `internal/run/run_windows.go`) and `execReal` (in `internal/shim/shim_windows.go`), replacing the Stage 1 \"not yet implemented\" stubs. Windows has no exec-replace primitive, so this is a spawn-and-wait port: start the target via `exec.Cmd` with stdio inherited, wait synchronously, then `os.Exit` with the child's exit code. The jitenv parent stays alive for the child's lifetime (visible in Task Manager) — the deliberate trade-off for not having `execve` on Windows.

## Design notes

- **Approach.** `exec.Cmd` + `Stdin/Stdout/Stderr = os.Stdin/Out/Err` + `cmd.Run()` + `os.Exit(child code)`. Env propagates via `cmd.Env`, so `__JITENV_INJECTED` / `__JITENV_AGENT_WARNED` markers survive across child invocations exactly as on Unix.
- **Signal forwarding.** Child is spawned with `syscall.SysProcAttr.CreationFlags = windows.CREATE_NEW_PROCESS_GROUP`. A goroutine listens for `os.Interrupt` and forwards to the child via `windows.GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)`. `CTRL_C_EVENT` cannot be targeted at a specific group via that API, only `CTRL_BREAK_EVENT` can; most console programs handle both equivalently.
- **Return-or-exit at the function boundary.** Both functions call `os.Exit` on a successful spawn-and-wait and only return a Go error when the child failed to start (`cmd.Start()` error path). The Unix path's `syscall.Exec` never returns on success either, so callers in `run.go` and `shim.go` are happy with the same shape on both OSes.
- **argv[0] note.** Unix `syscall.Exec` lets the wrapper set the child's `argv[0]` to the typed command name; `exec.Cmd` doesn't expose that in a portable way. Windows tools don't rely on `argv[0]` (they use `GetModuleFileName`), so the shim passes `argv[1:]` as `cmd.Args` and accepts the loss.

## Test coverage

- `internal/run/run_windows_test.go` — exit-code propagation (42 → 42, 0 → 0) and env-marker propagation through the built `jitenv.exe`. Uses the `__JITENV_INJECTED=1` short-circuit in `run.Run` so an agent isn't required (agent runtime is sibling issue #87).
- `internal/shim/shim_windows_test.go` — exit-code propagation (17 → 17, 0 → 0), env-marker propagation, and the missing-binary error path. Calls `execReal` directly via a `TestMain` re-exec driver, since `os.Exit` inside `execReal` would terminate the test runner.

CI's `test (windows)` job will exercise these.

## Out of scope

- chpwd / `.ps1` shim file generation — that's #89.
- Agent / daemonize / unlock — that's #87 (in flight in parallel).
- PowerShell hook — that's #90.

## Refs

- Closes #88
- Sibling: #87 (named-pipe agent runtime, in parallel)
- Foundation: #86 (Stage 2.1 transport + peer-auth)
- Parent epic: #39 (Windows port)

## Test plan

- [x] `make build` clean on Linux
- [x] `make build-windows` produces `bin/jitenv.exe`
- [x] `go vet ./...` clean on linux, darwin, windows
- [x] `go test ./...` passes on Linux (full suite)
- [x] CI `test (windows)` job green — new tests must run on a real Windows runner
- [x] `golangci-lint run ./...` green (CI)