### PR TITLE
feat(agent): hidden-console daemon spawn + key-handle handoff on Windows (#87)

### DIFF
--- a/cmd/jitenv/main.go
+++ b/cmd/jitenv/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gv/jitenv/internal/cli"
 	"github.com/gv/jitenv/internal/shim"
@@ -16,7 +17,16 @@ func main() {
 	// ~/.cache/jitenv/shells/<pid>/bin/npm → jitenv). Dispatch to the
 	// shim entrypoint without going through cobra so cold start stays
 	// fast for these per-command wrappings.
-	if base := filepath.Base(os.Args[0]); base != "jitenv" && base != "" {
+	//
+	// On Windows the executable is "jitenv.exe", not "jitenv", so strip
+	// the .exe suffix before the comparison — otherwise every direct
+	// `jitenv.exe ...` invocation would dispatch to the shim and try to
+	// re-find itself on $PATH.
+	base := filepath.Base(os.Args[0])
+	if name := strings.TrimSuffix(base, ".exe"); name != "" {
+		base = name
+	}
+	if base != "jitenv" && base != "" {
 		shim.Main(base, os.Args[1:])
 		return
 	}

--- a/internal/agent/daemonize_key_windows.go
+++ b/internal/agent/daemonize_key_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// ReadKeyFromHandle reads exactly KeyLen bytes from the given Windows
+// handle. The handle is expected to be the read end of an anonymous pipe
+// that the parent SpawnDaemon inherited into this process via
+// SysProcAttr.AdditionalInheritedHandles. The caller is responsible for
+// zeroing the returned slice.
+//
+// Mirrors ReadKeyFromFd on Unix; lives in agent because the daemon side
+// is what cracks open the inherited handle.
+func ReadKeyFromHandle(h syscall.Handle) ([]byte, error) {
+	f := os.NewFile(uintptr(h), "key-pipe")
+	if f == nil {
+		return nil, fmt.Errorf("handle %x not available", uintptr(h))
+	}
+	defer f.Close()
+	buf := make([]byte, crypto.KeyLen)
+	if _, err := readFull(f, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/internal/agent/daemonize_windows.go
+++ b/internal/agent/daemonize_windows.go
@@ -3,17 +3,136 @@
 package agent
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
 	"time"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/gv/jitenv/internal/crypto"
 )
 
-// SpawnDaemon on Windows refuses to spawn. The Unix double-fork +
-// Setsid pattern doesn't translate cleanly to Windows; a real port
-// will likely use DETACHED_PROCESS / CREATE_NEW_PROCESS_GROUP plus a
-// named-pipe transport. Tracking in #39 stage 2+.
+// SpawnDaemon on Windows starts a detached, hidden-console child running
+// `jitenv __agent` and hands the master key over an anonymous pipe whose
+// read end is inherited by the child.
 //
-// Callers (cmd/jitenv/internal/cli/unlock.go) wrap this error with a
-// user-facing message before printing.
-func SpawnDaemon(_ Paths, _ string, _ time.Duration, _ []byte) error {
-	return errors.New("jitenv: daemonization on Windows not yet implemented; tracking in #39")
+// The Unix daemonize path uses os/exec ExtraFiles to seat the read end at
+// fd 3 and tells the child --key-fd=3. Windows has no fixed fd 3 — handle
+// inheritance instead works via SysProcAttr.AdditionalInheritedHandles
+// plus a per-spawn handle value the parent communicates to the child via
+// a command-line flag (--key-handle=<hex>). The handle is a kernel
+// handle, not a path or fd, so its hex form is meaningful only inside the
+// child process; the master key itself never appears on the command line,
+// in the environment, or on disk.
+//
+// Detach is achieved with CREATE_NO_WINDOW (no console window flash) +
+// DETACHED_PROCESS (no inherited console at all) + HideWindow. Stdio is
+// redirected to the agent log file and os.DevNull so the child has no
+// dependence on the parent's console handles.
+//
+// Shutdown: there is no explicit shutdown signal from parent to child.
+// `jitenv lock` issues an OpLock RPC over the pipe and the agent's Serve
+// loop cancels itself + closes the listener; the process then exits
+// naturally. Pipe-close-as-shutdown is sufficient and avoids the
+// extra IPC of a named Windows event.
+func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte) error {
+	if existing, _ := ReadPidFile(paths.PidFile); existing > 0 && PidAlive(existing) {
+		return fmt.Errorf("agent already running (pid %d)", existing)
+	}
+	if len(key) != int(crypto.KeyLen) {
+		return errors.New("daemonize: invalid key length")
+	}
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer pw.Close()
+
+	// On Windows, os.Pipe is built on CreatePipe with an inheritable
+	// SECURITY_ATTRIBUTES, so both ends start inheritable. The write end
+	// stays with the parent — make sure it isn't inherited by the child
+	// (otherwise the child's read side would never see EOF).
+	wHandle := windows.Handle(pw.Fd())
+	if err := windows.SetHandleInformation(wHandle, windows.HANDLE_FLAG_INHERIT, 0); err != nil {
+		pr.Close()
+		return fmt.Errorf("clear inherit on write end: %w", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		pr.Close()
+		return err
+	}
+	logF, err := os.OpenFile(paths.LogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		pr.Close()
+		return err
+	}
+	defer logF.Close()
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+	if err != nil {
+		pr.Close()
+		return err
+	}
+	defer devNull.Close()
+
+	rHandle := syscall.Handle(pr.Fd())
+	args := []string{
+		"__agent",
+		"--key-handle=" + strconv.FormatUint(uint64(rHandle), 16),
+		"--config=" + configFile,
+		"--idle=" + idle.String(),
+	}
+	cmd := exec.Command(exe, args...)
+	cmd.Stdin = devNull
+	cmd.Stdout = logF
+	cmd.Stderr = logF
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow: true,
+		// DETACHED_PROCESS detaches from the parent's console entirely;
+		// CREATE_NO_WINDOW prevents Windows from allocating a fresh
+		// console for the child when it is spawned from a GUI process
+		// (e.g. a TUI session running under conpty).
+		CreationFlags:              windows.DETACHED_PROCESS | windows.CREATE_NO_WINDOW,
+		AdditionalInheritedHandles: []syscall.Handle{rHandle},
+	}
+
+	if err := cmd.Start(); err != nil {
+		pr.Close()
+		return err
+	}
+	pr.Close() // child holds its own duplicated handle
+
+	if _, err := pw.Write(key); err != nil {
+		return fmt.Errorf("write key to child: %w", err)
+	}
+	pw.Close()
+
+	// Wait for the named pipe to become reachable, indicating the agent
+	// has bound its listener. Unlike Unix where the socket is a file on
+	// disk and os.Stat suffices, Windows pipes live in a separate
+	// namespace — the only reliable "is it up?" check is to dial it.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		conn, derr := dialAgent(ctx, paths.Socket, 200*time.Millisecond)
+		cancel()
+		if derr == nil {
+			conn.Close()
+			_ = cmd.Process.Release()
+			return nil
+		}
+		if cmd.ProcessState != nil {
+			return fmt.Errorf("agent exited early: %s", cmd.ProcessState)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = cmd.Process.Kill()
+	return errors.New("agent did not start within 3s; check the agent log under %LOCALAPPDATA%\\jitenv\\agent.log")
 }

--- a/internal/agent/daemonize_windows_test.go
+++ b/internal/agent/daemonize_windows_test.go
@@ -1,0 +1,185 @@
+//go:build windows
+
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// buildBinaryWindows compiles the jitenv binary into the test's tempdir
+// and returns its path. Mirrors the Unix daemonize_test helper but emits
+// a .exe under Windows.
+func buildBinaryWindows(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "jitenv.exe")
+	cmd := exec.Command("go", "build", "-o", out, "../../cmd/jitenv")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return out
+}
+
+// TestSpawnDaemonEndToEndWindows exercises the Stage 2.2 hidden-console
+// daemon spawn + key-handle handoff. It cannot call SpawnDaemon directly
+// because that re-execs os.Executable(); under `go test` that's the
+// compiled test binary, which doesn't speak the __agent subcommand. So
+// we build a real jitenv.exe and replicate SpawnDaemon's handshake
+// against it (anonymous pipe, --key-handle=<hex>,
+// AdditionalInheritedHandles, CREATE_NO_WINDOW | DETACHED_PROCESS,
+// hidden window).
+//
+// The "no visible console" property is hard to assert programmatically;
+// reachability + clean shutdown via OpLock are what we cover here. CI
+// running this on a headless windows-latest runner is the closest
+// practical proxy for "doesn't pop a console window."
+func TestSpawnDaemonEndToEndWindows(t *testing.T) {
+	if os.Getenv("CI_NO_BUILD") != "" {
+		t.Skip("skipping daemon e2e in CI_NO_BUILD")
+	}
+	bin := buildBinaryWindows(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-daemon-win")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer func() {
+		for i := range key {
+			key[i] = 0
+		}
+	}()
+
+	// Per-test runtime dir: LOCALAPPDATA points the per-user runtime
+	// base directory at our tempdir so the pidfile + logs don't pollute
+	// the real user profile. The pipe name is per-user (SID-derived) and
+	// is the same for parent + child because both inherit the test
+	// process's user token.
+	runtimeDir := t.TempDir()
+	t.Setenv("LOCALAPPDATA", runtimeDir)
+	paths, err := DefaultPaths()
+	if err != nil {
+		t.Fatalf("paths: %v", err)
+	}
+
+	// Replicate SpawnDaemon's wiring against the freshly built binary.
+	pr, pw2, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	// Clear inherit on the write end so the child only inherits the read end.
+	if err := windows.SetHandleInformation(windows.Handle(pw2.Fd()), windows.HANDLE_FLAG_INHERIT, 0); err != nil {
+		t.Fatalf("clear inherit on write end: %v", err)
+	}
+
+	logF, err := os.OpenFile(paths.LogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer logF.Close()
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devNull.Close()
+
+	rHandle := syscall.Handle(pr.Fd())
+	cmd := exec.Command(bin,
+		"__agent",
+		"--key-handle="+strconv.FormatUint(uint64(rHandle), 16),
+		"--config="+cfgPath,
+		"--idle=10s",
+	)
+	cmd.Env = append(os.Environ(), "LOCALAPPDATA="+runtimeDir)
+	cmd.Stdin = devNull
+	cmd.Stdout = logF
+	cmd.Stderr = logF
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:                 true,
+		CreationFlags:              windows.DETACHED_PROCESS | windows.CREATE_NO_WINDOW,
+		AdditionalInheritedHandles: []syscall.Handle{rHandle},
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = cmd.Process.Kill() }()
+
+	// Wait for the pipe to be reachable, then issue a Status request.
+	cli := NewClient(paths.Socket)
+	var st *Status
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		st, lastErr = cli.Status(context.Background())
+		if lastErr == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if lastErr != nil {
+		t.Fatalf("status: %v", lastErr)
+	}
+	if st == nil || st.PID == 0 {
+		t.Fatalf("expected pid in status, got %+v", st)
+	}
+
+	// Lock cleanly shuts the agent down via OpLock — pipe-close-as-shutdown.
+	if err := cli.Lock(context.Background()); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	// After Lock + Wait, the listener should be gone.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, derr := dialAgent(ctx, paths.Socket, 500*time.Millisecond)
+	if derr == nil {
+		conn.Close()
+		t.Fatalf("expected pipe %s to be gone after Lock", paths.Socket)
+	}
+}
+
+// TestPidAliveWindows is a regression guard against Stage 1's Unix-only
+// PidAlive returning false for every pid on Windows. SpawnDaemon's
+// "agent already running?" check depends on this returning true for the
+// current process.
+func TestPidAliveWindows(t *testing.T) {
+	if !PidAlive(os.Getpid()) {
+		t.Fatalf("PidAlive returned false for self (pid %d)", os.Getpid())
+	}
+	// Pid 0 is the System Idle Process — OpenProcess rejects it as an
+	// invalid parameter, so PidAlive must report false.
+	if PidAlive(0) {
+		t.Fatalf("PidAlive returned true for pid 0")
+	}
+	// A reasonably impossible pid on a healthy Windows box.
+	if PidAlive(0x7fffffff) {
+		t.Fatalf("PidAlive returned true for absurd pid")
+	}
+}

--- a/internal/agent/daemonize_windows_test.go
+++ b/internal/agent/daemonize_windows_test.go
@@ -130,6 +130,35 @@ func TestSpawnDaemonEndToEndWindows(t *testing.T) {
 	pw2.Close()
 	defer func() { _ = cmd.Process.Kill() }()
 
+	// Surface the agent's log on failure — useful when the child fails
+	// to bind its pipe (config error, missing inherited handle, etc.)
+	// and the test only sees "connect agent: file not found".
+	dumpLog := func() {
+		if !t.Failed() {
+			return
+		}
+		// The child may still hold a write handle to the log file when
+		// the test fails (we haven't Wait'd yet). On Windows that
+		// usually still allows reads thanks to default FILE_SHARE_READ;
+		// best-effort either way.
+		b, err := os.ReadFile(paths.LogFile)
+		if err != nil {
+			t.Logf("agent log unreadable: %v", err)
+		} else {
+			t.Logf("agent log (%s):\n%s", paths.LogFile, string(b))
+		}
+		// Also wait for the child to expose a process state so we can
+		// surface its exit code.
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			if cmd.ProcessState != nil {
+				t.Logf("agent exit: %s", cmd.ProcessState)
+			}
+		}
+	}
+	t.Cleanup(dumpLog)
+
 	// Wait for the pipe to be reachable, then issue a Status request.
 	cli := NewClient(paths.Socket)
 	var st *Status

--- a/internal/agent/pidfile.go
+++ b/internal/agent/pidfile.go
@@ -1,12 +1,10 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // WritePidFile writes pid to path with 0600 perms.
@@ -31,19 +29,12 @@ func ReadPidFile(path string) (int, error) {
 }
 
 // PidAlive reports whether the process with pid is currently running.
-func PidAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	if err := p.Signal(syscall.Signal(0)); err != nil {
-		return errors.Is(err, syscall.EPERM) // EPERM means it exists but we don't own it
-	}
-	return true
-}
+// The actual liveness check is platform-split: pidfile_unix.go uses
+// kill(pid, 0) semantics via os.Process.Signal; pidfile_windows.go uses
+// OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION). os.Process.Signal on
+// Windows does not implement signal 0, so the Unix code path always
+// reports "not alive" there — a Windows-specific implementation is
+// required for SpawnDaemon's "agent already running?" guard to function.
 
 // RemovePidFile removes the pidfile, ignoring not-exist.
 func RemovePidFile(path string) error {

--- a/internal/agent/pidfile_unix.go
+++ b/internal/agent/pidfile_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package agent
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// PidAlive reports whether the process with pid is currently running.
+//
+// Implementation: signal 0 is the standard portable Unix probe — kill(2)
+// with signal 0 performs the permission check but doesn't deliver a
+// signal. EPERM means the process exists but we don't own it, ESRCH or
+// ENOENT means it's gone.
+func PidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if err := p.Signal(syscall.Signal(0)); err != nil {
+		return errors.Is(err, syscall.EPERM) // EPERM means it exists but we don't own it
+	}
+	return true
+}

--- a/internal/agent/pidfile_windows.go
+++ b/internal/agent/pidfile_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// PidAlive reports whether the process with pid is currently running.
+//
+// Implementation: OpenProcess with PROCESS_QUERY_LIMITED_INFORMATION is
+// the minimum-privilege probe that works across integrity levels for
+// the same user — symmetric with the peer-cred check in peer_windows.go.
+// ERROR_INVALID_PARAMETER from OpenProcess means the pid does not refer
+// to any process (alive or recently-exited-but-still-in-the-pid-table);
+// any other error (e.g. ACCESS_DENIED) means a process with that pid
+// exists, we just can't touch it.
+func PidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		// ERROR_INVALID_PARAMETER => no such pid. Treat any other error
+		// (e.g. ACCESS_DENIED) as "alive but inaccessible", matching the
+		// Unix EPERM branch.
+		return !errors.Is(err, windows.ERROR_INVALID_PARAMETER)
+	}
+	_ = windows.CloseHandle(h)
+	return true
+}

--- a/internal/cli/agent_internal.go
+++ b/internal/cli/agent_internal.go
@@ -15,8 +15,14 @@ import (
 
 // __agent is the in-process daemon entrypoint. It is invoked by the
 // parent `unlock` process and is not a user-facing command.
+//
+// The flag the parent uses to hand over the master key is
+// platform-split: --key-fd=<int> on Unix (an inherited fd from
+// ExtraFiles) and --key-handle=<hex> on Windows (an inherited kernel
+// handle from SysProcAttr.AdditionalInheritedHandles). See
+// agent_key_unix.go / agent_key_windows.go.
 func newAgentInternalCmd() *cobra.Command {
-	var keyFd int
+	var keyFlag string
 	var idle time.Duration
 	var cfgArg string
 
@@ -26,7 +32,7 @@ func newAgentInternalCmd() *cobra.Command {
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
-			key, err := agent.ReadKeyFromFd(keyFd)
+			key, err := readKeyFromFlag(keyFlag)
 			if err != nil {
 				return fmt.Errorf("read key: %w", err)
 			}
@@ -69,7 +75,7 @@ func newAgentInternalCmd() *cobra.Command {
 			return err
 		},
 	}
-	c.Flags().IntVar(&keyFd, "key-fd", 3, "fd to read the master key from")
+	c.Flags().StringVar(&keyFlag, keyFlagName, keyFlagDefault, "platform-specific handle to read the master key from")
 	c.Flags().DurationVar(&idle, "idle", 30*time.Minute, "idle timeout")
 	c.Flags().StringVar(&cfgArg, "config", "", "config file path")
 	return c

--- a/internal/cli/agent_key_unix.go
+++ b/internal/cli/agent_key_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gv/jitenv/internal/agent"
+)
+
+// keyFlagName is the platform-appropriate flag name the parent
+// SpawnDaemon uses to tell the __agent subprocess where to find the
+// master key. On Unix it's a fixed fd (3) inherited via ExtraFiles; on
+// Windows it's the hex value of a kernel handle inherited via
+// AdditionalInheritedHandles.
+const keyFlagName = "key-fd"
+
+// keyFlagDefault is the value the flag is set to when the caller did not
+// pass one. The Unix path historically defaulted to fd 3 and the e2e
+// tests rely on that.
+const keyFlagDefault = "3"
+
+// readKeyFromFlag converts the raw --key-fd / --key-handle value into a
+// freshly allocated copy of the master key. Caller zeroes.
+func readKeyFromFlag(value string) ([]byte, error) {
+	fd, err := strconv.Atoi(value)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s=%q: %w", keyFlagName, value, err)
+	}
+	return agent.ReadKeyFromFd(fd)
+}

--- a/internal/cli/agent_key_windows.go
+++ b/internal/cli/agent_key_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"syscall"
+
+	"github.com/gv/jitenv/internal/agent"
+)
+
+// keyFlagName is the platform-appropriate flag name the parent
+// SpawnDaemon uses to tell the __agent subprocess where to find the
+// master key. On Windows there is no fixed fd 3 — the parent passes
+// the hex value of a kernel handle inherited via
+// SysProcAttr.AdditionalInheritedHandles.
+const keyFlagName = "key-handle"
+
+// keyFlagDefault is the value the flag is set to when the caller did
+// not pass one. Zero is invalid for an inherited handle, so it doubles
+// as a "you forgot the flag" sentinel.
+const keyFlagDefault = "0"
+
+// readKeyFromFlag converts the raw --key-handle hex value into a freshly
+// allocated copy of the master key. Caller zeroes.
+func readKeyFromFlag(value string) ([]byte, error) {
+	h, err := strconv.ParseUint(value, 16, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s=%q: %w", keyFlagName, value, err)
+	}
+	if h == 0 {
+		return nil, fmt.Errorf("%s required (not passed by parent)", keyFlagName)
+	}
+	return agent.ReadKeyFromHandle(syscall.Handle(h))
+}

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,11 +21,6 @@ func newUnlockCmd() *cobra.Command {
 		Short: "Unlock the agent (prompts passphrase, starts background agent)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if runtime.GOOS == "windows" {
-				return fmt.Errorf("jitenv: Windows is not yet supported. " +
-					"The codebase compiles for GOOS=windows but the agent/shim/run paths " +
-					"are stubs. Track progress in https://github.com/gv/jitenv/issues/39.")
-			}
 			cfgPath, err := config.Resolve(configPath)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

Replaces the `SpawnDaemon` Windows stub with a working implementation, completing Stage 2.2 of #39 native Windows support. Builds on the named-pipe transport landed in #86; unblocks stages 2.3-2.6.

## Approach

- **exec.Cmd + CREATE_NO_WINDOW + DETACHED_PROCESS + HideWindow**: child has no visible console and no inherited console from the parent.
- **Key handoff via inherited handle**: `os.Pipe()` gives us a parent-write / child-read pair. The read end is added to `SysProcAttr.AdditionalInheritedHandles`; the parent clears `HANDLE_FLAG_INHERIT` on the write end so the child can't see it (otherwise the child's read side never gets EOF). The handle's hex value is passed to the child as `--key-handle=<hex>` — the key bytes themselves never appear on the command line, in env, or on disk.
- **Platform-split flag wiring**: a new `internal/cli/agent_key_{unix,windows}.go` pair exposes `keyFlagName` (`key-fd` vs `key-handle`) and `readKeyFromFlag`. The `__agent` cobra command is unchanged in spirit — just one flag whose interpretation differs per OS. `agent.ReadKeyFromHandle` is the Windows counterpart to `ReadKeyFromFd`.
- **Pidfile platform split**: pre-existing `PidAlive` used `os.Process.Signal(0)` which on Windows always errors (Go's `os.Process.signal` only handles `Kill`). That made `SpawnDaemon`'s "agent already running?" guard a no-op on Windows. `pidfile_windows.go` now uses `windows.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, ...)`, treating `ERROR_INVALID_PARAMETER` as "no such pid" and any other error as "alive but inaccessible" (symmetric with the Unix `EPERM` branch).
- **Readiness check**: Unix's `os.Stat(paths.Socket)` doesn't apply to a pipe name — we `dialAgent` with a short timeout in a loop instead.
- **Shutdown = pipe-close**: `jitenv lock` sends `OpLock` over the pipe; the agent's Serve loop cancels itself, the listener closes, the process exits. No named Windows event needed.
- **Removed the `runtime.GOOS == "windows"` early-return guard** at the top of `unlock.go`.

## Test plan

- [x] `go build ./...` clean (Linux)
- [x] `make build-windows` produces `bin/jitenv.exe`
- [x] `go vet ./...` clean on both Linux and `GOOS=windows`
- [x] `go test ./...` full suite passes on Linux
- [x] `GOOS=windows GOARCH=amd64 go test -c -o /dev/null ./...` — all Windows tests compile
- [x] `test (windows)` CI job — covers the new `TestSpawnDaemonEndToEndWindows` (real `jitenv.exe`, hidden-console spawn, key-handle handoff, Status RPC, OpLock shutdown, pipe-gone assertion) + `TestPidAliveWindows`
- [x] `test (macos)` CI job — guards against breaking the Unix double-fork path

## Notes

- Out of scope (separate issues): `jitenv run` / `__shim` on Windows (#88), `chpwd` (#89), PowerShell hook (#90), goreleaser/installer (#91).
- The Unix daemonize path is untouched.

Closes #87.  
Depends on #86.  
Part of #39.