### PR TITLE
fix(shim): use PATHEXT lookup for .exe candidates on Windows (#97)

### DIFF
--- a/internal/shim/lookpath_unix_test.go
+++ b/internal/shim/lookpath_unix_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindExecutableInDirUnix(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "myprog")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	noexec := filepath.Join(dir, "noexec")
+	if err := os.WriteFile(noexec, []byte("not executable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := findExecutableInDir(dir, "myprog"); !ok || got != exe {
+		t.Errorf("findExecutableInDir(myprog) = (%q, %v); want (%q, true)", got, ok, exe)
+	}
+	if _, ok := findExecutableInDir(dir, "noexec"); ok {
+		t.Error("findExecutableInDir(noexec) returned ok; want false (no exec bit)")
+	}
+	if _, ok := findExecutableInDir(dir, "missing"); ok {
+		t.Error("findExecutableInDir(missing) returned ok; want false")
+	}
+	if _, ok := findExecutableInDir(dir, "."); ok {
+		t.Error("findExecutableInDir(\".\") returned ok; want false (is a dir)")
+	}
+}

--- a/internal/shim/lookpath_windows_test.go
+++ b/internal/shim/lookpath_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFindExecutableInDirWindows is the regression for issue #97.
+// Pre-fix, findExecutableInDir's predecessor used info.Mode()&0o111 != 0
+// to decide whether a candidate was runnable. Windows os.Stat doesn't
+// populate the Unix exec bits on a .exe file, so every wrapped command
+// was silently rejected and the shim could never resolve its target.
+//
+// The PATHEXT rule below mirrors os/exec.LookPath: bare-name lookups
+// try each %PATHEXT% extension in order, fully-qualified names are
+// taken at face value.
+func TestFindExecutableInDirWindows(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "myprog.exe")
+	if err := os.WriteFile(exe, []byte("MZ"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := filepath.Join(dir, "helper.cmd")
+	if err := os.WriteFile(cmd, []byte("@echo off\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+
+	// Bare name → tries PATHEXT entries; finds .exe before .cmd.
+	if got, ok := findExecutableInDir(dir, "myprog"); !ok || got != exe {
+		t.Errorf("findExecutableInDir(myprog) = (%q, %v); want (%q, true)", got, ok, exe)
+	}
+	// Bare name → falls through to .cmd when .exe doesn't exist.
+	if got, ok := findExecutableInDir(dir, "helper"); !ok || got != cmd {
+		t.Errorf("findExecutableInDir(helper) = (%q, %v); want (%q, true)", got, ok, cmd)
+	}
+	// Already-extended name with known ext → taken as-is.
+	if got, ok := findExecutableInDir(dir, "myprog.exe"); !ok || got != exe {
+		t.Errorf("findExecutableInDir(myprog.exe) = (%q, %v); want (%q, true)", got, ok, exe)
+	}
+	// Already-extended name pointing at a missing file → no fallback.
+	if _, ok := findExecutableInDir(dir, "myprog.bat"); ok {
+		t.Error("findExecutableInDir(myprog.bat) returned ok; want false (no fallback when ext is known)")
+	}
+	// Missing file with bare name.
+	if _, ok := findExecutableInDir(dir, "missing"); ok {
+		t.Error("findExecutableInDir(missing) returned ok; want false")
+	}
+}
+
+func TestFindExecutableInDirEmptyPathExt(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "myprog.exe")
+	if err := os.WriteFile(exe, []byte("MZ"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATHEXT", "")
+	if got, ok := findExecutableInDir(dir, "myprog"); !ok || got != exe {
+		t.Errorf("findExecutableInDir with empty PATHEXT = (%q, %v); want (%q, true)", got, ok, exe)
+	}
+}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -193,19 +193,9 @@ func lookPathExcluding(name, excludeDir string) (string, error) {
 		if abs == excludeAbs {
 			continue
 		}
-		candidate := filepath.Join(dir, name)
-		info, err := os.Stat(candidate)
-		if err != nil {
-			continue
+		if candidate, ok := findExecutableInDir(dir, name); ok {
+			return candidate, nil
 		}
-		if info.IsDir() {
-			continue
-		}
-		// Same executable check os/exec uses: any executable bit set.
-		if info.Mode()&0o111 == 0 {
-			continue
-		}
-		return candidate, nil
 	}
 	return "", fmt.Errorf("%s: not found on $PATH (excluding %s)", name, excludeDir)
 }

--- a/internal/shim/shim_unix.go
+++ b/internal/shim/shim_unix.go
@@ -5,8 +5,26 @@ package shim
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 )
+
+// findExecutableInDir returns the absolute path of a usable executable
+// named `name` in `dir`, or ok=false if none. Unix predicate: the file
+// exists, isn't a directory, and has at least one executable mode bit
+// set — same rule os/exec.LookPath uses.
+func findExecutableInDir(dir, name string) (string, bool) {
+	candidate := filepath.Join(dir, name)
+	info, err := os.Stat(candidate)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	if info.Mode()&0o111 == 0 {
+		return "", false
+	}
+	return candidate, true
+}
 
 // execReal replaces the shim's process image with the real command at
 // realPath. Using syscall.Exec keeps the secret-bearing env confined

--- a/internal/shim/shim_windows.go
+++ b/internal/shim/shim_windows.go
@@ -8,10 +8,59 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
+
+// defaultPathExt is the fallback %PATHEXT% set used when the env var
+// is empty — matches the Windows default and os/exec.LookPath.
+const defaultPathExt = ".COM;.EXE;.BAT;.CMD"
+
+// findExecutableInDir returns the absolute path of a usable executable
+// named `name` in `dir`, or ok=false if none. Windows doesn't surface
+// Unix mode bits via os.Stat, so the Unix `Mode()&0o111` test would
+// reject every .exe; instead we follow os/exec.LookPath's PATHEXT
+// rule: if `name` already ends with a known extension, look for that
+// exact file; otherwise try `name + ext` for each %PATHEXT% entry,
+// case-insensitively. First hit wins. See issue #97.
+func findExecutableInDir(dir, name string) (string, bool) {
+	pathext := os.Getenv("PATHEXT")
+	if pathext == "" {
+		pathext = defaultPathExt
+	}
+	exts := strings.Split(strings.ToLower(pathext), ";")
+
+	if hasKnownExt(name, exts) {
+		candidate := filepath.Join(dir, name)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, true
+		}
+		return "", false
+	}
+	for _, ext := range exts {
+		if ext == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name+ext)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func hasKnownExt(name string, exts []string) bool {
+	lower := strings.ToLower(name)
+	for _, ext := range exts {
+		if ext != "" && strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
 
 // execReal on Windows spawns realPath synchronously: stdio is inherited
 // so the wrapped program is indistinguishable from a direct invocation


### PR DESCRIPTION
## Problem

\`lookPathExcluding\`'s per-candidate predicate in \`internal/shim/shim.go\` was:

\`\`\`go
if info.Mode()&0o111 == 0 {
    continue
}
\`\`\`

Unix-only. Windows \`os.Stat\` doesn't surface execute mode bits on a \`.exe\`, so every wrapped command was rejected and the shim could never resolve its target. Surfaced during PR #95 (#88) Windows integration testing — was working around it by routing test calls through \`TestMain\` re-exec.

## Fix

Factor the per-directory candidate match into a new \`findExecutableInDir(dir, name)\` helper, platform-split:

- **Unix** (\`shim_unix.go\`): same mode-bit predicate as before.
- **Windows** (\`shim_windows.go\`): mirror \`os/exec.LookPath\` — if \`name\` already ends with a known \`%PATHEXT%\` extension, look for that exact file; otherwise try \`name+ext\` for each \`%PATHEXT%\` entry case-insensitively. First hit wins. Default \`PATHEXT\` is \`.COM;.EXE;.BAT;.CMD\` when the env var is empty.

\`lookPathExcluding\` is now ~3 lines shorter and reads as:

\`\`\`go
if candidate, ok := findExecutableInDir(dir, name); ok {
    return candidate, nil
}
\`\`\`

## Tests

- \`lookpath_unix_test.go\` — exec-bit set / unset / missing / dir cases.
- \`lookpath_windows_test.go\` — bare-name PATHEXT walk (.exe wins over .cmd), fallthrough to .cmd when .exe absent, already-extended name taken as-is, missing-with-known-ext does NOT fall through, missing-with-bare-name, empty-\`PATHEXT\` falls back to the default set.

## Verification

- \`go test ./... -count=1\` — full suite green on Linux.
- \`go vet ./...\` + \`GOOS=windows go vet ./...\` — clean.
- Windows CI job will verify the new \`lookpath_windows_test.go\` against a real Windows runner.

## Unblocks

#89 (Windows \`.ps1\` chpwd) and #90 (PowerShell hook) — those stages drive cwd_glob commands through the shim end-to-end and would have hit this bug the moment they ran.

Closes #97.