### PR TITLE
feat(windows): PowerShell 7 hook + passphrase prompt over CONIN$/CONOUT$

### DIFF
--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -39,6 +39,28 @@ func newHookCmd() *cobra.Command {
 			return nil
 		},
 	})
+	c.AddCommand(&cobra.Command{
+		Use:     "powershell",
+		Aliases: []string{"pwsh"},
+		Short:   "Print PowerShell 7+ integration (Windows)",
+		Long: `Print the PowerShell hook snippet. Source it with:
+    Invoke-Expression (& jitenv hook powershell | Out-String)
+
+The snippet wraps the prompt function to drive cwd_glob reconciliation
+on every prompt and prepends the per-shell wrap dir to $env:Path so
+.ps1 shims resolve via PATHEXT. Absolute-path command interception
+(the bash DEBUG trap equivalent) is intentionally not implemented on
+PowerShell — see issue #39. PowerShell 5.x and cmd.exe are unsupported.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := shell.Render("powershell")
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), out)
+			return nil
+		},
+	})
 	c.AddCommand(newHookInstallCmd())
 	c.AddCommand(newHookStatusCmd())
 	return c
@@ -53,7 +75,10 @@ func newHookInstallCmd() *cobra.Command {
 login chain (.bash_profile / .bash_login / .profile) doesn't already
 end up sourcing ~/.bashrc, a guarded source line is added so that
 login shells pick up the hook too. For zsh, the eval line is
-appended to ~/.zshrc (sourced for both interactive and login).
+appended to ~/.zshrc (sourced for both interactive and login). For
+PowerShell, the Invoke-Expression line is appended to
+$PROFILE.CurrentUserCurrentHost (typically Documents\PowerShell\
+Microsoft.PowerShell_profile.ps1 on Windows).
 Re-running this command is a safe no-op when nothing needs to change.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -62,7 +87,7 @@ Re-running this command is a safe no-op when nothing needs to change.`,
 				sh = shell.DetectShell()
 			}
 			if sh == "" {
-				return fmt.Errorf("could not detect shell from $SHELL; pass --shell bash|zsh")
+				return fmt.Errorf("could not detect shell from $SHELL; pass --shell bash|zsh|powershell")
 			}
 			rep, err := shell.InstallShell(sh)
 			if err != nil {
@@ -86,7 +111,7 @@ Re-running this command is a safe no-op when nothing needs to change.`,
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&shellFlag, "shell", "", "shell to install for (bash|zsh); auto-detect by default")
+	cmd.Flags().StringVar(&shellFlag, "shell", "", "shell to install for (bash|zsh|powershell); auto-detect by default")
 	return cmd
 }
 
@@ -102,7 +127,7 @@ func newHookStatusCmd() *cobra.Command {
 			}
 			out := cmd.OutOrStdout()
 			if st.Shell == "" {
-				fmt.Fprintln(out, "shell: unsupported (only bash and zsh)")
+				fmt.Fprintln(out, "shell: unsupported (only bash, zsh, and PowerShell 7+)")
 				return nil
 			}
 			fmt.Fprintf(out, "shell:     %s\n", st.Shell)

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHookPowerShellCommand asserts that `jitenv hook powershell`
+// prints the PowerShell snippet with the runtime + config paths
+// substituted in. We don't reproduce the full Render-test surface here
+// — Render is tested directly in internal/shell — but this catches a
+// wiring regression where the subcommand drops the snippet on the
+// floor.
+func TestHookPowerShellCommand(t *testing.T) {
+	cfgDir := filepath.Join(t.TempDir(), "cfg")
+	runtimeDir := filepath.Join(t.TempDir(), "rt")
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("JITENV_CONFIG", "")
+	t.Setenv("LOCALAPPDATA", filepath.Join(t.TempDir(), "la"))
+
+	for _, name := range []string{"powershell", "pwsh"} {
+		t.Run(name, func(t *testing.T) {
+			cmd := newHookCmd()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{name})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute hook %s: %v", name, err)
+			}
+			out := buf.String()
+			if len(out) == 0 {
+				t.Fatalf("hook %s produced empty output", name)
+			}
+			if strings.Contains(out, "{{") || strings.Contains(out, "}}") {
+				t.Errorf("hook %s output still has unfilled markers:\n%s", name, out)
+			}
+			if !strings.Contains(out, "__JITENV_WRAP_DIR") {
+				t.Errorf("hook %s missing wrap-dir construction:\n%s", name, out)
+			}
+			if !strings.Contains(out, "function global:prompt") {
+				t.Errorf("hook %s missing prompt override:\n%s", name, out)
+			}
+		})
+	}
+}

--- a/internal/crypto/passphrase.go
+++ b/internal/crypto/passphrase.go
@@ -3,24 +3,31 @@ package crypto
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"golang.org/x/term"
 )
 
-// PromptPassphrase reads a passphrase from /dev/tty without echo.
-// If confirm is true, the user is asked twice and an error is returned on mismatch.
+// PromptPassphrase reads a passphrase from the controlling terminal
+// without echo. The terminal is opened directly (rather than via
+// os.Stdin) so the prompt still works when stdin is redirected from a
+// pipe or file. The device differs per platform: /dev/tty on Unix,
+// CONIN$/CONOUT$ on Windows — see openTTY in passphrase_unix.go /
+// passphrase_windows.go. If confirm is true, the user is asked twice
+// and an error is returned on mismatch.
 func PromptPassphrase(prompt string, confirm bool) ([]byte, error) {
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	in, out, err := openTTY()
 	if err != nil {
 		return nil, fmt.Errorf("open tty: %w", err)
 	}
-	defer tty.Close()
+	defer in.Close()
+	if out != in {
+		defer out.Close()
+	}
 
 	read := func(label string) ([]byte, error) {
-		fmt.Fprint(tty, label)
-		pw, err := term.ReadPassword(int(tty.Fd()))
-		fmt.Fprintln(tty)
+		fmt.Fprint(out, label)
+		pw, err := term.ReadPassword(int(in.Fd()))
+		fmt.Fprintln(out)
 		return pw, err
 	}
 

--- a/internal/crypto/passphrase_unix.go
+++ b/internal/crypto/passphrase_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package crypto
+
+import "os"
+
+// openTTY returns a single read/write handle to /dev/tty. The same file
+// is used for both prompt output and password input; callers should not
+// double-close.
+func openTTY() (in, out *os.File, err error) {
+	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, f, nil
+}

--- a/internal/crypto/passphrase_windows.go
+++ b/internal/crypto/passphrase_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package crypto
+
+import "os"
+
+// openTTY returns the Windows console handles. Unlike Unix's /dev/tty,
+// the console has separate device names for input and output (CONIN$
+// and CONOUT$), so two distinct files are returned. golang.org/x/term's
+// ReadPassword takes the input handle and toggles the console mode to
+// disable echo, while the prompt label is written to the output handle.
+// Opening these files bypasses any redirection of os.Stdin / os.Stdout,
+// matching the behaviour of opening /dev/tty on Unix.
+func openTTY() (in, out *os.File, err error) {
+	in, err = os.OpenFile("CONIN$", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, err = os.OpenFile("CONOUT$", os.O_RDWR, 0)
+	if err != nil {
+		in.Close()
+		return nil, nil, err
+	}
+	return in, out, nil
+}

--- a/internal/shell/install.go
+++ b/internal/shell/install.go
@@ -6,12 +6,18 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
-// DetectShell returns "bash" / "zsh" based on $SHELL, or "" if the
-// current shell isn't supported.
+// DetectShell returns "bash" / "zsh" / "powershell", or "" if the
+// current shell isn't supported. On Windows $SHELL is normally unset,
+// so we assume PowerShell 7+ (the only Windows shell jitenv supports —
+// see issue #39 for the cmd.exe / PowerShell 5.x decision).
 func DetectShell() string {
+	if runtime.GOOS == "windows" {
+		return "powershell"
+	}
 	sh := os.Getenv("SHELL")
 	if sh == "" {
 		return ""
@@ -26,7 +32,12 @@ func DetectShell() string {
 }
 
 // RcPath returns the conventional rc file path for shell, or "" if we
-// don't know one.
+// don't know one. For "powershell", this is $PROFILE.CurrentUserCurrentHost
+// — typically Documents\PowerShell\Microsoft.PowerShell_profile.ps1 under
+// the user's home directory on Windows; on non-Windows platforms (a
+// user invoking `jitenv hook install --shell powershell` from a WSL or
+// macOS pwsh session, for example) it resolves to ~/.config/powershell/
+// Microsoft.PowerShell_profile.ps1.
 func RcPath(shell string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -37,6 +48,8 @@ func RcPath(shell string) string {
 		return filepath.Join(home, ".bashrc")
 	case "zsh":
 		return filepath.Join(home, ".zshrc")
+	case "powershell", "pwsh":
+		return pwshProfilePath(home)
 	}
 	return ""
 }
@@ -46,6 +59,14 @@ func RcPath(shell string) string {
 // <shell>` at startup, the hook content itself is always whatever the
 // installed binary prints — there is no separate version to upgrade.
 func HookLine(shell string) string {
+	switch shell {
+	case "powershell", "pwsh":
+		// pwsh doesn't have a shorthand equivalent to `eval "$(...)"`;
+		// piping the snippet to Invoke-Expression is the documented
+		// way to source it (Out-String preserves newlines so the
+		// here-doc-style snippet parses cleanly).
+		return `Invoke-Expression (& jitenv hook powershell | Out-String)`
+	}
 	return fmt.Sprintf(`eval "$(jitenv hook %s)"`, shell)
 }
 
@@ -118,11 +139,13 @@ func CurrentStatus() (Status, error) {
 		return Status{}, err
 	}
 	st := Status{Shell: sh, RcPath: rc, Line: line, Installed: installed}
-	if sh == "bash" {
+	switch sh {
+	case "bash":
 		st.LoginPath, st.LoginSources = inspectBashLogin()
-	} else {
-		// zsh sources ~/.zshrc for both interactive and login shells,
-		// so there is no separate login file to track.
+	default:
+		// zsh sources ~/.zshrc for both interactive and login shells;
+		// PowerShell sources $PROFILE for the current host. Neither
+		// has a separate login file to track.
 		st.LoginSources = true
 	}
 	return st, nil
@@ -143,6 +166,9 @@ type InstallReport struct {
 //     a guarded source line; if none exists, ~/.bash_profile is
 //     created with one).
 //   - zsh: append eval line to ~/.zshrc only.
+//   - powershell / pwsh: append the Invoke-Expression line to
+//     $PROFILE.CurrentUserCurrentHost — no analogue of the bash login
+//     chain because pwsh runs $PROFILE in every interactive session.
 func InstallShell(shellName string) (InstallReport, error) {
 	rc := RcPath(shellName)
 	if rc == "" {

--- a/internal/shell/install_test.go
+++ b/internal/shell/install_test.go
@@ -262,3 +262,60 @@ func TestDetectShell(t *testing.T) {
 		t.Fatalf("empty SHELL should return empty, got %q", got)
 	}
 }
+
+// TestHookLinePowerShell pins the PowerShell activation line. The
+// `Invoke-Expression (& jitenv hook powershell | Out-String)` form is
+// load-bearing — pwsh has no `eval "$(...)"` equivalent.
+func TestHookLinePowerShell(t *testing.T) {
+	want := `Invoke-Expression (& jitenv hook powershell | Out-String)`
+	if got := HookLine("powershell"); got != want {
+		t.Errorf("HookLine(powershell): got %q want %q", got, want)
+	}
+	if got := HookLine("pwsh"); got != want {
+		t.Errorf("HookLine(pwsh): got %q want %q", got, want)
+	}
+}
+
+// TestInstallShell_PowerShellTouchesProfileOnly mirrors the zsh test:
+// PowerShell has no analogue of the bash login chain (pwsh sources
+// $PROFILE for every interactive host), so only the rc file gets
+// modified and the LoginPath / LoginAdded fields stay empty.
+//
+// Runs on non-Windows; the rc-path fallback resolves to
+// ~/.config/powershell/Microsoft.PowerShell_profile.ps1 if pwsh isn't
+// on PATH, which is enough to exercise the InstallShell plumbing.
+func TestInstallShell_PowerShellTouchesProfileOnly(t *testing.T) {
+	withFakeHome(t)
+	// Prepend an empty dir to $PATH so queryPwshProfilePath misses
+	// and we hit the documented fallback. Otherwise the test would
+	// depend on whether the host machine has pwsh installed.
+	t.Setenv("PATH", t.TempDir())
+	rep, err := InstallShell("powershell")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if rep.RcPath == "" {
+		t.Fatalf("expected non-empty RcPath for powershell")
+	}
+	if !strings.HasSuffix(rep.RcPath, "Microsoft.PowerShell_profile.ps1") {
+		t.Errorf("expected pwsh profile path, got %q", rep.RcPath)
+	}
+	if !rep.RcAdded {
+		t.Errorf("expected RcAdded=true on first install")
+	}
+	if rep.LoginPath != "" || rep.LoginAdded {
+		t.Errorf("pwsh install should not touch a login file (got %+v)", rep)
+	}
+	// Idempotent: a second install should be a no-op.
+	rep2, err := InstallShell("powershell")
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if rep2.RcAdded {
+		t.Errorf("second install should report RcAdded=false")
+	}
+	body, _ := os.ReadFile(rep.RcPath)
+	if strings.Count(string(body), HookLine("powershell")) != 1 {
+		t.Errorf("hook line should appear exactly once: %q", body)
+	}
+}

--- a/internal/shell/install_windows_test.go
+++ b/internal/shell/install_windows_test.go
@@ -1,0 +1,125 @@
+//go:build windows
+
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDetectShellWindows pins the Windows branch of DetectShell. $SHELL
+// is normally unset on Windows; we return "powershell" unconditionally
+// (cmd.exe and PowerShell 5.x are unsupported — see #39).
+func TestDetectShellWindows(t *testing.T) {
+	t.Setenv("SHELL", "")
+	if got := DetectShell(); got != "powershell" {
+		t.Errorf("DetectShell on Windows with empty SHELL: got %q want %q", got, "powershell")
+	}
+	// Even if a bash-style $SHELL leaks in (e.g. inside a Git Bash
+	// terminal that happens to run the Windows build), we still
+	// return powershell — the runtime port only supports pwsh.
+	t.Setenv("SHELL", "/usr/bin/bash")
+	if got := DetectShell(); got != "powershell" {
+		t.Errorf("DetectShell on Windows with bash SHELL: got %q want %q", got, "powershell")
+	}
+}
+
+// TestRcPathPowerShellDefaultsToDocuments asserts the fallback path
+// when pwsh is not on PATH. The Windows default is
+// %USERPROFILE%\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+// (pwsh 7+, no "WindowsPowerShell" 5.x suffix).
+func TestRcPathPowerShellDefaultsToDocuments(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	// Point PATH at an empty dir so queryPwshProfilePath misses and we
+	// exercise the documented fallback.
+	t.Setenv("PATH", t.TempDir())
+
+	got := RcPath("powershell")
+	want := filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+	if got != want {
+		t.Errorf("RcPath(powershell) fallback: got %q want %q", got, want)
+	}
+	if got := RcPath("pwsh"); got != want {
+		t.Errorf("RcPath(pwsh) alias: got %q want %q", got, want)
+	}
+}
+
+// TestInstallShellPowerShellWindows exercises the end-to-end install
+// path against a tempdir-rooted $USERPROFILE. The hook line should land
+// in $PROFILE, the login-chain fields should stay zero, and a second
+// install should be a no-op.
+func TestInstallShellPowerShellWindows(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir()) // force fallback
+
+	rep, err := InstallShell("powershell")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	wantRc := filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+	if rep.RcPath != wantRc {
+		t.Errorf("RcPath: got %q want %q", rep.RcPath, wantRc)
+	}
+	if !rep.RcAdded {
+		t.Errorf("expected RcAdded=true on first install")
+	}
+	if rep.LoginPath != "" || rep.LoginAdded {
+		t.Errorf("pwsh install should not touch a login file: %+v", rep)
+	}
+	body, err := os.ReadFile(rep.RcPath)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	if !strings.Contains(string(body), HookLine("powershell")) {
+		t.Errorf("hook line missing from profile:\n%s", body)
+	}
+	// Idempotent.
+	rep2, err := InstallShell("powershell")
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if rep2.RcAdded {
+		t.Errorf("second install should be no-op")
+	}
+	body, _ = os.ReadFile(rep.RcPath)
+	if strings.Count(string(body), HookLine("powershell")) != 1 {
+		t.Errorf("hook line should appear exactly once: %q", body)
+	}
+}
+
+// TestCurrentStatusPowerShellWindows asserts the status command's view
+// of the install state. PowerShell has no login-chain split, so
+// LoginPath stays empty and LoginSources defaults to true.
+func TestCurrentStatusPowerShellWindows(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+
+	// Pre-install so Installed=true.
+	if _, err := InstallShell("powershell"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	st, err := CurrentStatus()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if st.Shell != "powershell" {
+		t.Errorf("Shell: got %q want %q", st.Shell, "powershell")
+	}
+	if !st.Installed {
+		t.Errorf("Installed: expected true after InstallShell")
+	}
+	if st.LoginPath != "" {
+		t.Errorf("LoginPath: expected empty for powershell, got %q", st.LoginPath)
+	}
+	if !st.LoginSources {
+		t.Errorf("LoginSources: expected true (no separate login file)")
+	}
+}

--- a/internal/shell/profile_unix.go
+++ b/internal/shell/profile_unix.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package shell
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// pwshProfilePath returns $PROFILE.CurrentUserCurrentHost for the
+// installed PowerShell 7 host on a Unix system. PowerShell on Linux /
+// macOS resolves $PROFILE under ~/.config/powershell/ (XDG-style)
+// rather than ~/Documents — so the Unix default differs from the
+// Windows default.
+//
+// We probe pwsh first if it's on PATH (cross-platform users may rely
+// on a non-default location), then fall back to the documented
+// default:
+//
+//	~/.config/powershell/Microsoft.PowerShell_profile.ps1
+//
+// This branch mostly exists so the package compiles for Linux/macOS
+// when a user invokes `jitenv hook install --shell powershell` from a
+// WSL or pwsh-on-mac session. The primary target is still Windows.
+func pwshProfilePath(home string) string {
+	if p := queryPwshProfilePath(); p != "" {
+		return p
+	}
+	return filepath.Join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1")
+}
+
+// queryPwshProfilePath shells out to `pwsh -NoProfile -Command
+// '$PROFILE.CurrentUserCurrentHost'` and returns the trimmed result,
+// or "" if pwsh isn't found / errored.
+func queryPwshProfilePath() string {
+	exe, err := exec.LookPath("pwsh")
+	if err != nil {
+		return ""
+	}
+	cmd := exec.Command(exe, "-NoProfile", "-NoLogo", "-Command", "$PROFILE.CurrentUserCurrentHost")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	p := strings.TrimSpace(string(out))
+	if p == "" {
+		return ""
+	}
+	return p
+}

--- a/internal/shell/profile_windows.go
+++ b/internal/shell/profile_windows.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package shell
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// pwshProfilePath returns $PROFILE.CurrentUserCurrentHost for the
+// installed PowerShell 7 host. We first try to ask pwsh itself (the
+// only authoritative source — users can move their Documents folder
+// via OneDrive redirection or a custom $env:PSModulePath setup), and
+// fall back to the documented default if pwsh isn't on PATH at
+// install time:
+//
+//	%USERPROFILE%\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+//
+// (Note: "PowerShell" with no version suffix, unlike legacy 5.x which
+// used "WindowsPowerShell". pwsh 7+ is the only supported host.)
+//
+// The pwsh probe is run with -NoProfile to keep it fast and avoid
+// recursion if the user already has the jitenv hook in their profile
+// (the snippet's __JITENV_LOADED guard would no-op anyway, but
+// -NoProfile is the right thing).
+func pwshProfilePath(home string) string {
+	if p := queryPwshProfilePath(); p != "" {
+		return p
+	}
+	return filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+}
+
+// queryPwshProfilePath shells out to `pwsh -NoProfile -Command
+// '$PROFILE.CurrentUserCurrentHost'` and returns the trimmed result,
+// or "" if pwsh isn't found / errored.
+func queryPwshProfilePath() string {
+	exe, err := exec.LookPath("pwsh")
+	if err != nil {
+		return ""
+	}
+	cmd := exec.Command(exe, "-NoProfile", "-NoLogo", "-Command", "$PROFILE.CurrentUserCurrentHost")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	p := strings.TrimSpace(string(out))
+	if p == "" {
+		return ""
+	}
+	return p
+}

--- a/internal/shell/render.go
+++ b/internal/shell/render.go
@@ -8,20 +8,32 @@ import (
 	"github.com/gv/jitenv/internal/config"
 )
 
-// Render returns the shell hook snippet for shell ("bash" or "zsh") with
-// the binary's view of $XDG_RUNTIME_DIR/jitenv and the config path baked
-// in. Replaces the {{RuntimeDir}} and {{ConfigPath}} markers in the
-// embedded template. Eliminates the shell-side duplication of
-// agent.ResolvePaths() / config.DefaultPath(). Calls the no-mkdir
-// variant on purpose — `jitenv hook bash` should be side-effect-free
-// (and the runtime dir often doesn't exist yet at hook-print time).
+// Render returns the shell hook snippet for shell ("bash", "zsh", or
+// "powershell"/"pwsh") with the binary's view of the runtime dir and
+// the config path baked in. Replaces the {{RuntimeDir}} and
+// {{ConfigPath}} markers in the embedded template. Eliminates the
+// shell-side duplication of agent.ResolvePaths() / config.DefaultPath().
+// Calls the no-mkdir variant on purpose — `jitenv hook <shell>` should
+// be side-effect-free (and the runtime dir often doesn't exist yet at
+// hook-print time).
+//
+// "pwsh" is accepted as an alias for "powershell"; the canonical name
+// is "powershell" (matches the subcommand in internal/cli/hook.go).
 func Render(shell string) (string, error) {
-	var tmpl string
+	var (
+		tmpl  string
+		quote func(string) string
+	)
 	switch shell {
 	case "bash":
 		tmpl = Bash
+		quote = shellQuote
 	case "zsh":
 		tmpl = Zsh
+		quote = shellQuote
+	case "powershell", "pwsh":
+		tmpl = PowerShell
+		quote = pwshQuote
 	default:
 		return "", fmt.Errorf("unsupported shell %q", shell)
 	}
@@ -33,8 +45,8 @@ func Render(shell string) (string, error) {
 	}
 
 	r := strings.NewReplacer(
-		"{{RuntimeDir}}", shellQuote(paths.Dir),
-		"{{ConfigPath}}", shellQuote(cfgPath),
+		"{{RuntimeDir}}", quote(paths.Dir),
+		"{{ConfigPath}}", quote(cfgPath),
 	)
 	return r.Replace(tmpl), nil
 }
@@ -46,4 +58,13 @@ func Render(shell string) (string, error) {
 func shellQuote(s string) string {
 	// Single quotes can't contain a literal single quote; close + escape + reopen.
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// pwshQuote single-quotes a path for inclusion in a PowerShell literal
+// string. PowerShell single-quoted strings are literal (no
+// interpolation, no backslash escapes) — a single quote inside is
+// encoded by doubling it (`don”t`). Backslashes pass through as-is,
+// so Windows paths like C:\Users\... round-trip unmodified.
+func pwshQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }

--- a/internal/shell/render_test.go
+++ b/internal/shell/render_test.go
@@ -66,3 +66,68 @@ func TestRenderUnknownShellErrors(t *testing.T) {
 		t.Error("expected error for unsupported shell")
 	}
 }
+
+// TestRenderPowerShellBakesPaths is the pwsh-quoting counterpart to
+// TestRenderBakesPaths: pwsh uses ” to escape an embedded single quote
+// (vs bash's '\”) and otherwise round-trips a path literally. The
+// rendered snippet must wire up the wrap-dir + prompt-override plumbing.
+func TestRenderPowerShellBakesPaths(t *testing.T) {
+	cfgDir := filepath.Join(t.TempDir(), "cfg")
+	runtimeDir := filepath.Join(t.TempDir(), "rt")
+
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("JITENV_CONFIG", "")
+
+	wantRuntime := filepath.Join(runtimeDir, "jitenv")
+	wantCfg := filepath.Join(cfgDir, "jitenv", "config.toml")
+
+	for _, sh := range []string{"powershell", "pwsh"} {
+		t.Run(sh, func(t *testing.T) {
+			out, err := Render(sh)
+			if err != nil {
+				t.Fatalf("Render(%q): %v", sh, err)
+			}
+			if strings.Contains(out, "{{") || strings.Contains(out, "}}") {
+				t.Errorf("output still contains unfilled markers:\n%s", out)
+			}
+			if !strings.Contains(out, "__JITENV_RUNTIME_DIR = '"+wantRuntime+"'") {
+				t.Errorf("expected pwsh-quoted runtime dir %q in output;\n%s", wantRuntime, out)
+			}
+			if !strings.Contains(out, "__JITENV_CFG_PATH    = '"+wantCfg+"'") {
+				t.Errorf("expected pwsh-quoted config path %q in output;\n%s", wantCfg, out)
+			}
+			if !strings.Contains(out, "__JITENV_WRAP_DIR") {
+				t.Errorf("expected wrap-dir construction in pwsh snippet;\n%s", out)
+			}
+			if !strings.Contains(out, "$env:Path") {
+				t.Errorf("expected $env:Path prepend in pwsh snippet;\n%s", out)
+			}
+			if !strings.Contains(out, "function global:prompt") {
+				t.Errorf("expected global:prompt override in pwsh snippet;\n%s", out)
+			}
+			if !strings.Contains(out, "jitenv __chpwd") {
+				t.Errorf("expected __chpwd invocation in pwsh snippet;\n%s", out)
+			}
+		})
+	}
+}
+
+// TestPwshQuoteEscapesSingleQuote verifies the PowerShell single-quote
+// doubling escape ('don”t') without relying on the rendered snippet —
+// pwsh literal-string semantics differ subtly from bash, so this is
+// worth its own assertion.
+func TestPwshQuoteEscapesSingleQuote(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`C:\Users\Alice\AppData\Local\jitenv`, `'C:\Users\Alice\AppData\Local\jitenv'`},
+		{"/run/it's/jitenv", `'/run/it''s/jitenv'`},
+		{"", "''"},
+	}
+	for _, c := range cases {
+		if got := pwshQuote(c.in); got != c.want {
+			t.Errorf("pwshQuote(%q): got %q want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/shell/snippets.go
+++ b/internal/shell/snippets.go
@@ -7,3 +7,6 @@ var Bash string
 
 //go:embed snippets/zsh.sh
 var Zsh string
+
+//go:embed snippets/powershell.ps1
+var PowerShell string

--- a/internal/shell/snippets/powershell.ps1
+++ b/internal/shell/snippets/powershell.ps1
@@ -1,0 +1,100 @@
+# jitenv PowerShell hook -- source via:
+#   Invoke-Expression (& jitenv hook powershell | Out-String)
+#
+# Requires PowerShell 7+. Windows Server PowerShell 5.x is intentionally
+# unsupported (see issue #39 design call). Drives the cwd_glob wrapper
+# scheme only:
+#   - Prepends the per-shell wrap dir to $env:Path so PATHEXT picks up
+#     the .ps1 wrappers that `jitenv __chpwd` populates.
+#   - Wraps the user's `prompt` function so every new prompt fires
+#     `jitenv __chpwd` to reconcile the wrap dir against the mapping
+#     index. The cost is one fork per prompt; chpwd short-circuits in
+#     ~50us when nothing changed.
+#
+# v1 does NOT intercept absolute-path commands. PowerShell has no DEBUG
+# trap; a PSReadLine AcceptLine handler was rejected in #39 as too
+# invasive. Users on Windows route through the cwd_glob shims.
+#
+# The runtime-dir + config-path values below are baked in by
+# `jitenv hook powershell` at print time. See internal/shell/render.go.
+
+if ($global:__JITENV_LOADED) { return }
+$global:__JITENV_LOADED = $true
+
+$global:__JITENV_RUNTIME_DIR = {{RuntimeDir}}
+$global:__JITENV_CFG_PATH    = {{ConfigPath}}
+# Recorded so the shim can tell "this shell typed the command" from
+# "an unmapped descendant spawned the wrapped binary"; only the former
+# should pull in mapped env vars (issue #52).
+$global:__JITENV_SHELL_PID   = $PID
+$global:__JITENV_WRAP_DIR    = Join-Path $__JITENV_RUNTIME_DIR (Join-Path 'shells' (Join-Path "$PID" 'bin'))
+$global:__JITENV_LAST_PWD    = ''
+$env:__JITENV_SHELL_PID      = "$PID"
+$env:__JITENV_WRAP_DIR       = $__JITENV_WRAP_DIR
+
+# Create the wrap dir up-front so the PATH prepend has a real target
+# even before the first prompt fires. New-Item -Force is idempotent.
+New-Item -ItemType Directory -Force -Path $__JITENV_WRAP_DIR | Out-Null
+
+# Prepend, once per shell. PATHEXT must include .PS1 for the wrappers
+# to resolve when the user types `npm` (default on pwsh 7).
+$__jitenv_pathSeparator = [System.IO.Path]::PathSeparator
+$__jitenv_existing = $env:Path -split [regex]::Escape($__jitenv_pathSeparator)
+if (-not ($__jitenv_existing -contains $__JITENV_WRAP_DIR)) {
+    $env:Path = $__JITENV_WRAP_DIR + $__jitenv_pathSeparator + $env:Path
+}
+Remove-Variable __jitenv_pathSeparator, __jitenv_existing -ErrorAction SilentlyContinue
+
+# Tiny per-shell $JITENV_CONFIG override so users can re-point one
+# shell at a different config without re-sourcing the hook. The
+# baked-in default (see __JITENV_CFG_PATH above) is what `jitenv`
+# itself resolves; this function only exists so callers can query the
+# effective config path from inside the shell.
+function global:__jitenv_cfg_path {
+    if ($env:JITENV_CONFIG) {
+        return $env:JITENV_CONFIG
+    }
+    return $__JITENV_CFG_PATH
+}
+
+# chpwd: pwsh has no native chpwd event, so we drive `jitenv __chpwd`
+# from the prompt function (the only hook that runs once per
+# interactive submission). The Go side compares pwd and the config-file
+# mtime against per-shell sidecar state and short-circuits when nothing
+# changed. Keeping the state in Go means re-sourcing the hook doesn't
+# cause a spurious reconcile.
+$global:__JITENV_ORIG_PROMPT = $function:prompt
+
+function global:__jitenv_chpwd {
+    $cur = (Get-Location).Path
+    # No 2>$null on purpose: the chpwd subcommand is silent in normal
+    # operation (it only writes to stderr when JITENV_HOOK_DEBUG is
+    # set). Swallowing stderr here would hide debug diagnostics and a
+    # "jitenv: command not found" if the binary ever falls off PATH
+    # mid-session. Errors are still trapped so the prompt never breaks.
+    try {
+        & jitenv __chpwd "$PID" $__JITENV_LAST_PWD $cur | Out-Null
+    } catch {
+        if ($env:JITENV_HOOK_DEBUG) {
+            Write-Error $_
+        }
+    }
+    $global:__JITENV_LAST_PWD = $cur
+}
+
+function global:prompt {
+    __jitenv_chpwd
+    if ($__JITENV_ORIG_PROMPT) {
+        & $__JITENV_ORIG_PROMPT
+    } else {
+        "PS $((Get-Location).Path)> "
+    }
+}
+
+# Run once at hook-load so the wrap dir is populated before the first
+# command in this shell (matches bash/zsh behaviour).
+__jitenv_chpwd
+
+# The agent-down "Press Enter to skip, Ctrl+C to abort" countdown is
+# implemented in Go (internal/agentwarn/agentwarn.go) and rendered by
+# the cwd_glob shim. Nothing here needs to paint it.


### PR DESCRIPTION
Bundles PR #100 (PowerShell 7 hook) and the passphrase-prompt fix into a single Windows-usable PR. PR #100 alone shipped the hook but `jitenv config` still aborted with `open /dev/tty` on Windows; this PR resolves both so the user can run end-to-end on Windows after one merge.

## Summary
- **PowerShell 7 hook** (commit 40ac2cf, originally #100):
  - New embedded `internal/shell/snippets/powershell.ps1` and `shell.Render` dispatch for `powershell` / `pwsh`.
  - `shell.DetectShell` returns `"powershell"` on Windows; `RcPath("powershell")` probes `$PROFILE.CurrentUserCurrentHost` via `pwsh -NoProfile` (with `Documents\PowerShell\Microsoft.PowerShell_profile.ps1` fallback). Split into `profile_windows.go` / `profile_unix.go`.
  - `InstallShell("powershell")` reuses the generic Install path; new `jitenv hook powershell` cobra subcommand (alias `pwsh`).
- **Passphrase prompt over Windows console** (commit b89d600):
  - `PromptPassphrase` unconditionally opened `/dev/tty`, so on Windows `jitenv config` / `unlock` / `sources` aborted with `open tty: open /dev/tty: The system cannot find the path specified.`
  - Split into `passphrase_unix.go` (single RW handle on `/dev/tty`) and `passphrase_windows.go` (separate `CONIN$` / `CONOUT$` handles, matching `golang.org/x/term.ReadPassword`'s console-input-handle expectation).

Supersedes #100 — closing that PR; this branch contains its commit verbatim.

## Test plan
- [x] `go build ./...` (linux)
- [x] `GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/jitenv`
- [x] `go test ./...` (linux, all green)
- [x] CI: `test (windows)`, `test (macos)`, `build / test / lint`, `docker-compose harness` (from #100 run; will re-run on this PR)
- [x] Manual on Windows:
  - `jitenv.exe config` accepts passphrase without echo, creates config.
  - `jitenv.exe hook status` reports `shell: powershell`, an `rc file:` under `Documents\PowerShell\`, and `installed: no` before install / `yes` after.
  - `jitenv.exe hook install` writes the `Invoke-Expression (& jitenv hook powershell | Out-String)` line into `$PROFILE`.