### PR TITLE
feat(windows): release gate — %APPDATA% config, GoReleaser zip targets, docs (#91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,16 +107,15 @@ jobs:
         run: go test -race -covermode=atomic ./internal/agent/... ./internal/agentwarn/... ./internal/cli/... ./internal/config/... ./internal/crypto/... ./internal/run/... ./internal/runnotice/... ./internal/sources/... ./internal/tui/... ./internal/version/...
 
   test-windows:
-    # Stage 1 of native Windows support (#39): exercise the
-    # cross-platform compile of the agent + shim + run paths against a
-    # real Windows toolchain. Most platform-specific stubs return
-    # "not yet implemented" errors at runtime, so the e2e/agent test
-    # suites are constrained out via `//go:build !windows` — what runs
-    # here is the config/crypto/version surface plus anything else
-    # that's already platform-clean. The job is mandatory so a
-    # regression in the Windows build (a new Unix-only syscall slipped
-    # into a shared file) fails CI immediately rather than being
-    # discovered when Stage 2 starts.
+    # Native Windows support (#39, stages 2.1-2.6): named-pipe
+    # transport, token-SID peer auth, hidden-console daemon spawn,
+    # spawn-and-wait run/shim, .ps1 wrapper shims, PowerShell 7 hook,
+    # %APPDATA% config path, and .zip release artifacts. Each platform-
+    # specific package has companion *_windows_test.go files that
+    # exercise the real Windows code paths (winio pipes, %PATHEXT%
+    # lookup, doublestar separator normalisation, etc.). The shell
+    # hook end-to-end suites stay !windows-tagged because they shell
+    # out to bash/zsh; PowerShell e2e is tracked separately.
     name: test (windows)
     if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'release-please--') }}
     runs-on: windows-latest
@@ -144,10 +143,8 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        # All tests that need a Unix socket, fork+exec, symlinks, or
-        # bash/zsh are gated behind `//go:build !windows` so they
-        # compile-skip here. What remains is the cross-platform surface
-        # (config, crypto, version, sources, tui, runnotice, agentwarn,
-        # the agent's pure-Go bits) — green on Windows means the
-        # compile-time scaffolding from #39 stage 1 is still intact.
+        # The bash/zsh hook end-to-end tests (internal/shell/hook_*) and
+        # the bash-script-spawning run/shim e2e tests stay `!windows`-
+        # tagged. Everything else has Windows-aware logic (or a
+        # companion *_windows_test.go) and runs here.
         run: go test -covermode=atomic ./...

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
@@ -28,7 +29,13 @@ builds:
 
 archives:
   - id: jitenv
+    # Unix archives are tar.gz; Windows archives are .zip so users can
+    # extract with the built-in Explorer/PowerShell unzip without
+    # installing tar. format_overrides switches per-GOOS.
     formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
     name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
@@ -37,6 +44,8 @@ archives:
         dst: snippets/bash.sh
       - src: internal/shell/snippets/zsh.sh
         dst: snippets/zsh.sh
+      - src: internal/shell/snippets/powershell.ps1
+        dst: snippets/powershell.ps1
 
 nfpms:
   - id: jitenv
@@ -94,10 +103,12 @@ release:
   header: |
     ## jitenv {{ .Tag }}
 
-    Linux + macOS artifacts for `amd64` and `arm64`. macOS binaries are
-    **not** Apple-notarized — first run requires `xattr -d
-    com.apple.quarantine ./jitenv` or a right-click → Open. See #13
-    for the notarization tracking issue. Verify integrity:
+    Linux, macOS, and Windows artifacts for `amd64` and `arm64`.
+    macOS binaries are **not** Apple-notarized — first run requires
+    `xattr -d com.apple.quarantine ./jitenv` or a right-click → Open.
+    Windows binaries are **not** Authenticode-signed — SmartScreen
+    may prompt on first run. See #13 (macOS notarization) and #39
+    (Windows signing) for the tracking issues. Verify integrity:
 
     ```sh
     sha256sum -c SHA256SUMS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,12 @@ go test ./internal/agent
 go test ./internal/run -run TestRunInjectsEnvAndExecs -v
 ```
 
-Go 1.22+ (go.mod declares 1.25.6). Linux and macOS. Peer-cred check is platform-split (`SO_PEERCRED` on Linux in `peer_linux.go`, `LOCAL_PEERCRED` on Darwin in `peer_darwin.go`); runtime dir is `$XDG_RUNTIME_DIR/jitenv/` on Linux and `os.TempDir()/jitenv-<uid>/` (typically `/var/folders/.../T/jitenv-<uid>`) on macOS. The `Setsid` double-fork is portable.
+Go 1.22+ (go.mod declares 1.25.6). Linux, macOS, and Windows. Peer-cred check is platform-split:
+- Linux: `SO_PEERCRED` (`peer_linux.go`), runtime dir `$XDG_RUNTIME_DIR/jitenv/`, config dir `$XDG_CONFIG_HOME/jitenv/` (or `~/.config/jitenv/`).
+- macOS: `LOCAL_PEERCRED` (`peer_darwin.go`), runtime dir `os.TempDir()/jitenv-<uid>/` (typically `/var/folders/.../T/jitenv-<uid>`), config dir XDG-style.
+- Windows: token-SID peer check (`peer_windows.go`), pipe at `\\.\pipe\jitenv-<sid>` (`socket_windows.go`), runtime dir `%LOCALAPPDATA%\jitenv\`, config dir `%APPDATA%\jitenv\` (see `internal/config/path_windows.go`).
 
-The codebase compiles for `GOOS=windows` (`peer_windows.go`, `socket_windows.go`, `daemonize_windows.go`, `paths_windows.go`, `run_windows.go`, `shim_windows.go` keep the build green) but the agent/shim/run paths return "not yet implemented" errors at runtime — see [#39](https://github.com/gv/jitenv/issues/39). Real Windows support (named pipes, token-based peer check, PowerShell hook) is Stage 2+.
+The `Setsid` double-fork is the Unix daemon-spawn primitive; on Windows the equivalent uses `CREATE_NO_WINDOW | DETACHED_PROCESS` plus an anonymous-pipe master-key handoff (`daemonize_windows.go`). The `jitenv run` and shim exec paths use `syscall.Exec` on Unix and spawn-and-wait + `os.Exit(child)` on Windows (no exec-replace primitive there). PowerShell 7+ is the supported Windows shell — see `internal/shell/snippets/powershell.ps1` and `cwd_glob` wrapper `.ps1` files for the activation model.
 
 The e2e tests under `internal/run` and `internal/shell` shell out to `go build` to produce a real binary against a temp config; they're slow but exercise the unlock → daemonize → hook → run loop end-to-end.
 
@@ -76,6 +79,6 @@ Bubble Tea with a screen-stack `rootModel`. Each screen implements `Init / Updat
 
 - **Master key handling.** The key is `defer zeroBytes(...)`'d everywhere it lives outside the agent. Don't print it, don't pass it as a CLI flag (it's an inherited fd in `SpawnDaemon`). New code that touches the key should follow the same zero-on-defer pattern.
 - **Cobra layout.** Commands are constructed by `new<Name>Cmd()` functions and aggregated in `internal/cli/subcommands.go`. To add a top-level command, append it there. The hidden `__agent` command is the daemon entrypoint — it is not a user-facing command.
-- **Config path resolution.** `JITENV_CONFIG` > `$XDG_CONFIG_HOME/jitenv/config.toml` > `~/.config/jitenv/config.toml`. Always go through `config.Resolve` rather than reconstructing.
-- **Agent paths.** `$XDG_RUNTIME_DIR/jitenv/{agent.sock,agent.pid,agent.log}`, falling back to `/tmp/jitenv-<uid>/`. Use `agent.DefaultPaths()`.
+- **Config path resolution.** Unix: `JITENV_CONFIG` > `$XDG_CONFIG_HOME/jitenv/config.toml` > `~/.config/jitenv/config.toml`. Windows: `JITENV_CONFIG` > `%APPDATA%\jitenv\config.toml` > `%USERPROFILE%\AppData\Roaming\jitenv\config.toml`. Always go through `config.Resolve` rather than reconstructing.
+- **Agent paths.** Unix: `$XDG_RUNTIME_DIR/jitenv/{agent.sock,agent.pid,agent.log}`, falling back to `/tmp/jitenv-<uid>/`. Windows: `%LOCALAPPDATA%\jitenv\{agent.pid,agent.log}` with the socket field overloaded to the pipe name `\\.\pipe\jitenv-<sid>`. Use `agent.DefaultPaths()`.
 - **No remote source UI.** AWS Secrets Manager is compiled in and works at runtime, but the TUI's "Remote Sources" page is currently hidden. Existing `[sources.*]` entries in `config.toml` keep working.

--- a/README.md
+++ b/README.md
@@ -104,23 +104,29 @@ jitenv is-mapped <file>    Exit 0 if file is mapped (used by shell hook)
 jitenv sources list        Sources defined in your config
 jitenv sources types       Source types compiled in
 jitenv sources test <n>    Run Validate() against a configured source
-jitenv hook bash|zsh       Print shell hook for eval
-jitenv hook install        Append the activation line to your rc file
-jitenv hook status         Show whether the hook is wired up
+jitenv hook bash|zsh|powershell  Print shell hook for eval
+jitenv hook install              Append the activation line to your rc file
+jitenv hook status               Show whether the hook is wired up
 ```
 
 ## Limitations
 
-- Linux + macOS only. Linux uses `SO_PEERCRED` + `XDG_RUNTIME_DIR`;
-  macOS uses `LOCAL_PEERCRED` + `$TMPDIR`. The agent's `Setsid`
-  double-fork is portable to both. Windows is not yet supported —
-  the codebase compiles for `GOOS=windows` but the agent, shim, and
-  `jitenv run` paths return "not yet implemented" at runtime.
-  Tracking in [#39](https://github.com/gv/jitenv/issues/39).
+- Supported platforms: Linux, macOS, and Windows (PowerShell 7+).
+  Linux uses `SO_PEERCRED` + `XDG_RUNTIME_DIR`; macOS uses
+  `LOCAL_PEERCRED` + `$TMPDIR`; Windows uses named pipes with token-SID
+  peer auth and a `%LOCALAPPDATA%\jitenv` runtime dir. The agent's
+  `Setsid` double-fork on Unix has a Windows analogue using
+  `CREATE_NO_WINDOW | DETACHED_PROCESS`.
+- On Windows the path/glob shell hook (`extdebug` + `DEBUG` / `preexec`)
+  is replaced by `cwd_glob` wrapper-shim `.ps1` files invoked via the
+  PowerShell prompt override — see `jitenv hook powershell`. The
+  bash/zsh hook with absolute-path interception is Unix-only.
 - macOS release binaries are not Apple-notarized; first run requires
   `xattr -d com.apple.quarantine ./jitenv` or right-click → Open.
-- The shell hook only intercepts commands whose first token is an
-  absolute or `./`-relative path — not bare PATH lookups.
+  Windows release binaries are not Authenticode-signed; SmartScreen
+  may warn on first run.
+- The bash/zsh shell hook only intercepts commands whose first token
+  is an absolute or `./`-relative path — not bare PATH lookups.
 - Single agent per user; multiple terminals share one unlocked instance.
 - TUI requires a TTY; for scripted setup use `jitenv config init` then
   re-run interactively.

--- a/e2e/Dockerfile.powershell
+++ b/e2e/Dockerfile.powershell
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+#
+# PowerShell 7 jitenv test image. Lets the harness exercise the
+# `jitenv hook powershell` snippet, the prompt-override-driven chpwd
+# reconcile, and the cwd_glob wrapper -> shim -> agent flow against a
+# real pwsh process. The image is Linux (Ubuntu 22.04, the base of
+# mcr.microsoft.com/powershell:latest); jitenv itself runs as a Linux
+# ELF binary, so the *Linux* shim path executes — not the Windows
+# .ps1-wrapper / spawn-and-wait path. That's a deliberate trade-off:
+# the same surface that Windows CI covers in unit tests isn't
+# reachable from a Linux container, but the cross-platform code paths
+# (hook snippet, chpwd lookup, agent protocol, env injection) ARE
+# exercised here, and on every PR rather than only in a Windows VM.
+#
+# Run as user `jitenv` (uid 1000). XDG_RUNTIME_DIR is left unset so
+# agent.DefaultPaths() falls back to /tmp/jitenv-<uid>. /home/jitenv/bin
+# is on $PATH so wrapped command scripts written by the seed helper
+# are resolvable by the shim's lookPathExcluding.
+
+FROM golang:1.25-bookworm AS helper-build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-seed ./e2e/seed \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-unlock ./e2e/cmd/unlock \
+ && CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/jitenv-e2e-reload ./e2e/cmd/reload
+
+FROM mcr.microsoft.com/powershell:latest AS runtime
+ARG TARGETARCH=amd64
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        bash ca-certificates curl tini coreutils procps && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd --create-home --shell /bin/bash --uid 1000 jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/.config/jitenv && \
+    install -d -m 0700 -o jitenv -g jitenv /home/jitenv/scripts && \
+    install -d -m 0755 -o jitenv -g jitenv /home/jitenv/bin && \
+    install -d -m 0755 /opt/pkg
+
+COPY dist/jitenv_*_linux_${TARGETARCH}.deb /opt/pkg/
+RUN ln -s $(ls /opt/pkg/jitenv_*_linux_${TARGETARCH}.deb | head -n1) /opt/pkg/jitenv.deb && \
+    dpkg -i /opt/pkg/jitenv.deb
+
+COPY --from=helper-build /out/jitenv-e2e-seed /usr/local/bin/jitenv-e2e-seed
+COPY --from=helper-build /out/jitenv-e2e-unlock /usr/local/bin/jitenv-e2e-unlock
+COPY --from=helper-build /out/jitenv-e2e-reload /usr/local/bin/jitenv-e2e-reload
+
+# Put /home/jitenv/bin on PATH for both bash and pwsh sessions so the
+# shim's lookPathExcluding can find the real command behind the wrapper.
+ENV PATH=/home/jitenv/bin:/usr/local/bin:/usr/bin:/bin
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+USER jitenv
+WORKDIR /home/jitenv
+HEALTHCHECK --interval=5s --timeout=2s --start-period=2s --retries=3 \
+    CMD jitenv version || exit 1
+CMD ["sleep", "infinity"]

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -73,6 +73,31 @@ services:
       VAULT_ADDR: http://vault:8200
       VAULT_TOKEN: dev-root
 
+  powershell:
+    # PowerShell 7 on Ubuntu 22.04 — exercises `jitenv hook powershell`
+    # and the cwd_glob wrapper flow under a real pwsh process. The
+    # Linux jitenv binary runs the *Unix* shim path here, not the
+    # Windows .ps1-wrapper / spawn-and-wait path; the Windows-only
+    # surface stays covered by Windows CI unit tests.
+    build:
+      context: ..
+      dockerfile: e2e/Dockerfile.powershell
+    image: jitenv-e2e-powershell
+    container_name: jitenv-e2e-powershell
+    init: true
+    tmpfs:
+      - /tmp:exec,uid=1000,gid=1000
+    depends_on:
+      localstack:
+        condition: service_healthy
+      vault:
+        condition: service_healthy
+    environment:
+      JITENV_CONFIG: /home/jitenv/.config/jitenv/config.toml
+      LOCALSTACK_HOSTNAME: localstack
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
+
   alpine-source:
     build:
       context: ..

--- a/e2e/scenarios/powershell-hook-cwd-glob-injects-env.yaml
+++ b/e2e/scenarios/powershell-hook-cwd-glob-injects-env.yaml
@@ -1,0 +1,112 @@
+name: powershell-hook-cwd-glob-injects-env
+description: |
+  Exercises the `jitenv hook powershell` snippet end-to-end against a
+  real pwsh 7 process: the prompt-override-driven chpwd reconciles the
+  per-shell wrapper bin dir, the typed command resolves to a wrapper
+  in PATH, the shim hits the agent for env, and the wrapped script
+  observes the bag values in its environment.
+
+  The image is Linux (mcr.microsoft.com/powershell:latest is Ubuntu
+  22.04), so the *Unix* shim path runs — not the Windows .ps1-wrapper
+  spawn-and-wait path. Linux pwsh resolves bare command names via
+  Unix mode bits, so chpwd's reconcile_unix.go symlinks are what gets
+  invoked here. The Windows-specific surface (PATHEXT lookup,
+  spawn-and-wait, separator normalisation) stays covered by Windows
+  CI unit tests; this scenario closes the gap on the cross-platform
+  hook plumbing.
+
+  Setup is the symmetric counterpart of unlock-and-run-local for bash
+  and zsh-hook-injects-env for zsh: seed an encrypted config, unlock,
+  source the hook, observe env injection.
+
+service: powershell
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+      mkdir -p /home/jitenv/work
+
+  - name: write-mapped-script
+    exec: |
+      cat > /home/jitenv/bin/showenv <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      EOF
+      chmod +x /home/jitenv/bin/showenv
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed \
+        -out "$JITENV_CONFIG" \
+        -variant local-cwd-glob \
+        -cwd-glob /home/jitenv/work \
+        -commands showenv
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  # cd into the mapped dir *before* sourcing the hook so the
+  # initial __jitenv_chpwd call at hook-load fires from inside a
+  # matching pwd — the prompt-override that drives subsequent
+  # reconciles only fires under an interactive line editor, which
+  # `pwsh -Command` does not provide.
+  - name: pwsh-run-wrapped
+    exec: |
+      pwsh -NoProfile -Command '
+        Set-Location /home/jitenv/work
+        Invoke-Expression (& jitenv hook powershell | Out-String)
+        & showenv
+      '
+    timeout: 30s
+  - name: assert-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+  - name: assert-bar
+    assert_stdout_contains: "BAR=value-from-local-bar"
+
+  # Regression case: bare cwd_glob without a trailing slash must match
+  # the same way the trailing-slash variant does. The user-reported
+  # Windows bug had `cwd_glob = "~/test/"`; mapping.go's NewIndex
+  # normalises slashes after expandTilde, but the trailing-slash form
+  # is still worth pinning so a future expandTilde refactor doesn't
+  # silently regress matching.
+  - name: pwsh-trailing-slash-glob
+    exec: |
+      # Reseed with a trailing-slash cwd_glob, then re-run from a
+      # subdirectory to also exercise the matchAncestor walk.
+      mkdir -p /home/jitenv/work/sub
+      jitenv-e2e-seed \
+        -out "$JITENV_CONFIG" \
+        -variant local-cwd-glob \
+        -cwd-glob "/home/jitenv/work/" \
+        -commands showenv \
+        -preserve-meta
+      jitenv-e2e-reload
+      pwsh -NoProfile -Command '
+        Set-Location /home/jitenv/work/sub
+        Invoke-Expression (& jitenv hook powershell | Out-String)
+        & showenv
+      '
+    timeout: 30s
+  - name: assert-trailing-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/seed/seed.go
+++ b/e2e/seed/seed.go
@@ -20,6 +20,11 @@
 //     Path (defaults to /home/jitenv/scripts/*.sh) and
 //     the bag carries FOO/BAR/BAZ to exercise full bag
 //     expansion via a single empty-Name VarRef.
+//   - local-cwd-glob like local but uses a cwd_glob mapping with one
+//     or more `commands`. -cwd-glob and -commands flags
+//     parameterise the directory and command list. Used
+//     by the PowerShell hook scenarios to drive the
+//     chpwd → wrapper → shim → agent flow.
 //   - localstack   an aws-source fixture pointing at LocalStack with
 //     static dummy creds; mapping on .../show.sh fetches
 //     one key from the seeded SM secret.
@@ -33,6 +38,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
@@ -42,9 +48,11 @@ func main() {
 	var (
 		out           = flag.String("out", "", "output path for config.toml (required)")
 		passphrase    = flag.String("passphrase", "e2e-test-pass", "passphrase for the encrypted config")
-		variant       = flag.String("variant", "local", "fixture variant: local | local-alt | local-glob | localstack | vault")
+		variant       = flag.String("variant", "local", "fixture variant: local | local-alt | local-glob | local-cwd-glob | localstack | vault")
 		scriptPath    = flag.String("script", "/home/jitenv/scripts/show.sh", "absolute path used in the mapping (path variants)")
 		globPath      = flag.String("glob", "/home/jitenv/scripts/*.sh", "glob pattern used in the mapping (local-glob variant)")
+		cwdGlob       = flag.String("cwd-glob", "/home/jitenv/work", "cwd_glob pattern (local-cwd-glob variant)")
+		cmdsFlag      = flag.String("commands", "showenv", "comma-separated command names (local-cwd-glob variant)")
 		smARN         = flag.String("sm-arn", "arn:aws:secretsmanager:us-east-1:000000000000:secret:jitenv/demo", "SM secret ARN (localstack variant)")
 		smEndpoint    = flag.String("sm-endpoint", "http://localstack:4566", "SM endpoint URL (localstack variant)")
 		vaultAddr     = flag.String("vault-address", "http://vault:8200", "Vault address (vault variant)")
@@ -66,6 +74,8 @@ func main() {
 		variant:       *variant,
 		scriptPath:    *scriptPath,
 		globPath:      *globPath,
+		cwdGlob:       *cwdGlob,
+		commands:      splitCommas(*cmdsFlag),
 		smARN:         *smARN,
 		smEndpoint:    *smEndpoint,
 		vaultAddr:     *vaultAddr,
@@ -90,6 +100,8 @@ type runOpts struct {
 	variant       string
 	scriptPath    string
 	globPath      string
+	cwdGlob       string
+	commands      []string
 	smARN         string
 	smEndpoint    string
 	vaultAddr     string
@@ -158,6 +170,10 @@ func run(o runOpts) error {
 		}
 	case "local-glob":
 		if err := applyLocalGlob(cfg, key, o.globPath); err != nil {
+			return err
+		}
+	case "local-cwd-glob":
+		if err := applyLocalCwdGlob(cfg, key, o.cwdGlob, o.commands); err != nil {
 			return err
 		}
 	case "localstack":
@@ -237,6 +253,50 @@ func applyLocalGlob(cfg *config.Config, key []byte, globPath string) error {
 		},
 	}
 	return nil
+}
+
+// applyLocalCwdGlob mirrors applyLocal but routes via a cwd_glob mapping:
+// the bag expands when any of the listed commands runs from a directory
+// matching cwdGlob (or any descendant). Used by the PowerShell hook
+// scenarios to drive the chpwd → wrapper → shim → agent flow.
+func applyLocalCwdGlob(cfg *config.Config, key []byte, cwdGlob string, commands []string) error {
+	foo, err := crypto.EncryptField(key, "value-from-local-foo")
+	if err != nil {
+		return err
+	}
+	bar, err := crypto.EncryptField(key, "value-from-local-bar")
+	if err != nil {
+		return err
+	}
+	cfg.Sources = map[string]config.SourceConfig{
+		"vault": {Type: "local"},
+	}
+	cfg.Secrets = map[string]map[string]string{
+		"demo": {"FOO": foo, "BAR": bar},
+	}
+	cfg.Mappings = []config.Mapping{
+		{
+			CwdGlob:  cwdGlob,
+			Commands: append([]string(nil), commands...),
+			Vars: []config.VarRef{
+				{Source: "vault", Ref: "demo"},
+			},
+		},
+	}
+	return nil
+}
+
+// splitCommas turns "a,b,c" into ["a","b","c"], trimming whitespace and
+// dropping empties. Used by the -commands flag.
+func splitCommas(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		p := strings.TrimSpace(part)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // applyLocalstack wires an aws Secrets Manager source at the LocalStack

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -47,7 +47,7 @@ func newHookCmd() *cobra.Command {
     Invoke-Expression (& jitenv hook powershell | Out-String)
 
 The snippet wraps the prompt function to drive cwd_glob reconciliation
-on every prompt and prepends the per-shell wrap dir to $env:Path so
+on every prompt and prepends the per-shell wrap dir to $env:PATH so
 .ps1 shims resolve via PATHEXT. Absolute-path command interception
 (the bash DEBUG trap equivalent) is intentionally not implemented on
 PowerShell — see issue #39. PowerShell 5.x and cmd.exe are unsupported.`,

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -29,14 +29,18 @@ type cwdGlobEntry struct {
 }
 
 // NewIndex builds an Index from the parsed config. Glob and cwd_glob
-// patterns are normalised to forward slashes here because
-// doublestar.Match is forward-slash-only; without normalisation a
-// tilde-prefixed pattern like "~/test" silently fails on Windows
-// (expandTilde calls filepath.Join, which emits backslashes from
-// C:\Users\gv joined with "test", so the stored pattern is
-// "C:\Users\gv\test" — the path side of the comparison normalises
-// to forward slashes in matchAncestor / Lookup but a backslash-laden
-// pattern never matches). ToSlash is a no-op on Unix.
+// patterns are normalised in two ways before storage:
+//
+//  1. Forward slashes. doublestar.Match is forward-slash-only; without
+//     normalisation a tilde-prefixed pattern like "~/test" silently
+//     fails on Windows (expandTilde calls filepath.Join, which emits
+//     backslashes from C:\Users\gv joined with "test"). ToSlash is a
+//     no-op on Unix.
+//  2. No trailing slash. matchAncestor walks ancestors with path.Dir,
+//     which strips trailing slashes — so a stored pattern with a
+//     trailing slash never matches any ancestor form. Users routinely
+//     write `cwd_glob = "~/work/"`; treat it as identical to
+//     `~/work`. The root "/" edge case is preserved as-is.
 func NewIndex(mappings []Mapping) *Index {
 	idx := &Index{exact: map[string][]VarRef{}}
 	for _, m := range mappings {
@@ -49,18 +53,29 @@ func NewIndex(mappings []Mapping) *Index {
 			idx.exact[abs] = append(idx.exact[abs], m.Vars...)
 		case m.Glob != "":
 			idx.globs = append(idx.globs, globEntry{
-				pattern: filepath.ToSlash(expandTilde(m.Glob)),
+				pattern: normalisePattern(m.Glob),
 				vars:    m.Vars,
 			})
 		case m.CwdGlob != "":
 			idx.cwdGlobs = append(idx.cwdGlobs, cwdGlobEntry{
-				pattern:  filepath.ToSlash(expandTilde(m.CwdGlob)),
+				pattern:  normalisePattern(m.CwdGlob),
 				commands: append([]string(nil), m.Commands...),
 				vars:     m.Vars,
 			})
 		}
 	}
 	return idx
+}
+
+// normalisePattern applies the two transforms NewIndex relies on:
+// tilde expansion, forward-slash normalisation, and trailing-slash
+// removal (except the bare root "/").
+func normalisePattern(p string) string {
+	s := filepath.ToSlash(expandTilde(p))
+	if len(s) > 1 {
+		s = strings.TrimRight(s, "/")
+	}
+	return s
 }
 
 // Lookup returns the merged VarRefs for a given absolute path, in

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -28,7 +28,15 @@ type cwdGlobEntry struct {
 	vars     []VarRef
 }
 
-// NewIndex builds an Index from the parsed config.
+// NewIndex builds an Index from the parsed config. Glob and cwd_glob
+// patterns are normalised to forward slashes here because
+// doublestar.Match is forward-slash-only; without normalisation a
+// tilde-prefixed pattern like "~/test" silently fails on Windows
+// (expandTilde calls filepath.Join, which emits backslashes from
+// C:\Users\gv joined with "test", so the stored pattern is
+// "C:\Users\gv\test" — the path side of the comparison normalises
+// to forward slashes in matchAncestor / Lookup but a backslash-laden
+// pattern never matches). ToSlash is a no-op on Unix.
 func NewIndex(mappings []Mapping) *Index {
 	idx := &Index{exact: map[string][]VarRef{}}
 	for _, m := range mappings {
@@ -41,12 +49,12 @@ func NewIndex(mappings []Mapping) *Index {
 			idx.exact[abs] = append(idx.exact[abs], m.Vars...)
 		case m.Glob != "":
 			idx.globs = append(idx.globs, globEntry{
-				pattern: expandTilde(m.Glob),
+				pattern: filepath.ToSlash(expandTilde(m.Glob)),
 				vars:    m.Vars,
 			})
 		case m.CwdGlob != "":
 			idx.cwdGlobs = append(idx.cwdGlobs, cwdGlobEntry{
-				pattern:  expandTilde(m.CwdGlob),
+				pattern:  filepath.ToSlash(expandTilde(m.CwdGlob)),
 				commands: append([]string(nil), m.Commands...),
 				vars:     m.Vars,
 			})

--- a/internal/config/mapping_test.go
+++ b/internal/config/mapping_test.go
@@ -107,6 +107,32 @@ func TestIndex_LookupCwd_TildeExpansion(t *testing.T) {
 	}
 }
 
+// TestIndex_LookupCwd_TrailingSlash pins the trailing-slash normalisation
+// applied by NewIndex. matchAncestor walks ancestors with path.Dir,
+// which strips trailing slashes; a stored pattern that still carries
+// one therefore never matches any ancestor form. Surfaced via the
+// PowerShell e2e scenario where a user-natural `cwd_glob = "~/work/"`
+// silently produced an empty wanted set and the wrap dir stayed empty.
+func TestIndex_LookupCwd_TrailingSlash(t *testing.T) {
+	skipOnWindows(t)
+	tmp := t.TempDir()
+	sub := filepath.Join(tmp, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	idx := NewIndex([]Mapping{{
+		CwdGlob:  tmp + "/",
+		Commands: []string{"npm"},
+		Vars:     []VarRef{{Source: "x"}},
+	}})
+	if !idx.MappedCwd(tmp, "npm") {
+		t.Errorf("trailing-slash cwd_glob should match its own dir")
+	}
+	if !idx.MappedCwd(sub, "npm") {
+		t.Errorf("trailing-slash cwd_glob should match descendants too")
+	}
+}
+
 func TestValidate_RejectsMultipleKinds(t *testing.T) {
 	c := &Config{
 		Version: Version,

--- a/internal/config/mapping_windows_test.go
+++ b/internal/config/mapping_windows_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -44,5 +45,32 @@ func TestLookup_BackslashPath_ForwardSlashGlob(t *testing.T) {
 	}
 	if got := idx.Lookup(abs); len(got) != 1 {
 		t.Errorf("Lookup(%q): got %v, want one VarRef", abs, got)
+	}
+}
+
+// TestCwdCommands_TildeExpansion_NormalisesPattern is the regression
+// test for the user-reported bug where a config with
+// `cwd_glob = "~/test/"` never matched on Windows: expandTilde calls
+// filepath.Join(home, "test/"), which emits backslashes on Windows
+// (C:\Users\<user>\test). Without slash-normalisation in NewIndex,
+// doublestar.Match silently returned false for every shell prompt
+// and the wrapper bin dir stayed empty — `node` then ran without
+// the configured env injection.
+func TestCwdCommands_TildeExpansion_NormalisesPattern(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	pwd := filepath.Join(home, "test") // native backslash form
+
+	idx := NewIndex([]Mapping{{
+		CwdGlob:  "~/test/",
+		Commands: []string{"node"},
+		Vars:     []VarRef{{Source: "x"}},
+	}})
+
+	got := idx.CwdCommands(pwd)
+	if len(got) != 1 || got[0] != "node" {
+		t.Fatalf("CwdCommands(%q): got %v, want [node]; expandTilde+filepath.Join produces backslashes on Windows that must be normalised in NewIndex", pwd, got)
 	}
 }

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -1,26 +1,16 @@
 package config
 
-import (
-	"os"
-	"path/filepath"
-)
+import "os"
 
-// DefaultPath returns the canonical config file path.
-// Honors $JITENV_CONFIG; otherwise $XDG_CONFIG_HOME/jitenv/config.toml,
-// falling back to ~/.config/jitenv/config.toml.
+// DefaultPath returns the canonical config file path. Honors
+// $JITENV_CONFIG first; otherwise dispatches to a per-platform helper
+// (configDir + "/jitenv/config.toml"). See path_unix.go (XDG-style)
+// and path_windows.go (%APPDATA%).
 func DefaultPath() (string, error) {
 	if p := os.Getenv("JITENV_CONFIG"); p != "" {
 		return p, nil
 	}
-	xdg := os.Getenv("XDG_CONFIG_HOME")
-	if xdg == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		xdg = filepath.Join(home, ".config")
-	}
-	return filepath.Join(xdg, "jitenv", "config.toml"), nil
+	return platformDefaultPath()
 }
 
 // Resolve returns explicit if non-empty, else DefaultPath().

--- a/internal/config/path_unix.go
+++ b/internal/config/path_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// platformDefaultPath returns the XDG-style default on Unix: the
+// $XDG_CONFIG_HOME (or ~/.config) child "jitenv/config.toml". Used on
+// both Linux and macOS — jitenv treats macOS as Unix here rather than
+// using ~/Library/Application Support, matching the path conventions
+// the bash/zsh hooks and the existing macOS port already assume.
+func platformDefaultPath() (string, error) {
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	if xdg == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		xdg = filepath.Join(home, ".config")
+	}
+	return filepath.Join(xdg, "jitenv", "config.toml"), nil
+}

--- a/internal/config/path_unix_test.go
+++ b/internal/config/path_unix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultPath_XDGOverride(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join("/custom/xdg", "jitenv", "config.toml")
+	if got != want {
+		t.Errorf("DefaultPath(): got %q want %q", got, want)
+	}
+}
+
+func TestDefaultPath_HomeFallback(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "/home/test")
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join("/home/test", ".config", "jitenv", "config.toml")
+	if got != want {
+		t.Errorf("DefaultPath(): got %q want %q", got, want)
+	}
+}
+
+func TestDefaultPath_ExplicitEnv(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", "/some/explicit/path.toml")
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != "/some/explicit/path.toml" {
+		t.Errorf("DefaultPath(): got %q, want explicit env path", got)
+	}
+}

--- a/internal/config/path_windows.go
+++ b/internal/config/path_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// platformDefaultPath returns %APPDATA%\jitenv\config.toml on Windows.
+// %APPDATA% is the conventional location for per-user, roaming
+// application configuration on Windows; it's defined for every
+// interactive user session and defaults to
+// %USERPROFILE%\AppData\Roaming. We fall back to that derived path
+// when the env var is unset (rare — typically only inside stripped
+// service contexts) so the resolution is total. XDG_CONFIG_HOME is
+// intentionally ignored: Windows users running PowerShell expect
+// their config under AppData, not under the WSL-style ~/.config that
+// the Unix branch uses.
+func platformDefaultPath() (string, error) {
+	dir := os.Getenv("APPDATA")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(home, "AppData", "Roaming")
+	}
+	return filepath.Join(dir, "jitenv", "config.toml"), nil
+}

--- a/internal/config/path_windows_test.go
+++ b/internal/config/path_windows_test.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultPath_AppDataOverride(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", "")
+	t.Setenv("APPDATA", `C:\custom\AppData\Roaming`)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join(`C:\custom\AppData\Roaming`, "jitenv", "config.toml")
+	if got != want {
+		t.Errorf("DefaultPath(): got %q want %q", got, want)
+	}
+}
+
+func TestDefaultPath_AppDataHomeFallback(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", "")
+	t.Setenv("APPDATA", "")
+	t.Setenv("USERPROFILE", `C:\Users\test`)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join(`C:\Users\test`, "AppData", "Roaming", "jitenv", "config.toml")
+	if got != want {
+		t.Errorf("DefaultPath(): got %q want %q", got, want)
+	}
+}
+
+func TestDefaultPath_ExplicitEnv(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", `D:\elsewhere\config.toml`)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != `D:\elsewhere\config.toml` {
+		t.Errorf("DefaultPath(): got %q, want explicit env path", got)
+	}
+}
+
+// TestDefaultPath_IgnoresXDG asserts that the Windows branch does not
+// consult XDG_CONFIG_HOME — a WSL user with an inherited environment
+// shouldn't have their Windows-side config silently redirected into
+// the WSL-style ~/.config tree.
+func TestDefaultPath_IgnoresXDG(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", "")
+	t.Setenv("APPDATA", `C:\real\AppData\Roaming`)
+	t.Setenv("XDG_CONFIG_HOME", `/wsl/home/.config`)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join(`C:\real\AppData\Roaming`, "jitenv", "config.toml")
+	if got != want {
+		t.Errorf("DefaultPath(): got %q want %q (XDG_CONFIG_HOME should be ignored)", got, want)
+	}
+}

--- a/internal/shell/render_test.go
+++ b/internal/shell/render_test.go
@@ -100,8 +100,8 @@ func TestRenderPowerShellBakesPaths(t *testing.T) {
 			if !strings.Contains(out, "__JITENV_WRAP_DIR") {
 				t.Errorf("expected wrap-dir construction in pwsh snippet;\n%s", out)
 			}
-			if !strings.Contains(out, "$env:Path") {
-				t.Errorf("expected $env:Path prepend in pwsh snippet;\n%s", out)
+			if !strings.Contains(out, "$env:PATH") {
+				t.Errorf("expected $env:PATH prepend in pwsh snippet;\n%s", out)
 			}
 			if !strings.Contains(out, "function global:prompt") {
 				t.Errorf("expected global:prompt override in pwsh snippet;\n%s", out)

--- a/internal/shell/snippets/powershell.ps1
+++ b/internal/shell/snippets/powershell.ps1
@@ -4,7 +4,7 @@
 # Requires PowerShell 7+. Windows Server PowerShell 5.x is intentionally
 # unsupported (see issue #39 design call). Drives the cwd_glob wrapper
 # scheme only:
-#   - Prepends the per-shell wrap dir to $env:Path so PATHEXT picks up
+#   - Prepends the per-shell wrap dir to $env:PATH so PATHEXT picks up
 #     the .ps1 wrappers that `jitenv __chpwd` populates.
 #   - Wraps the user's `prompt` function so every new prompt fires
 #     `jitenv __chpwd` to reconcile the wrap dir against the mapping
@@ -38,10 +38,17 @@ New-Item -ItemType Directory -Force -Path $__JITENV_WRAP_DIR | Out-Null
 
 # Prepend, once per shell. PATHEXT must include .PS1 for the wrappers
 # to resolve when the user types `npm` (default on pwsh 7).
+#
+# Use $env:PATH (upper-case) rather than $env:Path. On Windows pwsh
+# env-var lookups are case-insensitive and either form works; on Linux
+# pwsh they are case-sensitive and the env var is named PATH — the
+# mixed-case form returns an empty string, which silently breaks both
+# the contains-check and the assignment. Same applies elsewhere in
+# this script.
 $__jitenv_pathSeparator = [System.IO.Path]::PathSeparator
-$__jitenv_existing = $env:Path -split [regex]::Escape($__jitenv_pathSeparator)
+$__jitenv_existing = $env:PATH -split [regex]::Escape($__jitenv_pathSeparator)
 if (-not ($__jitenv_existing -contains $__JITENV_WRAP_DIR)) {
-    $env:Path = $__JITENV_WRAP_DIR + $__jitenv_pathSeparator + $env:Path
+    $env:PATH = $__JITENV_WRAP_DIR + $__jitenv_pathSeparator + $env:PATH
 }
 Remove-Variable __jitenv_pathSeparator, __jitenv_existing -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
Final stage of #39 (Windows port). Stages 2.1-2.5 added named-pipe transport, token-SID peer auth, hidden-console daemon spawn, spawn-and-wait run/shim, `.ps1` wrapper shims, and the PowerShell 7 hook. This stage ships the release artifacts and the config-dir resolution Windows users expect.

## Summary

- **`internal/config/path.go` split.** `_unix.go` keeps the existing XDG_CONFIG_HOME > ~/.config behaviour for Linux + macOS; `_windows.go` resolves to `%APPDATA%\jitenv\config.toml` with `%USERPROFILE%\AppData\Roaming\jitenv\config.toml` as a fallback for stripped service-account envs. `XDG_CONFIG_HOME` is intentionally ignored on Windows so a WSL-inherited environment can't silently redirect into `~/.config`. Tests pin both platforms' resolution including the explicit-env override and the XDG-ignored-on-Windows invariant.
- **`.goreleaser.yaml` Windows artifacts.** Adds `windows` to `goos` with a per-GOOS `format_overrides` so Windows is `.zip` (built-in Explorer / PowerShell unzip) while Linux + macOS stay `tar.gz`. Pulls `internal/shell/snippets/powershell.ps1` into the archive. Release header updated to mention Windows + the SmartScreen note (Authenticode signing deferred — see #39).
- **CI comment refresh.** `test-windows` runs `go test ./...` unchanged — companion `*_windows_test.go` files added in stages 2.1-2.5 already exercise the Windows-specific code paths. The bash/zsh hook e2e tests stay `!windows`-tagged; PowerShell e2e is a separate follow-up.
- **README + CLAUDE.md.** Flips "Linux + macOS only" / "compiles for GOOS=windows but not yet implemented" claims. Documents the Windows-specific paths (named pipes, %LOCALAPPDATA%, %APPDATA%, CREATE_NO_WINDOW double-fork analogue).

## Verified locally

- [x] `go build ./...` (linux)
- [x] `GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/jitenv`
- [x] `GOOS=windows GOARCH=arm64 go build -trimpath ./cmd/jitenv`
- [x] `go test ./...` (linux, all green)
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `goreleaser release --snapshot --clean --skip=publish,sign` produces:
  - `jitenv_<v>_windows_amd64.zip` containing `jitenv.exe`, `LICENSE`, `README.md`, `snippets/{bash.sh,zsh.sh,powershell.ps1}`
  - `jitenv_<v>_windows_arm64.zip` (same contents)
  - Unix `.tar.gz` artifacts unchanged

## Out of scope (separate issues)

- winget manifest + publish workflow.
- Chocolatey package.
- Scoop manifest.
- MSI installer.
- Authenticode code-signing.

Closes #91. Closes the #39 Stage 2 chain.

## Test plan

- [x] CI: build/test/lint (linux), test (macos), test (windows), docker-compose harness.
- [x] Manual on a fresh Windows VM:
  - Download `jitenv_<v>_windows_amd64.zip`, extract.
  - `jitenv.exe hook install` writes the `Invoke-Expression` line to `$PROFILE`.
  - `jitenv.exe config` accepts passphrase, creates `%APPDATA%\jitenv\config.toml`.
  - `jitenv.exe unlock`, `cd` into a `cwd_glob` dir, run a wrapped command, see env vars injected.