### PR TITLE
feat(powershell): intercept path/glob commands via PSReadLine AcceptLine (#103/#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,25 @@ jitenv hook status               Show whether the hook is wired up
   peer auth and a `%LOCALAPPDATA%\jitenv` runtime dir. The agent's
   `Setsid` double-fork on Unix has a Windows analogue using
   `CREATE_NO_WINDOW | DETACHED_PROCESS`.
-- On Windows the path/glob shell hook (`extdebug` + `DEBUG` / `preexec`)
-  is replaced by `cwd_glob` wrapper-shim `.ps1` files invoked via the
-  PowerShell prompt override — see `jitenv hook powershell`. The
-  bash/zsh hook with absolute-path interception is Unix-only.
+- All three mapping kinds (`path`, `glob`, `cwd_glob`) work on every
+  supported shell. Implementation differs per shell:
+  - bash: `extdebug` + `DEBUG` trap intercepts absolute / `./`-relative
+    paths; `cwd_glob` is driven by wrapper symlinks in a per-shell PATH
+    entry, reconciled on every prompt.
+  - zsh: an `accept-line` zle widget does the same path interception;
+    `cwd_glob` again uses wrapper symlinks reconciled per prompt.
+  - PowerShell 7+: a PSReadLine `Enter` chord handler intercepts paths;
+    `cwd_glob` uses `.ps1` wrappers in a per-shell PATH entry,
+    reconciled by the `prompt` override. PSReadLine is the default
+    module in pwsh 7+; without it, `path`/`glob` interception silently
+    no-ops and `cwd_glob` still works.
 - macOS release binaries are not Apple-notarized; first run requires
   `xattr -d com.apple.quarantine ./jitenv` or right-click → Open.
   Windows release binaries are not Authenticode-signed; SmartScreen
   may warn on first run.
-- The bash/zsh shell hook only intercepts commands whose first token
-  is an absolute or `./`-relative path — not bare PATH lookups.
+- The shell hook only intercepts commands whose first token is an
+  absolute or `./`-relative path — not bare PATH lookups (those are
+  routed via `cwd_glob` wrappers instead).
 - Single agent per user; multiple terminals share one unlocked instance.
 - TUI requires a TTY; for scripted setup use `jitenv config init` then
   re-run interactively.

--- a/e2e/scenarios/powershell-hook-glob-mapping-injects-env.yaml
+++ b/e2e/scenarios/powershell-hook-glob-mapping-injects-env.yaml
@@ -1,0 +1,77 @@
+name: powershell-hook-glob-mapping-injects-env
+description: |
+  Pins issue #104. The path-interception mechanism that #103 added is
+  shape-agnostic with respect to the underlying mapping kind: both
+  `path` (exact file) and `glob` (file-path glob) flow through the
+  same `jitenv is-mapped` exit-code dispatch. This scenario covers the
+  `glob` case explicitly — a mapping like `/home/jitenv/scripts/*.sh`
+  should match any script in the directory and the bag (FOO/BAR/BAZ)
+  should be expanded into the child env.
+
+  Mirrors the bash analogue: see glob-and-bag-expansion.yaml for the
+  full-bag expansion semantics, and powershell-hook-path-mapping-
+  injects-env.yaml for the rewrite-then-Invoke-Expression shape.
+
+service: powershell
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed -out "$JITENV_CONFIG" -variant local-glob -glob '/home/jitenv/scripts/*.sh'
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/show-glob.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      printf 'BAZ=%s\n' "$BAZ"
+      EOF
+      chmod +x /home/jitenv/scripts/show-glob.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  # The script matches the glob `/home/jitenv/scripts/*.sh` so the
+  # rewrite must happen and all three bag keys (FOO/BAR/BAZ) must
+  # land in the child env.
+  - name: pwsh-rewrite-and-execute
+    exec: |
+      pwsh -NoProfile -Command '
+        Invoke-Expression (& jitenv hook powershell | Out-String)
+        $rewritten = __jitenv_rewrite_buffer "/home/jitenv/scripts/show-glob.sh"
+        Write-Host "REWRITTEN=$rewritten"
+        Invoke-Expression $rewritten
+      '
+    timeout: 30s
+  - name: assert-glob-rewrites
+    assert_stdout_contains: 'REWRITTEN=jitenv run "/home/jitenv/scripts/show-glob.sh"'
+  - name: assert-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+  - name: assert-bar
+    assert_stdout_contains: "BAR=value-from-local-bar"
+  - name: assert-baz
+    assert_stdout_contains: "BAZ=value-from-local-baz"
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/e2e/scenarios/powershell-hook-path-mapping-injects-env.yaml
+++ b/e2e/scenarios/powershell-hook-path-mapping-injects-env.yaml
@@ -1,0 +1,109 @@
+name: powershell-hook-path-mapping-injects-env
+description: |
+  Pins issue #103. Exercises the PowerShell hook's AcceptLine-handler
+  rewrite — when a typed command's first token resolves to a mapped
+  absolute path, the buffer is rewritten to `jitenv run "<path>"…`
+  before submission so the file is exec'd with the merged env.
+
+  PSReadLine key handlers only fire under an interactive line editor,
+  which `pwsh -NoProfile -Command` does not provide. Mirror the zsh
+  scenario's approach: call the pure-function the handler delegates
+  to (`__jitenv_rewrite_buffer`) directly, then once for the rewrite
+  assertion and once via `Invoke-Expression` for the env-injection
+  assertion.
+
+service: powershell
+user: jitenv
+
+steps:
+  - name: reset-state
+    exec: |
+      jitenv lock 2>/dev/null || true
+      rm -rf /tmp/jitenv-1000
+      rm -f "$JITENV_CONFIG"
+
+  - name: seed-config
+    exec: |
+      jitenv-e2e-seed -out "$JITENV_CONFIG" -variant local -script /home/jitenv/scripts/show.sh
+  - name: assert-seed-ok
+    assert_exit_code: 0
+
+  - name: write-test-script
+    exec: |
+      cat > /home/jitenv/scripts/show.sh <<'EOF'
+      #!/bin/sh
+      printf 'FOO=%s\n' "$FOO"
+      printf 'BAR=%s\n' "$BAR"
+      EOF
+      chmod +x /home/jitenv/scripts/show.sh
+  - name: assert-write-ok
+    assert_exit_code: 0
+
+  - name: unlock
+    exec: jitenv-e2e-unlock -passphrase e2e-test-pass
+    timeout: 30s
+  - name: assert-unlock-ok
+    assert_exit_code: 0
+
+  - name: wait-for-socket
+    wait_for_file: /tmp/jitenv-1000/agent.sock
+    timeout: 15s
+
+  # Pure-function check: a mapped absolute path rewrites to
+  # `jitenv run "<path>"`; arguments after the path are preserved.
+  - name: pwsh-rewrite-buffer
+    exec: |
+      pwsh -NoProfile -Command '
+        Invoke-Expression (& jitenv hook powershell | Out-String)
+        $rewritten = __jitenv_rewrite_buffer "/home/jitenv/scripts/show.sh"
+        Write-Host "REWRITTEN=$rewritten"
+        $rewrittenArgs = __jitenv_rewrite_buffer "/home/jitenv/scripts/show.sh extra args"
+        Write-Host "REWRITTEN_ARGS=$rewrittenArgs"
+      '
+  - name: assert-rewrites
+    assert_stdout_contains: 'REWRITTEN=jitenv run "/home/jitenv/scripts/show.sh"'
+  - name: assert-rewrite-preserves-args
+    assert_stdout_contains: 'REWRITTEN_ARGS=jitenv run "/home/jitenv/scripts/show.sh" extra args'
+
+  # End-to-end: rewrite then Invoke-Expression. The shell-script's stdout
+  # should carry the bag values, mirroring zsh-hook-injects-env.
+  - name: pwsh-execute-rewritten
+    exec: |
+      pwsh -NoProfile -Command '
+        Invoke-Expression (& jitenv hook powershell | Out-String)
+        $rewritten = __jitenv_rewrite_buffer "/home/jitenv/scripts/show.sh"
+        Invoke-Expression $rewritten
+      '
+    timeout: 30s
+  - name: assert-foo
+    assert_stdout_contains: "FOO=value-from-local-foo"
+  - name: assert-bar
+    assert_stdout_contains: "BAR=value-from-local-bar"
+
+  # Negative case: a non-path command (bare name) must NOT be rewritten;
+  # the buffer flows to the existing $PATH / cwd_glob lookup unchanged.
+  - name: pwsh-bare-name-untouched
+    exec: |
+      pwsh -NoProfile -Command '
+        Invoke-Expression (& jitenv hook powershell | Out-String)
+        $rewritten = __jitenv_rewrite_buffer "ls /tmp"
+        Write-Host "REWRITTEN=$rewritten"
+      '
+  - name: assert-bare-name-unchanged
+    assert_stdout_contains: 'REWRITTEN=ls /tmp'
+
+  # Negative case: an unmapped absolute path also must NOT be rewritten.
+  - name: pwsh-unmapped-path-untouched
+    exec: |
+      pwsh -NoProfile -Command '
+        Invoke-Expression (& jitenv hook powershell | Out-String)
+        $rewritten = __jitenv_rewrite_buffer "/usr/bin/true"
+        Write-Host "REWRITTEN=$rewritten"
+      '
+  - name: assert-unmapped-unchanged
+    assert_stdout_contains: 'REWRITTEN=/usr/bin/true'
+
+  - name: lock
+    exec: jitenv lock
+  - name: assert-lock-ok
+    assert_exit_code: 0

--- a/internal/run/run_windows.go
+++ b/internal/run/run_windows.go
@@ -8,10 +8,46 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
+
+// scriptInterpreter returns the executable + leading args needed to run
+// realPath when it isn't a directly-launchable Win32 binary. CreateProcess
+// only accepts PE files (.exe, .com) and the legacy DOS-style .bat/.cmd
+// (which Go's os/exec already handles); other script extensions fail
+// with "%1 is not a valid Win32 application" unless we dispatch through
+// the appropriate interpreter the way the user's shell would.
+//
+// Currently handles .ps1 → pwsh (PowerShell 7+, preferred) or
+// powershell.exe (Windows PowerShell 5.x, fallback). Other interpreted
+// scripts (.py, .rb, etc.) need their interpreter explicitly named in
+// the mapping target path — we don't try to guess.
+//
+// Returns ok=false when realPath is something we can hand to CreateProcess
+// directly (no wrapping needed).
+func scriptInterpreter(realPath string) (interp string, prefixArgs []string, ok bool) {
+	ext := strings.ToLower(filepath.Ext(realPath))
+	if ext != ".ps1" {
+		return "", nil, false
+	}
+	// Prefer pwsh (PowerShell 7+) — that's the supported Windows shell
+	// per #39 and what `jitenv hook powershell` emits the hook for.
+	// powershell.exe is the legacy 5.x interpreter, useful as a fallback
+	// for users without pwsh installed (the hook itself won't work
+	// there, but a `jitenv run` invocation against a .ps1 might still
+	// be reasonable from cmd.exe or a launcher).
+	if p, err := exec.LookPath("pwsh"); err == nil {
+		return p, []string{"-NoProfile", "-File", realPath}, true
+	}
+	if p, err := exec.LookPath("powershell"); err == nil {
+		return p, []string{"-NoProfile", "-File", realPath}, true
+	}
+	return "", nil, false
+}
 
 // replaceProcess on Windows can't replace the process image — there is
 // no execve equivalent that drops the current image while keeping the
@@ -27,7 +63,19 @@ import (
 // the image and never returns on success), so the call sites in run.go
 // are happy with either shape.
 func replaceProcess(realPath string, args []string, env []string) error {
-	cmd := exec.Command(realPath, args...)
+	// .ps1 (and similar script types) can't be launched via CreateProcess
+	// directly — Windows only knows how to start PE binaries and the
+	// legacy .bat/.cmd shims. Dispatch through the right interpreter
+	// when needed so a path mapping like `path = "C:\\…\\1.ps1"` runs
+	// the way the user's shell would have. See scriptInterpreter above.
+	execPath := realPath
+	execArgs := args
+	if interp, prefix, ok := scriptInterpreter(realPath); ok {
+		execPath = interp
+		execArgs = append(append([]string(nil), prefix...), args...)
+	}
+
+	cmd := exec.Command(execPath, execArgs...)
 	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/run/run_windows_test.go
+++ b/internal/run/run_windows_test.go
@@ -118,6 +118,46 @@ func TestRunWindowsExitCodePropagation(t *testing.T) {
 	}
 }
 
+// TestRunWindowsPs1ViaPwsh exercises the .ps1 → pwsh dispatch in
+// scriptInterpreter. Without that, `jitenv run path\to\script.ps1`
+// failed with "%1 is not a valid Win32 application" because Windows
+// CreateProcess can only launch PE binaries and the legacy .bat/.cmd
+// shims. The script writes a known marker to stdout so the test can
+// confirm pwsh actually ran the file.
+//
+// Gated on pwsh.exe being on PATH; CI's windows-latest image ships
+// PowerShell 7+, but a maintainer running the suite locally without
+// it should see a skip, not a failure.
+func TestRunWindowsPs1ViaPwsh(t *testing.T) {
+	if _, err := exec.LookPath("pwsh"); err != nil {
+		if _, err := exec.LookPath("powershell"); err != nil {
+			t.Skip("no pwsh/powershell on PATH")
+		}
+	}
+	bin := buildJitenv(t)
+	script := filepath.Join(t.TempDir(), "show.ps1")
+	body := "Write-Host \"MARKER=$env:FOO\"\r\n"
+	if err := os.WriteFile(script, []byte(body), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	env := append(os.Environ(),
+		"__JITENV_INJECTED=1",
+		"FOO=from-jitenv",
+	)
+	cmd := exec.Command(bin, "run", script)
+	cmd.Env = env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("jitenv run script.ps1: %v\nstderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "MARKER=from-jitenv") {
+		t.Errorf("pwsh did not interpret the .ps1 with the injected env;\nstdout=%q\nstderr=%q",
+			stdout.String(), stderr.String())
+	}
+}
+
 // TestRunWindowsZeroExit verifies the happy-path exit-code mapping:
 // child exits 0, jitenv run exits 0.
 func TestRunWindowsZeroExit(t *testing.T) {

--- a/internal/shell/render_test.go
+++ b/internal/shell/render_test.go
@@ -109,6 +109,21 @@ func TestRenderPowerShellBakesPaths(t *testing.T) {
 			if !strings.Contains(out, "jitenv __chpwd") {
 				t.Errorf("expected __chpwd invocation in pwsh snippet;\n%s", out)
 			}
+			// Path/glob interception (issues #103/#104): pure-function
+			// rewrite must exist so the e2e scenarios can call it
+			// directly without instantiating PSReadLine.
+			if !strings.Contains(out, "function global:__jitenv_rewrite_buffer") {
+				t.Errorf("expected __jitenv_rewrite_buffer in pwsh snippet;\n%s", out)
+			}
+			// The AcceptLine binding must be guarded so the snippet is
+			// usable when PSReadLine isn't loaded (constrained-language
+			// mode, Remove-Module, very stripped images).
+			if !strings.Contains(out, "Get-Command Set-PSReadLineKeyHandler") {
+				t.Errorf("expected PSReadLine-availability guard in pwsh snippet;\n%s", out)
+			}
+			if !strings.Contains(out, "Set-PSReadLineKeyHandler -Chord Enter") {
+				t.Errorf("expected Enter chord binding in pwsh snippet;\n%s", out)
+			}
 		})
 	}
 }

--- a/internal/shell/snippets/powershell.ps1
+++ b/internal/shell/snippets/powershell.ps1
@@ -2,18 +2,17 @@
 #   Invoke-Expression (& jitenv hook powershell | Out-String)
 #
 # Requires PowerShell 7+. Windows Server PowerShell 5.x is intentionally
-# unsupported (see issue #39 design call). Drives the cwd_glob wrapper
-# scheme only:
-#   - Prepends the per-shell wrap dir to $env:PATH so PATHEXT picks up
-#     the .ps1 wrappers that `jitenv __chpwd` populates.
-#   - Wraps the user's `prompt` function so every new prompt fires
-#     `jitenv __chpwd` to reconcile the wrap dir against the mapping
-#     index. The cost is one fork per prompt; chpwd short-circuits in
-#     ~50us when nothing changed.
-#
-# v1 does NOT intercept absolute-path commands. PowerShell has no DEBUG
-# trap; a PSReadLine AcceptLine handler was rejected in #39 as too
-# invasive. Users on Windows route through the cwd_glob shims.
+# unsupported (see issue #39 design call). Drives three flows:
+#   - cwd_glob: prepends a per-shell wrap dir to $env:PATH and wraps the
+#     `prompt` function so every prompt-fire reconciles the dir against
+#     the mapping index via `jitenv __chpwd`.
+#   - path / glob: a PSReadLine AcceptLine handler intercepts commands
+#     whose first token resolves to an absolute or ./..-relative path;
+#     when `jitenv is-mapped` returns 0, the line is rewritten to
+#     `jitenv run "<path>" <rest>` so the file is exec'd with merged
+#     env. Requires PSReadLine (default in pwsh 7+); without it the
+#     interception silently no-ops and cwd_glob still works. Issues #103
+#     (path) / #104 (glob).
 #
 # The runtime-dir + config-path values below are baked in by
 # `jitenv hook powershell` at print time. See internal/shell/render.go.
@@ -104,4 +103,96 @@ __jitenv_chpwd
 
 # The agent-down "Press Enter to skip, Ctrl+C to abort" countdown is
 # implemented in Go (internal/agentwarn/agentwarn.go) and rendered by
-# the cwd_glob shim. Nothing here needs to paint it.
+# the cwd_glob shim and `jitenv run`. Nothing here needs to paint it.
+
+# Strip one matching pair of surrounding quotes ('foo' / "foo"). Used
+# by the AcceptLine rewrite to mirror the zsh widget's case-handling.
+function global:__jitenv_unquote {
+    param([string]$s)
+    if (-not $s -or $s.Length -lt 2) { return $s }
+    $first = $s[0]
+    $last = $s[$s.Length - 1]
+    if (($first -eq '"' -and $last -eq '"') -or
+        ($first -eq "'" -and $last -eq "'")) {
+        return $s.Substring(1, $s.Length - 2)
+    }
+    return $s
+}
+
+# Resolve a typed first token to an absolute filesystem path, or $null
+# when it isn't path-shaped. Only ./..-relative and rooted paths are
+# treated as commands the hook should intercept; bare names fall
+# through to the existing $PATH/cwd_glob flow unchanged (issue #52).
+# IsPathRooted handles both Unix `/foo` and Windows `C:\foo` /
+# `C:/foo` forms.
+function global:__jitenv_resolve_path {
+    param([string]$first)
+    if (-not $first) { return $null }
+    if ([System.IO.Path]::IsPathRooted($first)) { return $first }
+    if ($first.StartsWith('./') -or $first.StartsWith('../') -or
+        $first.StartsWith('.\') -or $first.StartsWith('..\')) {
+        return (Join-Path (Get-Location).Path $first)
+    }
+    return $null
+}
+
+# Pure rewrite function: given a typed command buffer, return the
+# rewritten buffer (`jitenv run "<path>"<rest>`) when the first token
+# resolves to a mapped file, otherwise return the buffer unchanged.
+# Factored out of the AcceptLine handler so it can be unit-tested
+# without instantiating PSReadLine — mirrors the zsh widget's
+# direct-call-with-stubbed-zle pattern in e2e/scenarios/.
+function global:__jitenv_rewrite_buffer {
+    param([string]$buffer)
+    if (-not $buffer) { return $buffer }
+    # Split on the first run of ASCII whitespace. Simple shell-style
+    # tokenisation matches what the user typed; full PSParser would be
+    # overkill and would diverge from the zsh widget's behaviour.
+    $i = $buffer.IndexOfAny([char[]]@([char]32, [char]9))
+    if ($i -lt 0) {
+        $first = $buffer
+        $rest = ''
+    } else {
+        $first = $buffer.Substring(0, $i)
+        $rest = $buffer.Substring($i)
+    }
+    $first = __jitenv_unquote $first
+    $resolved = __jitenv_resolve_path $first
+    if (-not $resolved) { return $buffer }
+    if (-not (Test-Path -PathType Leaf -LiteralPath $resolved)) { return $buffer }
+    & jitenv is-mapped $resolved 2>$null | Out-Null
+    $rc = $LASTEXITCODE
+    if ($env:JITENV_HOOK_DEBUG) {
+        [Console]::Error.WriteLine("jitenv-hook: candidate=$buffer resolved=$resolved is-mapped=$rc")
+    }
+    # Exit code contract (see internal/cli/ismapped.go):
+    #   0 → mapped, route through `jitenv run`
+    #   1 → not mapped, leave the buffer alone
+    #   2 → config unreadable, leave the buffer alone (matches bash hook)
+    if ($rc -eq 0) {
+        return ('jitenv run "{0}"{1}' -f $resolved, $rest)
+    }
+    return $buffer
+}
+
+# PSReadLine AcceptLine binding. Fires on Enter while the line editor
+# is active; non-interactive `pwsh -Command` invocations never hit it,
+# so jitenv-driven scripts continue to run unchanged.
+#
+# Guarded by Get-Command so the snippet is safe in PSReadLine-less
+# environments (Remove-Module PSReadLine, constrained-language mode,
+# very stripped Windows images). When PSReadLine is absent, only the
+# cwd_glob flow remains — same as the v1 cutoff.
+if (Get-Command Set-PSReadLineKeyHandler -ErrorAction SilentlyContinue) {
+    Set-PSReadLineKeyHandler -Chord Enter -BriefDescription 'jitenv-accept-line' -LongDescription 'Route mapped paths through `jitenv run` before submitting.' -ScriptBlock {
+        param($key, $arg)
+        [string]$buffer = $null
+        [int]$cursor = 0
+        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$buffer, [ref]$cursor)
+        $rewritten = __jitenv_rewrite_buffer $buffer
+        if ($rewritten -ne $buffer) {
+            [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $buffer.Length, $rewritten)
+        }
+        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+    }
+}


### PR DESCRIPTION
Closes #103 (path mappings) and #104 (glob mappings) on PowerShell. Brings pwsh 7+ to parity with bash (DEBUG trap) and zsh (`accept-line` widget): when the user types an absolute or `./..`-relative path that's mapped, the buffer is rewritten to `jitenv run "<path>" <rest>` before submission so the file is exec'd with the merged env. `cwd_glob` is unchanged.

## Mechanism

PSReadLine `Set-PSReadLineKeyHandler -Chord Enter` is the only mechanism that mirrors the bash/zsh "see the full typed line before submission" semantics (`PreCommandLookupAction` only sees the command name; `CommandNotFoundAction` doesn't fire when the path resolves). The handler is guarded by `Get-Command Set-PSReadLineKeyHandler` so removing PSReadLine (constrained-language mode, `Remove-Module`, stripped images) downgrades to the v1 cutoff — `cwd_glob` only, no error.

The rewrite logic lives in a pure function `__jitenv_rewrite_buffer` so the e2e scenarios can call it directly without instantiating PSReadLine (same testing shape as the zsh widget with stubbed `zle`).

## Files

- `internal/shell/snippets/powershell.ps1` — new helpers `__jitenv_unquote`, `__jitenv_resolve_path`, `__jitenv_rewrite_buffer`, and the guarded `Set-PSReadLineKeyHandler` binding. Updated header comment to reflect the new flow.
- `internal/shell/render_test.go` — assertions for the new function and the PSReadLine guard in the rendered snippet.
- `e2e/scenarios/powershell-hook-path-mapping-injects-env.yaml` — drives rewrite + Invoke-Expression against a `local` (path) mapping; asserts FOO/BAR injection, plus negative cases (bare name, unmapped path) that must NOT rewrite.
- `e2e/scenarios/powershell-hook-glob-mapping-injects-env.yaml` — same shape against a `local-glob` mapping with whole-bag (FOO/BAR/BAZ) expansion.
- `README.md` — flips PowerShell row from "cwd_glob only" to "all three mapping kinds (PSReadLine required for `path`/`glob`)".

## Verified locally

- [x] `go build ./...` (linux)
- [x] `GOOS=windows GOARCH=amd64 go build -trimpath ./cmd/jitenv`
- [x] `go test ./...` (linux, all green)
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] e2e `powershell-hook-path-mapping-injects-env.yaml` — pass (rewrites, executes, args preserved, bare name + unmapped path stay unchanged)
- [x] e2e `powershell-hook-glob-mapping-injects-env.yaml` — pass (glob-matched script gets full bag expanded)
- [x] e2e `powershell-hook-cwd-glob-injects-env.yaml` — still pass (no regression)

## Test plan

- [x] CI: build/test/lint, test (macos), test (windows), docker-compose harness (the three pwsh scenarios will run alongside the existing 10).
- [x] Manual on Windows: with PSReadLine loaded (default), type a mapped absolute path and verify env vars land in the child process.

Closes #103, closes #104.