### PR TITLE
fix(agent): defer pr.Close in SpawnDaemon so the key-pipe read end can't leak (#115)

### DIFF
--- a/internal/agent/daemonize_unix.go
+++ b/internal/agent/daemonize_unix.go
@@ -31,6 +31,12 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 	if err != nil {
 		return err
 	}
+	// Both ends are closed on every early-return path; the success path
+	// explicitly closes pr after cmd.Start so the child holds the only
+	// reference, and pw after writing the key so the child's read EOFs.
+	// The defers are safety nets for the OpenFile/Executable error
+	// returns below — without them, pr would leak (security #115).
+	defer pr.Close()
 	defer pw.Close()
 
 	exe, err := os.Executable()
@@ -62,10 +68,12 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
 	if err := cmd.Start(); err != nil {
-		pr.Close()
 		return err
 	}
-	pr.Close() // child holds its own copy
+	// Close eagerly so the child holds the only ref to the read end —
+	// the defer above would still fire on return, but eager close keeps
+	// the parent's fd table tight while the agent runs.
+	pr.Close()
 
 	if _, err := pw.Write(key); err != nil {
 		return fmt.Errorf("write key to child: %w", err)

--- a/internal/agent/daemonize_unix_fd_test.go
+++ b/internal/agent/daemonize_unix_fd_test.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// TestSpawnDaemonDoesNotLeakPipeFdOnError is the regression for security
+// #115: SpawnDaemon allocates the master-key pipe via os.Pipe() and
+// previously only closed the read end (`pr`) on the success path and on
+// cmd.Start failure. Three earlier returns (os.Executable, OpenFile for
+// the log, OpenFile for /dev/null) leaked `pr`. Force the log-open path
+// to fail and assert the parent process's fd table is unchanged.
+func TestSpawnDaemonDoesNotLeakPipeFdOnError(t *testing.T) {
+	// Forge a paths block whose log directory doesn't exist; OpenFile
+	// on paths.LogFile will fail before cmd.Start.
+	badDir := filepath.Join(t.TempDir(), "does-not-exist", "nested")
+	paths := Paths{
+		Dir:     badDir,
+		Socket:  filepath.Join(badDir, "agent.sock"),
+		PidFile: filepath.Join(badDir, "agent.pid"),
+		LogFile: filepath.Join(badDir, "agent.log"),
+	}
+	key := make([]byte, crypto.KeyLen)
+
+	before := countOpenFds(t)
+	err := SpawnDaemon(paths, "/tmp/nope.toml", time.Second, key)
+	after := countOpenFds(t)
+
+	if err == nil {
+		t.Fatal("expected SpawnDaemon to fail (log path under a missing dir)")
+	}
+	if after > before {
+		t.Errorf("SpawnDaemon leaked %d fd(s) on the error path (before=%d, after=%d)",
+			after-before, before, after)
+	}
+}
+
+// countOpenFds returns the number of entries in /proc/self/fd. The act
+// of opening that directory itself uses one fd, but both calls do so
+// identically, so the delta is comparable.
+func countOpenFds(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatalf("read /proc/self/fd: %v", err)
+	}
+	return len(entries)
+}


### PR DESCRIPTION
## Summary
Closes #115.

Three early-return paths between `os.Pipe()` and `cmd.Start()` (the `os.Executable` lookup, the log-file `OpenFile`, and the `/dev/null` `OpenFile`) left `pr` — the master-key pipe's read end — open in the parent process. The Windows version already handles this; Unix did not.

## Fix
Add a `defer pr.Close()` immediately after `os.Pipe`, matching the discipline already used for `pw`. The eager success-path close stays so the parent's fd table remains tight while the agent runs.

## Regression test
`TestSpawnDaemonDoesNotLeakPipeFdOnError` (Linux-tagged) polls `/proc/self/fd` before/after a `SpawnDaemon` call against a bad log path. On the old code: `leaked 1 fd(s)`. On the fix: zero leak.

## Test plan
- [x] New test fails on `main`, passes on this branch.
- [x] `go test ./...` clean on Linux.
- [x] `GOOS=windows go vet ./...` clean (Windows path unchanged).
- [ ] CI passes.