### PR TITLE
fix(agent): cap concurrent connections + set deadline before peer check (#114)

### DIFF
--- a/internal/agent/conn_limit_test.go
+++ b/internal/agent/conn_limit_test.go
@@ -1,0 +1,77 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestAgentRejectsExcessConnections is the regression for security #114:
+// without a concurrent-connection cap, a same-user process can hold an
+// unbounded number of half-finished connections (each occupying a
+// goroutine and an fd in the agent), exhausting the agent's resources.
+// With the cap, connections above the limit must be closed promptly at
+// accept time.
+func TestAgentRejectsExcessConnections(t *testing.T) {
+	// Drop the cap from its default 64 to a tight value so the test is
+	// fast and doesn't depend on hitting RLIMIT_NOFILE.
+	old := maxConcurrentAgentConns
+	maxConcurrentAgentConns = 4
+	t.Cleanup(func() { maxConcurrentAgentConns = old })
+
+	a, p := newTestAgent(t, nil)
+	go a.Serve(context.Background()) //nolint:errcheck
+
+	// Wait for listener readiness via a normal Status round-trip.
+	cli := NewClient(p.Socket)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Open exactly the cap's worth of connections and intentionally
+	// don't send a request — each blocks in the agent's ReadMessage
+	// (under the per-conn deadline), holding a slot.
+	holders := make([]net.Conn, 0, maxConcurrentAgentConns)
+	t.Cleanup(func() {
+		for _, c := range holders {
+			_ = c.Close()
+		}
+	})
+	for i := 0; i < maxConcurrentAgentConns; i++ {
+		c, err := net.Dial("unix", p.Socket)
+		if err != nil {
+			t.Fatalf("dial holder %d: %v", i, err)
+		}
+		holders = append(holders, c)
+	}
+
+	// Give the accept loop a moment to land all `cap` conns inside
+	// handle() so the semaphore is full.
+	time.Sleep(100 * time.Millisecond)
+
+	// The (cap+1)th connection must be rejected promptly: the agent
+	// either refuses the connect at the OS level or accepts-then-
+	// closes immediately. Either is a valid signal that the cap fired.
+	extra, err := net.Dial("unix", p.Socket)
+	if err != nil {
+		// OS refused the connect — also a valid rejection.
+		return
+	}
+	defer extra.Close()
+	if err := extra.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	n, err := extra.Read(buf)
+	if err != io.EOF {
+		t.Errorf("excess connection was not closed promptly; n=%d err=%v (want io.EOF)", n, err)
+	}
+}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -12,6 +12,14 @@ import (
 	"time"
 )
 
+// maxConcurrentAgentConns caps how many in-flight connection handlers
+// the agent allows. A misbehaving (or hostile) same-user process could
+// otherwise open arbitrarily many half-finished connections, each
+// holding a goroutine and an fd. Excess connections are closed at
+// accept time. Tunable from tests; the default is meant to sit well
+// above any realistic workload.
+var maxConcurrentAgentConns = 64
+
 // Agent is the per-user secret-fetching daemon.
 type Agent struct {
 	paths    Paths
@@ -119,6 +127,10 @@ func (a *Agent) Serve(ctx context.Context) error {
 		a.listener.Close()
 	}()
 
+	// Semaphore bounds concurrent connection handlers. Snapshotted at
+	// Serve-time so tests can lower the cap before calling Serve.
+	sem := make(chan struct{}, maxConcurrentAgentConns)
+
 	for {
 		conn, err := a.listener.Accept()
 		if err != nil {
@@ -127,7 +139,18 @@ func (a *Agent) Serve(ctx context.Context) error {
 			}
 			return err
 		}
-		go a.handle(ctx, conn)
+		select {
+		case sem <- struct{}{}:
+			go func() {
+				defer func() { <-sem }()
+				a.handle(ctx, conn)
+			}()
+		default:
+			// Cap reached. Drop the conn rather than queue it — a
+			// queue just delays the same DoS, and a legitimate
+			// client will retry within milliseconds.
+			_ = conn.Close()
+		}
 	}
 }
 
@@ -172,12 +195,17 @@ func (a *Agent) idleLoop(ctx context.Context) {
 
 func (a *Agent) handle(ctx context.Context, c net.Conn) {
 	defer c.Close()
-	if err := checkPeerUid(c); err != nil {
-		_ = WriteMessage(c, Response{OK: false, Error: "unauthorized"})
-		return
-	}
+	// Set the per-conn deadline FIRST so even rejected (unauthorized)
+	// clients can't hang the handler with a slow-read attack against
+	// our WriteMessage. Previously the deadline was only applied after
+	// the peer check, leaving the unauthorized-reply write unbounded
+	// (security #114).
 	if err := c.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
 		_ = WriteMessage(c, Response{OK: false, Error: "set deadline: " + err.Error()})
+		return
+	}
+	if err := checkPeerUid(c); err != nil {
+		_ = WriteMessage(c, Response{OK: false, Error: "unauthorized"})
 		return
 	}
 


### PR DESCRIPTION
## Summary
Closes #114. Two related DoS fixes for the per-user agent's accept loop.

### 1. Deadline-before-auth
`handle` set the 10s per-conn deadline AFTER `checkPeerUid`, so the rejected-peer branch wrote `unauthorized` to a deadline-less conn. A same-user process that connects (passing the 0600/SDDL gate) and refuses to read can pin the handler goroutine indefinitely.

Moved `SetDeadline` to the first line of `handle`.

### 2. Concurrent-connection cap
`Serve` spawned an unbounded `go handle(...)` per accepted conn. A misbehaving same-user process could open thousands of half-finished connections, exhausting the agent's goroutine count and fd table.

Added a semaphore-bounded spawn keyed off `maxConcurrentAgentConns` (default 64, overridable in tests). Excess accepts are closed promptly so legitimate clients see a fast EOF and retry rather than queue forever.

## Regression test
`TestAgentRejectsExcessConnections` (cap=4) holds the cap, then verifies the (cap+1)th connection is closed at accept time (`io.EOF` on read).

## Test plan
- [x] Regression test fails on main (`i/o timeout`), passes on this branch (`io.EOF`).
- [x] `go test ./...` clean.
- [x] `GOOS=windows go vet ./...` clean.
- [ ] CI passes.