### PR TITLE
fix(sources/vault): warn loudly when tls_skip_verify is enabled (#113)

### DIFF
--- a/internal/sources/vault/vault.go
+++ b/internal/sources/vault/vault.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -74,7 +75,7 @@ func schema() []source.ParamField {
 			Enum: []string{kvV1, kvV2},
 			Help: "v1 or v2 (default v2)"},
 		{Key: "tls_skip_verify", Label: "TLS skip verify",
-			Help: "Bool; for dev-mode against self-signed certs."},
+			Help: "INSECURE: disables certificate verification. Only for dev-mode self-signed targets. Setting this in production allows HTTPS_PROXY to MITM every Vault fetch and capture tokens + secret values."},
 	}
 }
 
@@ -103,6 +104,13 @@ func New(cfg map[string]any) (source.Source, error) {
 	}
 	if err := s.validateStatic(); err != nil {
 		return nil, err
+	}
+	if s.tlsSkipVerify {
+		// One loud line at construction (i.e. once per agent startup
+		// and once per reload). Repeating the warning on every Fetch
+		// would just spam the log.
+		slog.Warn("vault source: TLS verification disabled (tls_skip_verify=true); HTTPS_PROXY can MITM all Vault traffic — do not use in production",
+			"address", s.address)
 	}
 	return s, nil
 }

--- a/internal/sources/vault/vault_test.go
+++ b/internal/sources/vault/vault_test.go
@@ -1,8 +1,10 @@
 package vault
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -103,6 +105,50 @@ func TestNew_UnknownKVVersion(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "unknown kv_version") {
 		t.Fatalf("expected unknown kv_version error, got %v", err)
+	}
+}
+
+// TestNew_TLSSkipVerify_LogsWarning is the regression for security #113:
+// enabling tls_skip_verify must produce a loud, structured warning at
+// New() time so the operator can spot a misconfigured Vault source in
+// the agent log. Without this signal, a stray dev-mode setting can
+// survive a promotion to production and MITM all Vault fetches via
+// HTTPS_PROXY.
+func TestNew_TLSSkipVerify_LogsWarning(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	if _, err := New(map[string]any{
+		"address":         "https://vault.example.com:8200",
+		"auth_method":     "token",
+		"token":           "x",
+		"tls_skip_verify": true,
+	}); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, `"level":"WARN"`) {
+		t.Errorf("expected a WARN-level log line; got:\n%s", out)
+	}
+	if !strings.Contains(out, "tls_skip_verify") && !strings.Contains(out, "TLS verification disabled") {
+		t.Errorf("warning should mention TLS verification being disabled; got:\n%s", out)
+	}
+
+	// Reset the buffer; a source without the flag must NOT log a
+	// warning, otherwise every legitimate Vault setup spams the log.
+	buf.Reset()
+	if _, err := New(map[string]any{
+		"address":     "https://vault.example.com:8200",
+		"auth_method": "token",
+		"token":       "x",
+	}); err != nil {
+		t.Fatalf("New (clean): %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("unexpected warning when tls_skip_verify is unset:\n%s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #113.

The vault source quietly accepted `tls_skip_verify=true` and switched to an `InsecureSkipVerify` TLS config with only a `//nolint:gosec` marker. Combined with the transport's `Proxy: http.ProxyFromEnvironment`, this let an attacker who can set `HTTPS_PROXY` in the agent's environment MITM every Vault token login and KV fetch.

## Fix
- Log a structured `WARN` line at `New()` time when `tls_skip_verify=true`. One line per source (not per fetch) so the log stays readable.
- Rewrite the schema help text from `"Bool; for dev-mode"` to an explicit INSECURE notice mentioning the `HTTPS_PROXY` MitM risk.

## Regression test
`TestNew_TLSSkipVerify_LogsWarning` captures slog output, asserts the WARN line fires for `tls_skip_verify=true`, and asserts no warning is emitted for a clean source.

## Test plan
- [x] Test fails on main, passes on this branch.
- [x] `go test ./...` clean.
- [ ] CI passes.