### PR TITLE
fix(tui): encrypt-by-default for source params on save (#112)

### DIFF
--- a/internal/tui/save.go
+++ b/internal/tui/save.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
-	"github.com/gv/jitenv/internal/sources"
-	"github.com/gv/jitenv/pkg/source"
 )
 
 // saveCmd takes a snapshot of the in-memory config, re-encrypts every
@@ -88,17 +86,18 @@ func cloneForSave(c *config.Config) *config.Config {
 // encryptForSave walks the config and re-encrypts every value that
 // must not be on disk in plaintext. It assumes c was decrypted on
 // load: every sensitive param is currently a plaintext string.
+//
+// Encrypt-by-default: every non-envelope string param is encrypted,
+// regardless of whether the source's schema flagged it Sensitive
+// (security #112). A schema-only gate silently leaked params for
+// sources without a registered schema and for fields a source author
+// forgot to flag. The schema's `Sensitive` bit is still meaningful
+// — the TUI uses it to mask the field in the editor — but it no
+// longer controls disk encryption.
 func encryptForSave(c *config.Config, key []byte) error {
 	for name, sc := range c.Sources {
 		if sc.Params == nil {
 			continue
-		}
-		schema := schemaFor(sc.Type)
-		sensitive := map[string]struct{}{}
-		for _, f := range schema {
-			if f.Sensitive {
-				sensitive[f.Key] = struct{}{}
-			}
 		}
 		for k, v := range sc.Params {
 			s, ok := v.(string)
@@ -107,9 +106,6 @@ func encryptForSave(c *config.Config, key []byte) error {
 			}
 			if crypto.IsEnvelope(s) {
 				// Already encrypted (e.g. unchanged on this save).
-				continue
-			}
-			if _, isSensitive := sensitive[k]; !isSensitive {
 				continue
 			}
 			env, err := crypto.EncryptField(key, s)
@@ -132,9 +128,4 @@ func encryptForSave(c *config.Config, key []byte) error {
 		}
 	}
 	return nil
-}
-
-// schemaFor returns the registered parameter schema for a source type.
-func schemaFor(typeName string) []source.ParamField {
-	return sources.Schema(typeName)
 }

--- a/internal/tui/save_test.go
+++ b/internal/tui/save_test.go
@@ -70,9 +70,15 @@ func TestEncryptForSave_RoundTrip(t *testing.T) {
 	if !crypto.IsEnvelope(sak) {
 		t.Fatalf("secret_access_key not encrypted on disk: %q", sak)
 	}
+	// Security #112: encrypt-by-default. Every non-envelope string
+	// param must land on disk as an envelope, regardless of whether
+	// the schema flagged it Sensitive. The previous behaviour treated
+	// the schema as the sole gate, which silently leaked params from
+	// sources without a registered schema (or sources where an author
+	// forgot the Sensitive flag).
 	region := reloaded.Sources["prod_aws"].Params["region"].(string)
-	if crypto.IsEnvelope(region) {
-		t.Fatalf("non-sensitive region got encrypted: %q", region)
+	if !crypto.IsEnvelope(region) {
+		t.Fatalf("non-sensitive region was NOT encrypted on disk: %q", region)
 	}
 	for _, v := range reloaded.Secrets["stripe"] {
 		if !crypto.IsEnvelope(v) {
@@ -87,7 +93,67 @@ func TestEncryptForSave_RoundTrip(t *testing.T) {
 	if reloaded.Sources["prod_aws"].Params["secret_access_key"] != "AWSsupersecret" {
 		t.Fatalf("secret_access_key round-trip broken: %v", reloaded.Sources["prod_aws"].Params["secret_access_key"])
 	}
+	if reloaded.Sources["prod_aws"].Params["region"] != "us-east-1" {
+		t.Fatalf("region round-trip broken: %v", reloaded.Sources["prod_aws"].Params["region"])
+	}
 	if reloaded.Secrets["stripe"]["PK"] != "pk_live_x" {
 		t.Fatalf("PK round-trip: %v", reloaded.Secrets["stripe"]["PK"])
+	}
+}
+
+// TestEncryptForSave_EncryptsParamsWithoutSchema is the regression for
+// security #112: a source type whose schema is missing entirely (e.g.
+// `noop` — registered but with no RegisterSchema call) MUST still get
+// its string params encrypted on save. The previous schema-only gate
+// would silently leak any value typed into the TUI's generic editor.
+func TestEncryptForSave_EncryptsParamsWithoutSchema(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+
+	// `noop` is the schema-less source; a user-entered string in the
+	// generic editor lands in Params as a bare string.
+	c.Sources = map[string]config.SourceConfig{
+		"myop": {Type: "noop", Params: map[string]any{
+			"opaque_token": "shhh-this-is-a-secret-someone-typed-here",
+		}},
+	}
+	c.Mappings = []config.Mapping{
+		{Path: "/x", Vars: []config.VarRef{{Name: "TOKEN", Source: "myop"}}},
+	}
+
+	out := cloneForSave(c)
+	if err := encryptForSave(out, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := config.AtomicSave(path, out); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	reloaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	v := reloaded.Sources["myop"].Params["opaque_token"].(string)
+	if !crypto.IsEnvelope(v) {
+		t.Fatalf("schema-less param was NOT encrypted on disk: %q", v)
+	}
+	if err := config.DecryptInPlace(reloaded, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if reloaded.Sources["myop"].Params["opaque_token"] != "shhh-this-is-a-secret-someone-typed-here" {
+		t.Fatalf("round-trip broken: %v", reloaded.Sources["myop"].Params["opaque_token"])
 	}
 }

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -37,11 +37,18 @@ type Constructor func(cfg map[string]any) (Source, error)
 // uses these to render form fields (mask sensitive values, validate
 // required fields, present enum choices). Sources that omit a schema
 // fall back to a generic key/value editor.
+//
+// NOTE on `Sensitive`: as of the encrypt-by-default change (#112), the
+// save pipeline encrypts EVERY non-envelope string param on disk, not
+// just the ones flagged Sensitive here. This flag is purely a TUI
+// affordance now — it controls whether the field is masked while
+// editing and whether it's listed under the secret-key picker. Do NOT
+// rely on it as a "this stays plaintext on disk" signal.
 type ParamField struct {
 	Key       string   // map key under [sources.<name>.params]
 	Label     string   // human-readable label; falls back to Key when empty
 	Required  bool     // form rejects save when empty
-	Sensitive bool     // mask in TUI; encrypt with master key on save
+	Sensitive bool     // mask in TUI; ALL string params encrypt on save regardless
 	Enum      []string // optional fixed-choice list
 	Help      string   // optional one-line help text
 }


### PR DESCRIPTION
## Summary
Closes #112.

`encryptForSave` previously only encrypted params whose key was both:
- in the source type's registered schema, AND
- flagged `Sensitive: true` on that schema entry.

That double-gate silently leaked any string typed into the TUI's generic key/value editor against (a) a source type with no registered schema (e.g. \`noop\`), (b) a known-schema source where the author forgot the \`Sensitive\` flag, or (c) ad-hoc params a user added through the free-form editor.

## Fix
Switch to encrypt-by-default: every non-envelope string param is encrypted on save, full stop. \`ParamField.Sensitive\` stays meaningful for the TUI (mask-while-editing + secret-key picker) but no longer governs disk encryption. The doc comment on \`ParamField\` is updated so future source authors can't be confused.

## Regression tests
- \`TestEncryptForSave_RoundTrip\` now asserts the AWS \`region\` field (previously plaintext) is encrypted on disk.
- \`TestEncryptForSave_EncryptsParamsWithoutSchema\` covers the noop-source case directly.

## Test plan
- [x] Both tests fail on \`main\`, pass on this branch.
- [x] \`go test ./...\` clean.
- [ ] CI passes.