### PR TITLE
fix(config,crypto): reject KDF parameters below documented floors (#111)

### DIFF
--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -67,6 +67,23 @@ func DeriveKeyFromMeta(c *Config, passphrase []byte) ([]byte, error) {
 		MemKiB:  nz(c.Meta.ArgonMemoryKiB, crypto.DefaultArgonMemKiB),
 		Threads: nzU8(c.Meta.ArgonThreads, crypto.DefaultArgonThreads),
 	}
+	// Reject KDF params below documented floors. Without this check a
+	// config-write attacker can drop argon_time to 1 and argon_memory_kib
+	// to a few KiB so the next derive (and any offline brute-force
+	// against a leaked memory/swap dump) costs almost nothing
+	// (security #111).
+	if params.Time < crypto.MinArgonTime {
+		return nil, fmt.Errorf("config _meta.argon_time=%d is below minimum %d; re-init with `jitenv config init`", params.Time, crypto.MinArgonTime)
+	}
+	if params.MemKiB < crypto.MinArgonMemKiB {
+		return nil, fmt.Errorf("config _meta.argon_memory_kib=%d is below minimum %d (OWASP floor); re-init with `jitenv config init`", params.MemKiB, crypto.MinArgonMemKiB)
+	}
+	if params.Threads < crypto.MinArgonThreads {
+		return nil, fmt.Errorf("config _meta.argon_threads=%d is below minimum %d; re-init with `jitenv config init`", params.Threads, crypto.MinArgonThreads)
+	}
+	if len(salt) < crypto.MinSaltLen {
+		return nil, fmt.Errorf("config _meta.salt is %d bytes; minimum %d", len(salt), crypto.MinSaltLen)
+	}
 	key := crypto.DeriveKey(passphrase, salt, params)
 	if pt, err := crypto.DecryptField(key, c.Meta.Verify); err != nil || pt != verifySentinel {
 		zero(key)

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -3,8 +3,65 @@ package config
 import (
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
+
+// TestDeriveKeyFromMeta_RejectsWeakArgonParams is the regression for
+// security #111: the KDF parameters in [_meta] are stored unauthenticated
+// on disk. An attacker who can write to config.toml could otherwise drop
+// argon_time to 1 and argon_memory_kib to a few KiB so the next derive
+// (and any offline attempt against a leaked memory/swap dump) costs
+// almost nothing. Reject configs whose params are below documented
+// floors at derive time.
+func TestDeriveKeyFromMeta_RejectsWeakArgonParams(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Sanity: default-init params must derive cleanly.
+	if _, err := DeriveKeyFromMeta(c, pw); err != nil {
+		t.Fatalf("default params should derive: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		mut  func(*Meta)
+		want string
+	}{
+		{"time too low", func(m *Meta) { m.ArgonTime = 1 }, "argon_time"},
+		{"memory too low", func(m *Meta) { m.ArgonMemoryKiB = 8 }, "argon_memory"},
+		{"threads zero would be replaced by default", nil, ""}, // sanity entry; threads=0 is preserved as default via nzU8
+	}
+	for _, tc := range cases {
+		if tc.mut == nil {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			// Reload fresh each iteration so previous mutations don't
+			// taint the next subtest.
+			c2, err := Load(path)
+			if err != nil {
+				t.Fatalf("reload: %v", err)
+			}
+			tc.mut(&c2.Meta)
+			_, err = DeriveKeyFromMeta(c2, pw)
+			if err == nil {
+				t.Fatalf("expected error for weak %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q missing expected mention of %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
 
 func TestInitAndDeriveKey(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/crypto/kdf.go
+++ b/internal/crypto/kdf.go
@@ -15,6 +15,23 @@ const (
 	SaltLen                    = 16
 )
 
+// Minimum Argon2id parameters. Configs whose [_meta] specifies values
+// below these floors are rejected at derive time (security #111): the
+// params are stored unauthenticated on disk, so without floors a
+// config-write attacker can silently weaken the KDF and reduce the
+// cost of offline brute-force against a leaked memory/swap dump.
+//
+// MinArgonMemKiB tracks the OWASP Password Storage cheat sheet's
+// Argon2id minimum of 19 MiB; the rest are conservative floors well
+// below the project defaults so legitimately-strict (but slower)
+// configurations remain valid.
+const (
+	MinArgonTime    uint32 = 2
+	MinArgonMemKiB  uint32 = 19 * 1024
+	MinArgonThreads uint8  = 1
+	MinSaltLen             = 16
+)
+
 type ArgonParams struct {
 	Time    uint32
 	MemKiB  uint32


### PR DESCRIPTION
## Summary
Closes #111.

`[_meta]` holds `argon_time` / `argon_memory_kib` / `argon_threads` / `salt` as plaintext, unauthenticated TOML fields. A config-write attacker could drop the parameters to near-zero so the next legitimate unlock derives the KEK cheaply — and any offline brute-force against a leaked memory/swap/core-dump becomes correspondingly cheap.

## Fix
Add minimum constants in `internal/crypto/kdf.go` and a guard in `DeriveKeyFromMeta`:

| param | min |
|---|---|
| `MinArgonTime` | 2 |
| `MinArgonMemKiB` | 19 × 1024 (OWASP) |
| `MinArgonThreads` | 1 |
| `MinSaltLen` | 16 |

Reject configs below the floors at derive time with a clear error that points the user at `jitenv config init`. Default-init params already exceed all minimums, so existing configs continue to work unchanged.

## Regression test
`TestDeriveKeyFromMeta_RejectsWeakArgonParams` mutates a freshly-init'd config's `[_meta]` to set `argon_time=1` / `argon_memory_kib=8`, asserts `DeriveKeyFromMeta` returns an error mentioning the offending param.

## Test plan
- [x] Test fails on `main` (incorrect-passphrase generic error), passes on this branch.
- [x] `go test ./...` clean.
- [ ] CI passes.