### PR TITLE
fix(crypto,config,tui,seed): bind envelopes to per-slot AAD (#110)

### DIFF
--- a/e2e/seed/seed.go
+++ b/e2e/seed/seed.go
@@ -196,11 +196,11 @@ func run(o runOpts) error {
 // expands the bag. fooVal/barVal let the caller produce distinguishable
 // fixtures (used by local-alt to differentiate before/after a reload).
 func applyLocal(cfg *config.Config, key []byte, scriptPath, fooVal, barVal string) error {
-	foo, err := crypto.EncryptField(key, fooVal)
+	foo, err := crypto.EncryptField(key, fooVal, config.SecretAAD("demo", "FOO"))
 	if err != nil {
 		return err
 	}
-	bar, err := crypto.EncryptField(key, barVal)
+	bar, err := crypto.EncryptField(key, barVal, config.SecretAAD("demo", "BAR"))
 	if err != nil {
 		return err
 	}
@@ -226,15 +226,15 @@ func applyLocal(cfg *config.Config, key []byte, scriptPath, fooVal, barVal strin
 // (instead of an exact Path) and a bag with three keys that all expand
 // via a single empty-Name VarRef.
 func applyLocalGlob(cfg *config.Config, key []byte, globPath string) error {
-	foo, err := crypto.EncryptField(key, "value-from-local-foo")
+	foo, err := crypto.EncryptField(key, "value-from-local-foo", config.SecretAAD("demo", "FOO"))
 	if err != nil {
 		return err
 	}
-	bar, err := crypto.EncryptField(key, "value-from-local-bar")
+	bar, err := crypto.EncryptField(key, "value-from-local-bar", config.SecretAAD("demo", "BAR"))
 	if err != nil {
 		return err
 	}
-	baz, err := crypto.EncryptField(key, "value-from-local-baz")
+	baz, err := crypto.EncryptField(key, "value-from-local-baz", config.SecretAAD("demo", "BAZ"))
 	if err != nil {
 		return err
 	}
@@ -260,11 +260,11 @@ func applyLocalGlob(cfg *config.Config, key []byte, globPath string) error {
 // matching cwdGlob (or any descendant). Used by the PowerShell hook
 // scenarios to drive the chpwd → wrapper → shim → agent flow.
 func applyLocalCwdGlob(cfg *config.Config, key []byte, cwdGlob string, commands []string) error {
-	foo, err := crypto.EncryptField(key, "value-from-local-foo")
+	foo, err := crypto.EncryptField(key, "value-from-local-foo", config.SecretAAD("demo", "FOO"))
 	if err != nil {
 		return err
 	}
-	bar, err := crypto.EncryptField(key, "value-from-local-bar")
+	bar, err := crypto.EncryptField(key, "value-from-local-bar", config.SecretAAD("demo", "BAR"))
 	if err != nil {
 		return err
 	}
@@ -303,11 +303,11 @@ func splitCommas(s string) []string {
 // endpoint. Static creds are used because LocalStack accepts any string.
 // We only fetch a single JSON key (FOO) to also exercise that path.
 func applyLocalstack(cfg *config.Config, key []byte, scriptPath, smARN, smEndpoint string) error {
-	akid, err := crypto.EncryptField(key, "test")
+	akid, err := crypto.EncryptField(key, "test", config.SourceParamAAD("awssm", "access_key_id"))
 	if err != nil {
 		return err
 	}
-	sak, err := crypto.EncryptField(key, "test")
+	sak, err := crypto.EncryptField(key, "test", config.SourceParamAAD("awssm", "secret_access_key"))
 	if err != nil {
 		return err
 	}
@@ -343,11 +343,11 @@ func applyLocalstack(cfg *config.Config, key []byte, scriptPath, smARN, smEndpoi
 // child's env. The v1 mount is created by the scenario via the Vault
 // HTTP API; the seed itself only writes config.toml.
 func applyVault(cfg *config.Config, key []byte, o runOpts) error {
-	tokV2, err := crypto.EncryptField(key, o.vaultToken)
+	tokV2, err := crypto.EncryptField(key, o.vaultToken, config.SourceParamAAD("vault-kv2", "token"))
 	if err != nil {
 		return err
 	}
-	tokV1, err := crypto.EncryptField(key, o.vaultToken)
+	tokV1, err := crypto.EncryptField(key, o.vaultToken, config.SourceParamAAD("vault-kv1", "token"))
 	if err != nil {
 		return err
 	}

--- a/internal/config/decrypt.go
+++ b/internal/config/decrypt.go
@@ -6,15 +6,21 @@ import (
 	"github.com/gv/jitenv/internal/crypto"
 )
 
-// DecryptInPlace walks every enc:v1: envelope in c (Sources[*].Params and
-// Secrets[*][*]) and replaces it with its plaintext. Plaintext fields are
-// left untouched. Called once by the agent at unlock.
+// DecryptInPlace walks every envelope in c (Sources[*].Params and
+// Secrets[*][*]) and replaces it with its plaintext. Plaintext fields
+// are left untouched. Called once by the agent at unlock.
+//
+// Each decrypt call passes the value's canonical AAD context so the
+// AEAD tag verifies the envelope is in the right slot (security #110).
+// Existing enc:v1 envelopes have no AAD to verify against and continue
+// to decrypt for backward compatibility — they upgrade to v2 on the
+// next save.
 func DecryptInPlace(c *Config, key []byte) error {
 	for name, s := range c.Sources {
 		if s.Params == nil {
 			continue
 		}
-		if err := crypto.DecryptStringsInPlace(key, s.Params); err != nil {
+		if err := crypto.DecryptStringsInPlace(key, s.Params, crypto.AAD("src", name)); err != nil {
 			return fmt.Errorf("decrypt source %q: %w", name, err)
 		}
 	}
@@ -23,7 +29,7 @@ func DecryptInPlace(c *Config, key []byte) error {
 			if !crypto.IsEnvelope(v) {
 				continue
 			}
-			pt, err := crypto.DecryptField(key, v)
+			pt, err := crypto.DecryptField(key, v, SecretAAD(bag, k))
 			if err != nil {
 				return fmt.Errorf("decrypt secret %q.%q: %w", bag, k, err)
 			}

--- a/internal/config/decrypt_test.go
+++ b/internal/config/decrypt_test.go
@@ -24,8 +24,8 @@ func TestDecryptInPlace(t *testing.T) {
 	}
 	defer zero(key)
 
-	encToken, _ := crypto.EncryptField(key, "real-token")
-	encDB, _ := crypto.EncryptField(key, "postgres://x")
+	encToken, _ := crypto.EncryptField(key, "real-token", SourceParamAAD("vault", "access_key_id"))
+	encDB, _ := crypto.EncryptField(key, "postgres://x", SecretAAD("app", "DB_URL"))
 	c.Sources = map[string]SourceConfig{
 		"vault": {Type: "aws", Params: map[string]any{"access_key_id": encToken, "region": "us-east-1"}},
 	}
@@ -47,5 +47,50 @@ func TestDecryptInPlace(t *testing.T) {
 	}
 	if got := c.Secrets["app"]["PLAIN"]; got != "still-plain" {
 		t.Fatalf("plaintext secret value mutated: %q", got)
+	}
+}
+
+// TestDecryptInPlace_RejectsTransplantedEnvelope is the end-to-end
+// regression for security #110: an envelope sealed against slot A
+// must fail to decrypt when placed at slot B in the config, even
+// when the master key is correct.
+func TestDecryptInPlace_RejectsTransplantedEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+
+	// Seal a value bound to one slot, transplant it into another.
+	envForToken, _ := crypto.EncryptField(key, "real-token", SourceParamAAD("vault", "token"))
+
+	c.Sources = map[string]SourceConfig{
+		// Place the (token-bound) envelope into a different param slot.
+		"aws": {Type: "aws", Params: map[string]any{"secret_access_key": envForToken}},
+	}
+	err = DecryptInPlace(c, key)
+	if err == nil {
+		t.Fatal("DecryptInPlace must reject envelope transplanted to a different param slot")
+	}
+
+	// Same envelope under the right name still decrypts.
+	c.Sources = map[string]SourceConfig{
+		"vault": {Type: "vault", Params: map[string]any{"token": envForToken}},
+	}
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("DecryptInPlace must accept envelope in its bound slot: %v", err)
+	}
+	if got := c.Sources["vault"].Params["token"]; got != "real-token" {
+		t.Fatalf("decrypted plaintext: %v", got)
 	}
 }

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -14,6 +14,27 @@ import (
 
 const verifySentinel = "jitenv-ok"
 
+// metaVerifyAAD is the associated-data string that binds the [_meta]
+// verify envelope to its slot. Mirrored on encrypt (InitNew) and
+// decrypt (DeriveKeyFromMeta) — changing either side independently
+// would break the passphrase check (security #110).
+const metaVerifyAAD = "meta.verify"
+
+// SourceParamAAD builds the AAD context for a value stored under
+// [sources.<name>.params.<key>]. Both the TUI save pipeline and the
+// agent's resolver must agree on this exact string; the dotted form
+// matches what DecryptStringsInPlace produces when fed ctx=
+// "src."+name.
+func SourceParamAAD(sourceName, paramKey string) string {
+	return crypto.AAD("src", sourceName, paramKey)
+}
+
+// SecretAAD builds the AAD context for a value stored under
+// [secrets.<bag>.<key>].
+func SecretAAD(bag, key string) string {
+	return crypto.AAD("secret", bag, key)
+}
+
 // InitNew creates a brand-new encrypted config at path. The file is written
 // atomically with 0600.
 func InitNew(path string, passphrase []byte) error {
@@ -28,7 +49,7 @@ func InitNew(path string, passphrase []byte) error {
 	key := crypto.DeriveKey(passphrase, salt, params)
 	defer zero(key)
 
-	verify, err := crypto.EncryptField(key, verifySentinel)
+	verify, err := crypto.EncryptField(key, verifySentinel, metaVerifyAAD)
 	if err != nil {
 		return err
 	}
@@ -68,7 +89,7 @@ func DeriveKeyFromMeta(c *Config, passphrase []byte) ([]byte, error) {
 		Threads: nzU8(c.Meta.ArgonThreads, crypto.DefaultArgonThreads),
 	}
 	key := crypto.DeriveKey(passphrase, salt, params)
-	if pt, err := crypto.DecryptField(key, c.Meta.Verify); err != nil || pt != verifySentinel {
+	if pt, err := crypto.DecryptField(key, c.Meta.Verify, metaVerifyAAD); err != nil || pt != verifySentinel {
 		zero(key)
 		return nil, errors.New("incorrect passphrase")
 	}

--- a/internal/crypto/aead.go
+++ b/internal/crypto/aead.go
@@ -8,9 +8,12 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
-// Seal encrypts plaintext under key using XChaCha20-Poly1305.
-// The returned blob is nonce || ciphertext || tag.
-func Seal(key, plaintext []byte) ([]byte, error) {
+// Seal encrypts plaintext under key using XChaCha20-Poly1305, binding
+// the resulting ciphertext to the supplied associated data via the
+// AEAD tag. The returned blob is nonce || ciphertext || tag. ad may
+// be nil for legacy callers; new envelopes (security #110) must
+// always pass a non-empty per-call context.
+func Seal(key, plaintext, ad []byte) ([]byte, error) {
 	if len(key) != int(KeyLen) {
 		return nil, fmt.Errorf("seal: key must be %d bytes, got %d", KeyLen, len(key))
 	}
@@ -22,15 +25,17 @@ func Seal(key, plaintext []byte) ([]byte, error) {
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, err
 	}
-	ct := aead.Seal(nil, nonce, plaintext, nil)
+	ct := aead.Seal(nil, nonce, plaintext, ad)
 	out := make([]byte, 0, len(nonce)+len(ct))
 	out = append(out, nonce...)
 	out = append(out, ct...)
 	return out, nil
 }
 
-// Open decrypts a blob produced by Seal.
-func Open(key, blob []byte) ([]byte, error) {
+// Open decrypts a blob produced by Seal. The supplied ad must match
+// what Seal was called with; otherwise the AEAD tag check fails and
+// an error is returned.
+func Open(key, blob, ad []byte) ([]byte, error) {
 	if len(key) != int(KeyLen) {
 		return nil, fmt.Errorf("open: key must be %d bytes, got %d", KeyLen, len(key))
 	}
@@ -42,5 +47,5 @@ func Open(key, blob []byte) ([]byte, error) {
 		return nil, errors.New("open: ciphertext too short")
 	}
 	nonce, ct := blob[:aead.NonceSize()], blob[aead.NonceSize():]
-	return aead.Open(nil, nonce, ct, nil)
+	return aead.Open(nil, nonce, ct, ad)
 }

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,9 +1,12 @@
 package crypto
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 )
+
+func b64encode(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
 
 func mustKey(t *testing.T) []byte {
 	t.Helper()
@@ -17,11 +20,11 @@ func mustKey(t *testing.T) []byte {
 func TestSealOpenRoundTrip(t *testing.T) {
 	key := mustKey(t)
 	for _, pt := range []string{"", "hello", strings.Repeat("x", 4096)} {
-		blob, err := Seal(key, []byte(pt))
+		blob, err := Seal(key, []byte(pt), []byte("test.ad"))
 		if err != nil {
 			t.Fatalf("seal: %v", err)
 		}
-		got, err := Open(key, blob)
+		got, err := Open(key, blob, []byte("test.ad"))
 		if err != nil {
 			t.Fatalf("open: %v", err)
 		}
@@ -34,25 +37,25 @@ func TestSealOpenRoundTrip(t *testing.T) {
 func TestOpenWrongKeyFails(t *testing.T) {
 	k1 := mustKey(t)
 	k2 := mustKey(t)
-	blob, err := Seal(k1, []byte("secret"))
+	blob, err := Seal(k1, []byte("secret"), []byte("test.ad"))
 	if err != nil {
 		t.Fatalf("seal: %v", err)
 	}
-	if _, err := Open(k2, blob); err == nil {
+	if _, err := Open(k2, blob, []byte("test.ad")); err == nil {
 		t.Fatalf("expected open with wrong key to fail")
 	}
 }
 
 func TestEnvelopeRoundTrip(t *testing.T) {
 	key := mustKey(t)
-	env, err := EncryptField(key, "hunter2")
+	env, err := EncryptField(key, "hunter2", "test.ad")
 	if err != nil {
 		t.Fatalf("encrypt: %v", err)
 	}
 	if !IsEnvelope(env) {
 		t.Fatalf("expected envelope prefix, got %q", env)
 	}
-	pt, err := DecryptField(key, env)
+	pt, err := DecryptField(key, env, "test.ad")
 	if err != nil {
 		t.Fatalf("decrypt: %v", err)
 	}
@@ -63,30 +66,32 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 
 func TestDecryptFieldRejectsMalformed(t *testing.T) {
 	key := mustKey(t)
-	if _, err := DecryptField(key, "not-an-envelope"); err == nil {
+	if _, err := DecryptField(key, "not-an-envelope", "test.ad"); err == nil {
 		t.Fatalf("expected error for non-envelope")
 	}
-	if _, err := DecryptField(key, EnvelopePrefix+"!!!not-base64!!!"); err == nil {
+	if _, err := DecryptField(key, EnvelopePrefix+"!!!not-base64!!!", "test.ad"); err == nil {
 		t.Fatalf("expected error for malformed base64")
 	}
-	if _, err := DecryptField(key, EnvelopePrefix+"YWFh"); err == nil {
+	if _, err := DecryptField(key, EnvelopePrefix+"YWFh", "test.ad"); err == nil {
 		t.Fatalf("expected error for short blob")
 	}
 }
 
 func TestDecryptStringsInPlace(t *testing.T) {
 	key := mustKey(t)
-	encA, _ := EncryptField(key, "valueA")
-	encB, _ := EncryptField(key, "valueB")
+	const ctx = "src.testsrc"
+	encA, _ := EncryptField(key, "valueA", ctx+".a")
+	encB, _ := EncryptField(key, "valueB", ctx+".nested.b")
+	encL, _ := EncryptField(key, "valueA", ctx+".list[1]")
 	m := map[string]any{
 		"a":     encA,
 		"plain": "stay",
 		"nested": map[string]any{
 			"b": encB,
 		},
-		"list": []any{"plain", encA},
+		"list": []any{"plain", encL},
 	}
-	if err := DecryptStringsInPlace(key, m); err != nil {
+	if err := DecryptStringsInPlace(key, m, ctx); err != nil {
 		t.Fatalf("decrypt walk: %v", err)
 	}
 	if m["a"].(string) != "valueA" {
@@ -100,6 +105,63 @@ func TestDecryptStringsInPlace(t *testing.T) {
 	}
 	if m["list"].([]any)[1].(string) != "valueA" {
 		t.Fatalf("list[1]: %v", m["list"])
+	}
+}
+
+// TestEnvelopeRejectsTransplant is the regression for security #110:
+// an enc:v2 envelope MUST refuse to decrypt under a different AD than
+// the one it was sealed with. This is what stops a config-write
+// attacker from swapping a vault_token envelope into an
+// aws_secret_access_key slot (or any other slot) and tricking the
+// agent into handing the wrong plaintext to the wrong consumer.
+func TestEnvelopeRejectsTransplant(t *testing.T) {
+	key := mustKey(t)
+	env, err := EncryptField(key, "secret-value", "src.aws.secret_access_key")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// Correct AD: must succeed.
+	pt, err := DecryptField(key, env, "src.aws.secret_access_key")
+	if err != nil {
+		t.Fatalf("decrypt with correct ad: %v", err)
+	}
+	if pt != "secret-value" {
+		t.Fatalf("unexpected plaintext: %q", pt)
+	}
+
+	// Wrong AD (transplanted to a different slot): must fail.
+	if _, err := DecryptField(key, env, "src.aws.access_key_id"); err == nil {
+		t.Fatal("decrypt with wrong ad must fail (transplantation)")
+	}
+	if _, err := DecryptField(key, env, "secret.stripe.SK"); err == nil {
+		t.Fatal("decrypt with cross-section ad must fail")
+	}
+	if _, err := DecryptField(key, env, ""); err == nil {
+		t.Fatal("decrypt with empty ad must fail when envelope is v2")
+	}
+}
+
+// TestEnvelopeAcceptsLegacyV1 covers backward compatibility: an enc:v1
+// envelope (produced before the AAD migration) must still decrypt on
+// the read path, regardless of the ad argument — there's nothing to
+// verify against, so we accept it and rely on re-save to upgrade.
+func TestEnvelopeAcceptsLegacyV1(t *testing.T) {
+	key := mustKey(t)
+	// Construct a legacy v1 envelope (no AAD) by sealing with nil AD
+	// and prefixing the legacy tag.
+	blob, err := Seal(key, []byte("legacy-value"), nil)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	v1 := EnvelopeLegacyV1Prefix + b64encode(blob)
+
+	pt, err := DecryptField(key, v1, "any.context.string")
+	if err != nil {
+		t.Fatalf("decrypt v1 with arbitrary ad must succeed: %v", err)
+	}
+	if pt != "legacy-value" {
+		t.Fatalf("unexpected plaintext: %q", pt)
 	}
 }
 

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -3,65 +3,128 @@ package crypto
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"strings"
 )
 
-const EnvelopePrefix = "enc:v1:"
+// Envelope format. New writes are always enc:v2: with the value bound
+// to a per-call associated-data string (security #110). Reads accept
+// both forms so existing on-disk configs continue to load; the agent
+// (or TUI save) upgrades them on the next save.
+const (
+	EnvelopePrefix         = "enc:v2:" // current — AAD-bound
+	EnvelopeLegacyV1Prefix = "enc:v1:" // legacy — no AAD; accept-on-read only
+)
 
-// IsEnvelope reports whether s looks like an enc:v1: envelope.
+// IsEnvelope reports whether s looks like any supported envelope.
 func IsEnvelope(s string) bool {
-	return strings.HasPrefix(s, EnvelopePrefix)
+	return strings.HasPrefix(s, EnvelopePrefix) ||
+		strings.HasPrefix(s, EnvelopeLegacyV1Prefix)
 }
 
-// EncryptField wraps plaintext into an enc:v1: string.
-func EncryptField(key []byte, plaintext string) (string, error) {
-	blob, err := Seal(key, []byte(plaintext))
+// AAD constructs a canonical associated-data string by joining the
+// parts with dots. Callers should use this to keep encrypt/decrypt
+// sides in sync: a typo in one place silently makes envelopes
+// undecryptable in the other. Empty parts panic — they indicate a
+// bug at the call site (e.g. a missing source name).
+func AAD(parts ...string) string {
+	if len(parts) == 0 {
+		panic("crypto.AAD: at least one part required")
+	}
+	for i, p := range parts {
+		if p == "" {
+			panic(fmt.Sprintf("crypto.AAD: part %d is empty", i))
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+// EncryptField wraps plaintext into an enc:v2: envelope bound to ad.
+// ad must be non-empty: a per-call context derived from the value's
+// location in the config (e.g. "src.aws.secret_access_key"). Without
+// it, an attacker who can write to the config can transplant a
+// ciphertext from one slot into another and the agent would happily
+// hand the wrong plaintext to the wrong consumer.
+func EncryptField(key []byte, plaintext, ad string) (string, error) {
+	if ad == "" {
+		return "", errors.New("EncryptField: ad must be non-empty")
+	}
+	blob, err := Seal(key, []byte(plaintext), []byte(ad))
 	if err != nil {
 		return "", err
 	}
 	return EnvelopePrefix + base64.StdEncoding.EncodeToString(blob), nil
 }
 
-// DecryptField unwraps an enc:v1: string.
-func DecryptField(key []byte, env string) (string, error) {
-	if !IsEnvelope(env) {
-		return "", errors.New("not an enc:v1: envelope")
+// DecryptField unwraps an envelope.
+//
+// For enc:v2: the supplied ad MUST match the one passed to
+// EncryptField; otherwise the AEAD tag check fails.
+//
+// For enc:v1: (legacy, pre-AAD), ad is ignored — those envelopes were
+// sealed with nil AD and have no provenance to verify against. They
+// remain readable so existing configs keep working; the TUI save
+// pipeline rewrites them as v2 on the next save.
+func DecryptField(key []byte, env, ad string) (string, error) {
+	switch {
+	case strings.HasPrefix(env, EnvelopePrefix):
+		if ad == "" {
+			return "", errors.New("DecryptField: ad must be non-empty for enc:v2")
+		}
+		blob, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(env, EnvelopePrefix))
+		if err != nil {
+			return "", err
+		}
+		pt, err := Open(key, blob, []byte(ad))
+		if err != nil {
+			return "", err
+		}
+		return string(pt), nil
+	case strings.HasPrefix(env, EnvelopeLegacyV1Prefix):
+		blob, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(env, EnvelopeLegacyV1Prefix))
+		if err != nil {
+			return "", err
+		}
+		pt, err := Open(key, blob, nil) // legacy: pre-AAD, ignore ad
+		if err != nil {
+			return "", err
+		}
+		return string(pt), nil
+	default:
+		return "", errors.New("not an envelope")
 	}
-	blob, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(env, EnvelopePrefix))
-	if err != nil {
-		return "", err
-	}
-	pt, err := Open(key, blob)
-	if err != nil {
-		return "", err
-	}
-	return string(pt), nil
 }
 
 // DecryptStringsInPlace walks a map[string]any and replaces every
-// enc:v1: string value with its plaintext. Nested maps and slices
-// of strings are also walked. Non-string values are left untouched.
-func DecryptStringsInPlace(key []byte, m map[string]any) error {
+// envelope string value with its plaintext. ctx is the dotted-path
+// prefix accumulated as the walker descends; each value's AAD is
+// constructed as ctx + "." + key (or ctx + "." + key + "[i]" for slice
+// elements). Callers pass the outer context — see config.DecryptInPlace
+// for the canonical naming ("src.<name>", "secret.<bag>").
+func DecryptStringsInPlace(key []byte, m map[string]any, ctx string) error {
+	if ctx == "" {
+		return errors.New("DecryptStringsInPlace: ctx must be non-empty")
+	}
 	for k, v := range m {
 		switch x := v.(type) {
 		case string:
 			if IsEnvelope(x) {
-				pt, err := DecryptField(key, x)
+				pt, err := DecryptField(key, x, ctx+"."+k)
 				if err != nil {
-					return err
+					return fmt.Errorf("%s.%s: %w", ctx, k, err)
 				}
 				m[k] = pt
 			}
 		case map[string]any:
-			if err := DecryptStringsInPlace(key, x); err != nil {
+			if err := DecryptStringsInPlace(key, x, ctx+"."+k); err != nil {
 				return err
 			}
 		case []any:
 			for i, item := range x {
 				if s, ok := item.(string); ok && IsEnvelope(s) {
-					pt, err := DecryptField(key, s)
+					pt, err := DecryptField(key, s, fmt.Sprintf("%s.%s[%d]", ctx, k, i))
 					if err != nil {
-						return err
+						return fmt.Errorf("%s.%s[%d]: %w", ctx, k, i, err)
 					}
 					x[i] = pt
 				}

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -211,8 +211,8 @@ func TestRunLocalBag(t *testing.T) {
 	}
 
 	// Build encrypted bag values exactly as the TUI's save path would.
-	pk, _ := crypto.EncryptField(key, "pk_live_x")
-	sk, _ := crypto.EncryptField(key, "sk_live_y")
+	pk, _ := crypto.EncryptField(key, "pk_live_x", config.SecretAAD("stripe", "STRIPE_PK"))
+	sk, _ := crypto.EncryptField(key, "sk_live_y", config.SecretAAD("stripe", "STRIPE_SK"))
 	cfg.Sources = map[string]config.SourceConfig{
 		"vault": {Type: "local"},
 	}

--- a/internal/sources/vault/vault_test.go
+++ b/internal/sources/vault/vault_test.go
@@ -455,16 +455,16 @@ func TestEnvelopeRoundTripIntoNew(t *testing.T) {
 		t.Fatalf("NewSalt: %v", err)
 	}
 	key := crypto.DeriveKey([]byte("correct horse battery staple"), salt, crypto.DefaultArgonParams())
-	tokenEnv, err := crypto.EncryptField(key, "real-token")
+	tokenEnv, err := crypto.EncryptField(key, "real-token", crypto.AAD("src", "vaultsrc", "token"))
 	if err != nil {
 		t.Fatalf("EncryptField: %v", err)
 	}
-	secretEnv, err := crypto.EncryptField(key, "real-secret-id")
+	secretEnv, err := crypto.EncryptField(key, "real-secret-id", crypto.AAD("src", "vaultsrc", "secret_id"))
 	if err != nil {
 		t.Fatalf("EncryptField: %v", err)
 	}
 	if !crypto.IsEnvelope(tokenEnv) || !crypto.IsEnvelope(secretEnv) {
-		t.Fatalf("envelopes not formed as enc:v1:")
+		t.Fatalf("envelopes not formed")
 	}
 
 	// Token-auth envelope round-trip.
@@ -473,7 +473,7 @@ func TestEnvelopeRoundTripIntoNew(t *testing.T) {
 		"auth_method": "token",
 		"token":       tokenEnv,
 	}
-	if err := crypto.DecryptStringsInPlace(key, params); err != nil {
+	if err := crypto.DecryptStringsInPlace(key, params, crypto.AAD("src", "vaultsrc")); err != nil {
 		t.Fatalf("DecryptStringsInPlace: %v", err)
 	}
 	if params["token"] != "real-token" {
@@ -490,7 +490,7 @@ func TestEnvelopeRoundTripIntoNew(t *testing.T) {
 		"role_id":     "rid",
 		"secret_id":   secretEnv,
 	}
-	if err := crypto.DecryptStringsInPlace(key, params2); err != nil {
+	if err := crypto.DecryptStringsInPlace(key, params2, crypto.AAD("src", "vaultsrc")); err != nil {
 		t.Fatalf("DecryptStringsInPlace: %v", err)
 	}
 	if params2["secret_id"] != "real-secret-id" {

--- a/internal/tui/save.go
+++ b/internal/tui/save.go
@@ -112,7 +112,7 @@ func encryptForSave(c *config.Config, key []byte) error {
 			if _, isSensitive := sensitive[k]; !isSensitive {
 				continue
 			}
-			env, err := crypto.EncryptField(key, s)
+			env, err := crypto.EncryptField(key, s, config.SourceParamAAD(name, k))
 			if err != nil {
 				return fmt.Errorf("source %q.%s: %w", name, k, err)
 			}
@@ -124,7 +124,7 @@ func encryptForSave(c *config.Config, key []byte) error {
 			if v == "" || crypto.IsEnvelope(v) {
 				continue
 			}
-			env, err := crypto.EncryptField(key, v)
+			env, err := crypto.EncryptField(key, v, config.SecretAAD(bag, k))
 			if err != nil {
 				return fmt.Errorf("secret %q.%s: %w", bag, k, err)
 			}


### PR DESCRIPTION
## Summary
Closes #110.

XChaCha20-Poly1305 was sealing with `nil` associated data, so every `enc:v1:` blob on disk was decryptable in any slot. An attacker with config-write rights could move a \`vault_token\` envelope into an \`aws_secret_access_key\` slot and the agent would hand the wrong plaintext to the wrong consumer.

## Fix
Introduce \`enc:v2:\` envelopes bound via the AEAD tag to a canonical AAD string derived from the value's location:

| slot | AAD |
|---|---|
| source param | \`src.<sourceName>.<paramKey>\` |
| local secret | \`secret.<bag>.<key>\` |
| meta verify | \`meta.verify\` |

### API changes (internal module only)
- \`crypto.Seal\` / \`crypto.Open\` now take an \`ad []byte\` argument.
- \`crypto.EncryptField\` / \`crypto.DecryptField\` now take an \`ad string\`.
- \`crypto.DecryptStringsInPlace\` now takes a \`ctx string\` prefix that the walker concatenates with the map key.
- \`crypto.AAD(parts...)\` builds canonical dotted strings; both sides must use it (or the helpers in \`config\`) to stay in sync.

### Backward compatibility
Reads still accept \`enc:v1:\` envelopes (legacy, no AAD), so existing on-disk configs continue to load. The next save rewrites them as \`enc:v2:\` with proper binding.

## Regression tests
- \`crypto.TestEnvelopeRejectsTransplant\` — \`enc:v2\` refuses to decrypt under any AAD other than the seal-time one.
- \`crypto.TestEnvelopeAcceptsLegacyV1\` — \`enc:v1\` still decrypts (legacy compat).
- \`config.TestDecryptInPlace_RejectsTransplantedEnvelope\` — end-to-end: a token-bound envelope dropped into a different source slot is rejected by \`DecryptInPlace\`.

## Test plan
- [x] All transplant tests fail on main, pass on this branch.
- [x] \`go test ./...\` clean.
- [ ] CI passes (incl. all e2e seed permutations).