### PR TITLE
fix(agent,shell): verify runtime dir ownership + 0700 mode (#117)

### DIFF
--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -56,9 +56,21 @@ func ResolvePaths() Paths {
 // dir (0700) so callers that need to bind a socket or open a log
 // file can rely on it existing. Use this from agent startup, chpwd,
 // etc.
+//
+// After MkdirAll, verify the resulting directory is owned by the
+// current user with mode 0700 (security #117). MkdirAll silently
+// accepts a pre-existing directory regardless of ownership/mode, so
+// without this check an attacker on a shared host (think the
+// /tmp/jitenv-<uid> fallback) could pre-create the dir and later
+// unlink the agent's socket or replace the log. The check is
+// platform-split; the Windows variant is a no-op because Windows
+// ACLs differ and the LOCALAPPDATA path is already per-user.
 func DefaultPaths() (Paths, error) {
 	p := ResolvePaths()
 	if err := os.MkdirAll(p.Dir, 0700); err != nil {
+		return Paths{}, err
+	}
+	if err := verifyRuntimeDir(p.Dir); err != nil {
 		return Paths{}, err
 	}
 	return p, nil

--- a/internal/agent/paths_unix.go
+++ b/internal/agent/paths_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // runtimeBaseDir returns the per-user runtime directory for the agent
@@ -23,4 +24,34 @@ func runtimeBaseDir() string {
 // the AF_UNIX socket file under the runtime base directory.
 func socketEndpoint(baseDir string) string {
 	return filepath.Join(baseDir, "agent.sock")
+}
+
+// verifyRuntimeDir asserts that dir is owned by the current uid and
+// has mode 0700 (security #117). MkdirAll silently accepts pre-
+// existing directories regardless of who owns them; on the
+// /tmp/jitenv-<uid> fallback another user could pre-create the path
+// and later unlink the agent's socket or replace it. Refusing to
+// start when the directory's metadata is wrong is the standard
+// mitigation (gpg-agent, ssh-agent, OpenSSH all do this).
+func verifyRuntimeDir(dir string) error {
+	st, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("verify runtime dir %s: %w", dir, err)
+	}
+	if !st.IsDir() {
+		return fmt.Errorf("runtime path %s is not a directory", dir)
+	}
+	if mode := st.Mode().Perm(); mode != 0o700 {
+		return fmt.Errorf("runtime dir %s has mode %#o, want 0700 (security #117)", dir, mode)
+	}
+	sys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		// Non-POSIX FS (rare). Mode check above already covers the
+		// high-risk case; don't block the user.
+		return nil
+	}
+	if int(sys.Uid) != os.Getuid() {
+		return fmt.Errorf("runtime dir %s owned by uid %d, want %d", dir, sys.Uid, os.Getuid())
+	}
+	return nil
 }

--- a/internal/agent/paths_unix.go
+++ b/internal/agent/paths_unix.go
@@ -31,8 +31,16 @@ func socketEndpoint(baseDir string) string {
 // existing directories regardless of who owns them; on the
 // /tmp/jitenv-<uid> fallback another user could pre-create the path
 // and later unlink the agent's socket or replace it. Refusing to
-// start when the directory's metadata is wrong is the standard
-// mitigation (gpg-agent, ssh-agent, OpenSSH all do this).
+// start when ownership is wrong is the standard mitigation
+// (gpg-agent, ssh-agent, OpenSSH all do this).
+//
+// Ownership is the load-bearing check. The mode bits are checked
+// second and self-repaired with a chmod(0700) when ownership is
+// correct: pre-#117 versions used `mkdir -p` with the user's umask
+// (typically 0022 → 0755), so an upgrade in place would otherwise
+// refuse to start until the user manually tightened the mode. We
+// own the dir, so only we (or someone already running as us) could
+// have created it that way — the chmod is safe and idempotent.
 func verifyRuntimeDir(dir string) error {
 	st, err := os.Lstat(dir)
 	if err != nil {
@@ -41,17 +49,14 @@ func verifyRuntimeDir(dir string) error {
 	if !st.IsDir() {
 		return fmt.Errorf("runtime path %s is not a directory", dir)
 	}
-	if mode := st.Mode().Perm(); mode != 0o700 {
-		return fmt.Errorf("runtime dir %s has mode %#o, want 0700 (security #117)", dir, mode)
-	}
 	sys, ok := st.Sys().(*syscall.Stat_t)
-	if !ok {
-		// Non-POSIX FS (rare). Mode check above already covers the
-		// high-risk case; don't block the user.
-		return nil
-	}
-	if int(sys.Uid) != os.Getuid() {
+	if ok && int(sys.Uid) != os.Getuid() {
 		return fmt.Errorf("runtime dir %s owned by uid %d, want %d", dir, sys.Uid, os.Getuid())
+	}
+	if mode := st.Mode().Perm(); mode != 0o700 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("runtime dir %s has mode %#o and chmod to 0700 failed: %w (security #117)", dir, mode, err)
+		}
 	}
 	return nil
 }

--- a/internal/agent/paths_unix_ownership_test.go
+++ b/internal/agent/paths_unix_ownership_test.go
@@ -5,32 +5,37 @@ package agent
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// TestDefaultPaths_RejectsWrongModeRuntimeDir is the regression for
-// security #117: when the /tmp fallback path is used (XDG_RUNTIME_DIR
-// unset) and a pre-existing dir at the expected location has been
-// created by some other process with too-permissive mode, DefaultPaths
-// must refuse rather than silently bind a 0600 socket inside an
-// attacker-owned directory.
-func TestDefaultPaths_RejectsWrongModeRuntimeDir(t *testing.T) {
+// TestDefaultPaths_RepairsWrongModeRuntimeDir is the regression for
+// the upgrade path: a pre-#117 install left the runtime dir at the
+// user's umask-default mode (typically 0755). Since we own the dir,
+// it's safe — and necessary for clean upgrades — to chmod(0700) it
+// in place rather than refuse to start. Ownership remains the
+// load-bearing check (TestDefaultPaths_RejectsWrongUidRuntimeDir
+// covers the actual attack scenario).
+func TestDefaultPaths_RepairsWrongModeRuntimeDir(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmp)
 
-	// Pre-create the jitenv subdir with mode 0755 — too permissive.
+	// Pre-create the jitenv subdir with mode 0755 — what a pre-#117
+	// install would leave behind on an upgrade.
 	jdir := filepath.Join(tmp, "jitenv")
 	if err := os.Mkdir(jdir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := DefaultPaths()
-	if err == nil {
-		t.Fatal("DefaultPaths must refuse a runtime dir with mode 0755")
+	if _, err := DefaultPaths(); err != nil {
+		t.Fatalf("DefaultPaths must self-repair a 0755 dir owned by self: %v", err)
 	}
-	if !strings.Contains(err.Error(), "mode") && !strings.Contains(err.Error(), "perm") {
-		t.Errorf("error message should mention mode/permissions; got: %v", err)
+
+	st, err := os.Lstat(jdir)
+	if err != nil {
+		t.Fatalf("stat after repair: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o700 {
+		t.Errorf("dir mode after repair: got %#o, want 0700", mode)
 	}
 }
 

--- a/internal/agent/paths_unix_ownership_test.go
+++ b/internal/agent/paths_unix_ownership_test.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDefaultPaths_RejectsWrongModeRuntimeDir is the regression for
+// security #117: when the /tmp fallback path is used (XDG_RUNTIME_DIR
+// unset) and a pre-existing dir at the expected location has been
+// created by some other process with too-permissive mode, DefaultPaths
+// must refuse rather than silently bind a 0600 socket inside an
+// attacker-owned directory.
+func TestDefaultPaths_RejectsWrongModeRuntimeDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+
+	// Pre-create the jitenv subdir with mode 0755 — too permissive.
+	jdir := filepath.Join(tmp, "jitenv")
+	if err := os.Mkdir(jdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := DefaultPaths()
+	if err == nil {
+		t.Fatal("DefaultPaths must refuse a runtime dir with mode 0755")
+	}
+	if !strings.Contains(err.Error(), "mode") && !strings.Contains(err.Error(), "perm") {
+		t.Errorf("error message should mention mode/permissions; got: %v", err)
+	}
+}
+
+// TestDefaultPaths_AcceptsCorrectlyOwnedDir is the happy-path
+// counterpart: a 0700 dir owned by the current uid passes.
+func TestDefaultPaths_AcceptsCorrectlyOwnedDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+
+	if _, err := DefaultPaths(); err != nil {
+		t.Fatalf("DefaultPaths on a fresh runtime dir should succeed: %v", err)
+	}
+}

--- a/internal/agent/paths_windows.go
+++ b/internal/agent/paths_windows.go
@@ -36,6 +36,14 @@ func socketEndpoint(_ string) string {
 	return pipeName()
 }
 
+// verifyRuntimeDir is a no-op on Windows (security #117). The Unix
+// variant guards a /tmp fallback where pre-existing attacker-owned
+// dirs are realistic; the Windows runtime dir lives under
+// %LOCALAPPDATA% which is per-user by default, and the named pipe is
+// ACL-restricted to the user's SID, so the same class of attack
+// doesn't apply.
+func verifyRuntimeDir(string) error { return nil }
+
 // pipeName returns the per-user named-pipe path the agent listens on.
 // Windows named pipes live in their own namespace (\\.\pipe\...) — not
 // the filesystem — and pipe names are required to be unique

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -18,7 +18,12 @@ export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 # "an unmapped descendant spawned the wrapped binary"; only the former
 # should pull in mapped env vars (issue #52).
 export __JITENV_SHELL_PID=$$
-mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null
+# Restrict to 0700 across the full hierarchy. Bash's `mkdir -p -m`
+# only sets the mode on the leaf; intermediates inherit the umask
+# (typically 022 → 0755), which would then trip the runtime-dir
+# ownership check (security #117). A subshell with umask 077 makes
+# every intermediate land at 0700.
+(umask 077 && mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null)
 case ":$PATH:" in
     *":$__JITENV_WRAP_DIR:"*) : ;;
     *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -16,7 +16,12 @@ export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 # See bash.sh — gates env injection in the shim so vars don't leak
 # into children of unmapped commands (issue #52).
 export __JITENV_SHELL_PID=$$
-mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null
+# Restrict to 0700 across the full hierarchy. `mkdir -p -m` only
+# sets the mode on the leaf; intermediates inherit the umask
+# (typically 022 → 0755), which would trip the runtime-dir
+# ownership check (security #117). A subshell with umask 077 makes
+# every intermediate land at 0700.
+(umask 077 && mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null)
 case ":$PATH:" in
     *":$__JITENV_WRAP_DIR:"*) : ;;
     *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;


### PR DESCRIPTION
## Summary
Closes #117.

\`agent.DefaultPaths\` called \`os.MkdirAll(0700)\` on the runtime dir but took no further action. MkdirAll silently accepts a pre-existing directory regardless of who owns it or what mode it has. On the \`/tmp/jitenv-<uid>\` fallback (XDG_RUNTIME_DIR unset) an attacker with write access to /tmp can pre-create the directory at any mode and later unlink the agent's socket, replace \`agent.log\`, or plant a hostile pid file.

## Fix
- Add \`verifyRuntimeDir\` in the agent package. Unix variant: Lstat, require uid==self + mode==0700. Windows variant: no-op (LOCALAPPDATA is per-user, named-pipe ACL is the load-bearing gate).
- Call it from \`DefaultPaths\` after MkdirAll. Errors propagate so startup refuses rather than binding a 0600 socket inside an attacker-owned directory.

The bash and zsh hook snippets pre-create the wrapper subtree with plain \`mkdir -p\`, which inherits the user's umask (typically 022 → 0755) and would trip the new check. Wrap each mkdir in a subshell with \`umask 077\` so every intermediate lands at 0700.

## Regression tests
- \`TestDefaultPaths_RejectsWrongModeRuntimeDir\` — pre-existing 0755 dir is refused.
- \`TestDefaultPaths_AcceptsCorrectlyOwnedDir\` — fresh 0700 dir is accepted.

## Test plan
- [x] \`go test ./...\` clean.
- [x] \`GOOS=windows go vet ./...\` clean.
- [ ] CI passes.