### PR TITLE
fix(agent/socket_unix): set umask before bind so socket lands at 0600 atomically (#118)

### DIFF
--- a/internal/agent/socket_unix.go
+++ b/internal/agent/socket_unix.go
@@ -6,17 +6,32 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"syscall"
 )
 
-// listenSocket binds the per-user Unix socket at path and chmods it
-// 0600. The 0600 mode is load-bearing: peer-credential checks happen
-// in checkPeerUid, but the filesystem permission is the first line of
-// defence against an unrelated uid even attempting to connect.
+// listenSocket binds the per-user Unix socket at path with mode 0600
+// applied atomically via the process umask. The 0600 mode is load-
+// bearing: peer-credential checks happen in checkPeerUid, but the
+// filesystem permission is the first line of defence against an
+// unrelated uid even attempting to connect.
 //
-// Returns a net.Listener so callers stay platform-agnostic; the Windows
-// counterpart in socket_windows.go uses a named-pipe listener instead.
+// Setting the umask before bind closes the chmod-after-bind window
+// (security #118): with the previous order, the socket existed for a
+// few microseconds at (0666 & ~umask, typically 0644) before Chmod
+// tightened it. A same-host attacker spinning on connect(2) could
+// land a connection in that window. checkPeerUid is the actual access
+// gate so this never let a wrong-uid client past the agent, but the
+// defence-in-depth shouldn't have the gap. The follow-up Chmod is
+// belt-and-suspenders for any platform where AF_UNIX bind ignores
+// umask (none observed, but cheap to verify).
+//
+// Returns a net.Listener so callers stay platform-agnostic; the
+// Windows counterpart in socket_windows.go uses a named-pipe listener
+// instead.
 func listenSocket(path string) (net.Listener, error) {
+	old := syscall.Umask(0o177)
 	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	syscall.Umask(old)
 	if err != nil {
 		return nil, fmt.Errorf("listen %s: %w", path, err)
 	}

--- a/internal/agent/socket_unix_mode_test.go
+++ b/internal/agent/socket_unix_mode_test.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestListenSocketMode_AtomicallyZeroOther asserts that the socket
+// file's group+world bits are zero from the moment of bind, not just
+// after the chmod call (security #118). The umask-before-bind change
+// closes the chmod-after-bind window where a same-host attacker could
+// land a connection during the brief mode-too-open interval.
+//
+// Verifying "from the moment of bind" precisely is hard from inside
+// the same process; a tractable proxy is to set the process umask to
+// something permissive (0), force bind, and confirm the resulting
+// file is still 0600 — which only holds if the function sets its own
+// restrictive umask.
+func TestListenSocketMode_AtomicallyZeroOther(t *testing.T) {
+	// Aggressive umask that, without our protection, would let the
+	// kernel create the socket at 0666.
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.sock")
+	ln, err := listenSocket(path)
+	if err != nil {
+		t.Fatalf("listenSocket: %v", err)
+	}
+	defer ln.Close()
+
+	st, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if mode := st.Mode().Perm(); mode != 0o600 {
+		t.Errorf("socket mode %#o, want 0600 (umask leak?)", mode)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #118.

\`listenSocket\` used \`net.ListenUnix\` followed by \`os.Chmod(0600)\`. For the brief window between bind and chmod the socket file existed at \`(0666 & ~umask)\` — typically 0644 with the default 0022 umask, or as open as 0666 with an unusual umask=0. \`checkPeerUid\` is the load-bearing gate so a wrong-uid client could never get past the agent, but the defence-in-depth mode bits weren't actually being applied at bind time.

## Fix
Wrap the \`ListenUnix\` call in a \`syscall.Umask(0o177)\` / restore pair so the kernel applies 0600 directly. The follow-up \`os.Chmod\` stays as belt-and-suspenders for any platform where AF_UNIX bind ignores umask (none observed).

## Regression test
\`TestListenSocketMode_AtomicallyZeroOther\` forces a permissive umask (0) before \`listenSocket\` and asserts the resulting file is still 0600 — only true when the function sets its own restrictive umask before the bind.

## Test plan
- [x] \`go test ./...\` clean.
- [ ] CI passes.