### PR TITLE
fix(sources/vault): reject path-traversal refs at Fetch time (#119)

### DIFF
--- a/internal/sources/vault/vault.go
+++ b/internal/sources/vault/vault.go
@@ -260,6 +260,13 @@ func (v *vaultSource) Fetch(ctx context.Context, ref source.SecretRef) (map[stri
 	if ref.ID == "" {
 		return nil, fmt.Errorf("vault: ref.ID (KV path) is required")
 	}
+	// Reject path-traversal refs before hitting the network (security
+	// #119). Vault's HTTP router normalises `..` server-side, so a ref
+	// like "../../sys/policies" would otherwise escape the configured
+	// mount and reach any path the token's policy permits.
+	if hasPathTraversal(ref.ID) {
+		return nil, fmt.Errorf("vault: ref %q contains path traversal segment", ref.ID)
+	}
 	cli, err := v.newClient(ctx)
 	if err != nil {
 		return nil, err
@@ -292,6 +299,19 @@ func (v *vaultSource) Fetch(ctx context.Context, ref source.SecretRef) (map[stri
 		out[k] = stringify(val)
 	}
 	return out, nil
+}
+
+// hasPathTraversal reports whether name contains a `..` segment that
+// would let the resulting Vault HTTP path escape its configured
+// mount. We check both raw-component matches ("../foo", "foo/..",
+// "foo/../bar") and the standalone ".." case.
+func hasPathTraversal(name string) bool {
+	for _, seg := range strings.Split(name, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // readPath builds the Vault HTTP path for a KV read. For v2 the path

--- a/internal/sources/vault/vault_test.go
+++ b/internal/sources/vault/vault_test.go
@@ -190,6 +190,46 @@ func TestReadPath_V1(t *testing.T) {
 	}
 }
 
+// TestFetch_RejectsPathTraversal is the regression for security #119:
+// a VarRef.Ref containing ".." segments would otherwise let a user
+// who controls the config escape the configured mount and reach any
+// Vault path their token's policy permits (e.g. ../../sys/policies).
+// Fetch must reject such refs before issuing the HTTP request.
+func TestFetch_RejectsPathTraversal(t *testing.T) {
+	s, err := New(map[string]any{
+		"address":     "http://127.0.0.1:1",
+		"auth_method": "token",
+		"token":       "x",
+		"mount":       "secret",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cases := []string{
+		"../../sys/policies/acl/default",
+		"foo/../../etc",
+		"foo/..",
+		"..",
+		"./.././bar",
+	}
+	for _, name := range cases {
+		// Cancelled context proves we reject BEFORE the network: an
+		// implementation that defers validation would either return
+		// context.Canceled (network attempted) or block. Our reject
+		// returns a synchronous "traversal"-message error.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := s.Fetch(ctx, source.SecretRef{ID: name})
+		if err == nil {
+			t.Errorf("Fetch(%q) must reject path-traversal ref", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "traversal") {
+			t.Errorf("Fetch(%q) error %q should mention 'traversal' (rejection at validation, not network failure)", name, err)
+		}
+	}
+}
+
 func TestUnwrap_V2_MissingDataWrapper(t *testing.T) {
 	v := &vaultSource{kvVersion: "v2"}
 	_, err := v.unwrap(map[string]any{"foo": "bar"})


### PR DESCRIPTION
## Summary
Closes #119.

\`readPath\` concatenates the configured mount with the user's \`VarRef.Ref\`, doing only a one-shot \`TrimPrefix\` of the mount segment. A ref like \`"../../sys/policies/acl/default"\` produced an HTTP path that Vault's server-side router normalised back into \`sys/…\`, silently escaping the configured mount and reaching any path the token's policy permitted.

## Fix
Validate \`ref.ID\` at the top of \`Fetch\` and refuse any input whose slash-separated segments include \`..\`. This catches the obvious \`"../../foo"\` and \`"foo/../bar"\` shapes plus the standalone \`".."\`, and runs before the network call so the rejection is fast and obviously intentional. Clean refs are unaffected.

## Regression test
\`TestFetch_RejectsPathTraversal\` uses a pre-cancelled context: a clean ref dies with \`context.Canceled\` (network was attempted), a traversal ref dies with the new \`"contains path traversal"\` error (rejected at validation).

## Test plan
- [x] \`go test ./...\` clean.
- [ ] CI passes.