### PR TITLE
fix(shell/install): shell-quote bashrc path in login sourcing block (#124)

### DIFF
--- a/internal/shell/install.go
+++ b/internal/shell/install.go
@@ -275,9 +275,14 @@ func bashLoginCandidates() []string {
 // loginSourcingBlock returns the comment + source line to append. If
 // the target is .profile (which sh may also source), the source line
 // is wrapped in a $BASH_VERSION guard so non-bash shells skip it.
+//
+// The bashrc path is shell-quoted via shellQuote (security #124) so
+// $HOME directories containing spaces or other shell metacharacters
+// (legal on macOS, WSL-mounted Windows homes, etc.) don't produce
+// broken syntax in the generated .bash_profile / .profile.
 func loginSourcingBlock(target string) string {
 	home, _ := os.UserHomeDir()
-	bashrc := filepath.Join(home, ".bashrc")
+	bashrc := shellQuote(filepath.Join(home, ".bashrc"))
 	if filepath.Base(target) == ".profile" {
 		return fmt.Sprintf(
 			"\n# jitenv: ensure bash login shells load ~/.bashrc (sh-safe)\n"+
@@ -291,7 +296,9 @@ func loginSourcingBlock(target string) string {
 }
 
 // loginFileSourcesBashrc reports whether `text` contains a line that
-// sources ~/.bashrc, in any of the common forms.
+// sources ~/.bashrc, in any of the common forms. Recognises both the
+// historical unquoted forms and the quoted form emitted by
+// loginSourcingBlock since security #124.
 func loginFileSourcesBashrc(text string) bool {
 	home, _ := os.UserHomeDir()
 	bashrc := filepath.Join(home, ".bashrc")
@@ -302,6 +309,8 @@ func loginFileSourcesBashrc(text string) bool {
 		". $HOME/.bashrc",
 		"source " + bashrc,
 		". " + bashrc,
+		"source " + shellQuote(bashrc),
+		". " + shellQuote(bashrc),
 	}
 	for _, p := range patterns {
 		if strings.Contains(text, p) {

--- a/internal/shell/install_test.go
+++ b/internal/shell/install_test.go
@@ -133,6 +133,43 @@ func withFakeHome(t *testing.T) string {
 	return dir
 }
 
+// TestInstallShell_BashHomeWithSpaces is the regression for security
+// #124: loginSourcingBlock used unquoted %s interpolation, so a $HOME
+// containing spaces (legal on macOS and WSL) produced broken shell
+// syntax in the generated .bash_profile — the user's login shell
+// would emit a parse error on every startup.
+func TestInstallShell_BashHomeWithSpaces(t *testing.T) {
+	parent := t.TempDir()
+	home := filepath.Join(parent, "John Doe")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	rep, err := InstallShell("bash")
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	body, err := os.ReadFile(rep.LoginPath)
+	if err != nil {
+		t.Fatalf("read login file: %v", err)
+	}
+	got := string(body)
+
+	// The path must be shell-quoted (single quotes) so spaces don't
+	// split the [ -f … ] test into multiple arguments.
+	wantQuoted := "'" + filepath.Join(home, ".bashrc") + "'"
+	if !strings.Contains(got, wantQuoted) {
+		t.Errorf("login block should contain shell-quoted bashrc path %q; got:\n%s", wantQuoted, got)
+	}
+	// The raw (unquoted) form would split on the space — a regression
+	// would leave a `[ -f /…/John` token in the file.
+	bad := "-f " + filepath.Join(home, ".bashrc") + " "
+	if strings.Contains(got, bad) {
+		t.Errorf("login block contains unquoted path with embedded space: %q\n%s", bad, got)
+	}
+}
+
 func TestInstallShell_BashCreatesLoginChain(t *testing.T) {
 	home := withFakeHome(t)
 	rep, err := InstallShell("bash")


### PR DESCRIPTION
## Summary
Closes #124.

\`loginSourcingBlock\` built the \`.bash_profile\` / \`.profile\` snippet with unquoted \`%s\` interpolation:

\`\`\`sh
[ -f /Users/John Doe/.bashrc ] && . /Users/John Doe/.bashrc
\`\`\`

A \`\$HOME\` containing a space (legal on macOS, common on WSL-mounted Windows homes) produced syntactically broken shell that the user's login shell emitted a parse error for on every startup.

## Fix
- Wrap the bashrc path with the existing \`shellQuote\` helper so spaces (and \$/\`/(/[ /etc.) are safe.
- Teach \`loginFileSourcesBashrc\` to recognise the quoted form too, so re-installing on top of a previously-generated quoted line doesn't duplicate the source line.

## Regression test
\`TestInstallShell_BashHomeWithSpaces\` forces \`\$HOME="/tmp/.../John Doe"\`, runs \`InstallShell\`, asserts the generated \`.bash_profile\` contains the single-quoted path and not the bare-space form.

## Test plan
- [x] \`go test ./...\` clean (incl. all existing InstallShell tests).
- [ ] CI passes.