### PR TITLE
fix(crypto/passphrase): zero buffers + constant-time compare (#126)

### DIFF
--- a/internal/crypto/passphrase.go
+++ b/internal/crypto/passphrase.go
@@ -1,11 +1,26 @@
 package crypto
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 
 	"golang.org/x/term"
 )
+
+// zeroPassphrase overwrites the bytes of a passphrase slice in place.
+// Used everywhere PromptPassphrase abandons a buffer (mismatched
+// confirm, empty-passphrase reject, read error after first input) so
+// the cleartext lifespan in the heap is bounded. Go strings are
+// immutable and unzeroable; the comparison path therefore uses
+// subtle.ConstantTimeCompare on the raw byte slices rather than
+// `string(pw) != string(pw2)`, which would spawn two unzeroable
+// string copies (security #126).
+func zeroPassphrase(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
 
 // PromptPassphrase reads a passphrase from the controlling terminal
 // without echo. The terminal is opened directly (rather than via
@@ -38,9 +53,12 @@ func PromptPassphrase(prompt string, confirm bool) ([]byte, error) {
 	if confirm {
 		pw2, err := read("Confirm: ")
 		if err != nil {
+			zeroPassphrase(pw)
 			return nil, err
 		}
-		if string(pw) != string(pw2) {
+		defer zeroPassphrase(pw2)
+		if subtle.ConstantTimeCompare(pw, pw2) != 1 {
+			zeroPassphrase(pw)
 			return nil, errors.New("passphrases do not match")
 		}
 	}


### PR DESCRIPTION
## Summary
Closes #126.

\`PromptPassphrase\` abandoned the confirmation buffer (\`pw2\`) without zeroing, and used \`string(pw) != string(pw2)\` which spawns two immutable Go string copies of both passphrases — those copies live in the heap until next GC and cannot be cleared. The first passphrase buffer (\`pw\`) was also leaked on the mismatch error path.

## Fix
- Add a package-private \`zeroPassphrase\` helper.
- Zero \`pw\` on mismatch / second-read-error paths.
- \`defer zeroPassphrase(pw2)\` so it never outlives the function.
- Replace the string comparison with \`subtle.ConstantTimeCompare\` on the raw byte slices. No mid-function string conversion of the passphrase remains.

## Test plan
- [x] \`go test ./...\` clean (no behavioural change to the success path).
- [ ] CI passes.