### PR TITLE
fix(sources/vault): cache authenticated client until lease expires (#133)

### DIFF
--- a/internal/sources/vault/vault.go
+++ b/internal/sources/vault/vault.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	vaultapi "github.com/hashicorp/vault/api"
 	approleauth "github.com/hashicorp/vault/api/auth/approle"
@@ -138,7 +140,29 @@ type vaultSource struct {
 	mount         string
 	kvVersion     string
 	tlsSkipVerify bool
+
+	// Cached authenticated client (security #133). AppRole logins burn
+	// a use-count on every call and re-send role_id + secret_id over
+	// the wire, so re-authenticating per-Fetch was both wasteful and a
+	// secret_id leak amplifier. The cache is invalidated when the
+	// recorded lease expiry passes (with a 60s safety margin) or on
+	// any auth failure the client surfaces. Static tokens have no
+	// known expiry from this side; we cache the client for tokenCacheTTL
+	// and let downstream API errors trigger a rebuild.
+	cacheMu      sync.Mutex
+	cachedClient *vaultapi.Client
+	cachedExpiry time.Time
 }
+
+// tokenCacheTTL is the cache lifetime for static-token auth where we
+// have no lease-duration to derive from. An hour balances "cheap" vs
+// "responsive to token revocation".
+const tokenCacheTTL = time.Hour
+
+// authCacheSafetyMargin is the slack we subtract from the Vault-reported
+// lease duration so we re-authenticate before the cached token actually
+// expires. Hides clock skew + in-flight request latency.
+const authCacheSafetyMargin = 60 * time.Second
 
 func (v *vaultSource) Name() string { return TypeName }
 
@@ -176,9 +200,31 @@ func (v *vaultSource) validateStatic() error {
 	return nil
 }
 
-// newClient builds a configured *api.Client and authenticates it. The
-// resulting client carries the auth token that subsequent calls use.
+// newClient returns an authenticated Vault client, reusing a cached
+// one when it's still within its lease window (security #133). The
+// cache is keyed off the source instance so two sources with the same
+// address but different auth params get separate clients.
 func (v *vaultSource) newClient(ctx context.Context) (*vaultapi.Client, error) {
+	v.cacheMu.Lock()
+	defer v.cacheMu.Unlock()
+
+	if v.cachedClient != nil && time.Now().Before(v.cachedExpiry) {
+		return v.cachedClient, nil
+	}
+
+	cli, expiry, err := v.buildAndAuthenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	v.cachedClient = cli
+	v.cachedExpiry = expiry
+	return cli, nil
+}
+
+// buildAndAuthenticate constructs a fresh *vaultapi.Client and runs
+// the configured auth flow. Returns the client plus the time at which
+// its credentials should be treated as expired.
+func (v *vaultSource) buildAndAuthenticate(ctx context.Context) (*vaultapi.Client, time.Time, error) {
 	cfg := vaultapi.DefaultConfig()
 	cfg.Address = v.address
 
@@ -194,16 +240,17 @@ func (v *vaultSource) newClient(ctx context.Context) (*vaultapi.Client, error) {
 
 	cli, err := vaultapi.NewClient(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("vault: new client: %w", err)
+		return nil, time.Time{}, fmt.Errorf("vault: new client: %w", err)
 	}
 	if v.namespace != "" {
 		cli.SetNamespace(v.namespace)
 	}
 
-	if err := v.authenticate(ctx, cli); err != nil {
-		return nil, err
+	expiry, err := v.authenticate(ctx, cli)
+	if err != nil {
+		return nil, time.Time{}, err
 	}
-	return cli, nil
+	return cli, expiry, nil
 }
 
 // cleanTransport returns a fresh http.Transport sized for one-shot
@@ -220,27 +267,39 @@ func cleanTransport() *http.Transport {
 	}
 }
 
-func (v *vaultSource) authenticate(ctx context.Context, cli *vaultapi.Client) error {
+// authenticate runs the configured auth flow against cli and returns
+// the time at which the resulting credentials should be re-acquired.
+// For static-token auth there's no server-reported expiry, so we use
+// the local tokenCacheTTL ceiling; downstream API errors will force
+// a rebuild sooner if the token is revoked.
+func (v *vaultSource) authenticate(ctx context.Context, cli *vaultapi.Client) (time.Time, error) {
 	switch v.authMethod {
 	case authToken:
 		cli.SetToken(v.token)
-		return nil
+		return time.Now().Add(tokenCacheTTL), nil
 	case authAppRole:
 		secret := &approleauth.SecretID{FromString: v.secretID}
 		appRole, err := approleauth.NewAppRoleAuth(v.roleID, secret)
 		if err != nil {
-			return fmt.Errorf("vault: approle auth setup: %w", err)
+			return time.Time{}, fmt.Errorf("vault: approle auth setup: %w", err)
 		}
 		out, err := cli.Auth().Login(ctx, appRole)
 		if err != nil {
-			return fmt.Errorf("vault: approle login: %w", err)
+			return time.Time{}, fmt.Errorf("vault: approle login: %w", err)
 		}
 		if out == nil || out.Auth == nil || out.Auth.ClientToken == "" {
-			return fmt.Errorf("vault: approle login returned no token")
+			return time.Time{}, fmt.Errorf("vault: approle login returned no token")
 		}
-		return nil
+		lease := time.Duration(out.Auth.LeaseDuration) * time.Second
+		if lease <= authCacheSafetyMargin {
+			// Server returned a near-zero lease (or 0 = no expiry).
+			// Default to a short cache so we don't pin a stale token,
+			// but still avoid per-Fetch re-auth.
+			return time.Now().Add(authCacheSafetyMargin), nil
+		}
+		return time.Now().Add(lease - authCacheSafetyMargin), nil
 	}
-	return fmt.Errorf("vault: unsupported auth_method %q", v.authMethod)
+	return time.Time{}, fmt.Errorf("vault: unsupported auth_method %q", v.authMethod)
 }
 
 // Validate authenticates against Vault without reading any secret.

--- a/internal/sources/vault/vault_test.go
+++ b/internal/sources/vault/vault_test.go
@@ -372,6 +372,49 @@ func TestFetch_AppRoleAuth_V2(t *testing.T) {
 	}
 }
 
+// TestFetch_AppRoleAuth_CachesToken is the regression for security
+// #133: two consecutive Fetches against the same source should reuse
+// the previous AppRole login rather than calling /auth/approle/login
+// every time. Re-auth-per-Fetch exhausts secret_id use-counts and
+// triples the wire footprint of secret_id over the network.
+func TestFetch_AppRoleAuth_CachesToken(t *testing.T) {
+	var loginCalls atomic.Int32
+	srv := stubServer(t, map[string]http.HandlerFunc{
+		"PUT /v1/auth/approle/login": func(w http.ResponseWriter, r *http.Request) {
+			loginCalls.Add(1)
+			writeJSON(w, 200, map[string]any{
+				"auth": map[string]any{
+					"client_token":   "issued-token",
+					"lease_duration": 3600, // 1h — well above the 60s safety margin
+				},
+			})
+		},
+		"GET /v1/secret/data/myapp/prod": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, 200, map[string]any{
+				"data": map[string]any{"data": map[string]any{"FOO": "bar"}},
+			})
+		},
+	})
+
+	s, err := New(map[string]any{
+		"address":     srv.URL,
+		"auth_method": "approle",
+		"role_id":     "rid",
+		"secret_id":   "sid",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := s.Fetch(context.Background(), source.SecretRef{ID: "myapp/prod"}); err != nil {
+			t.Fatalf("Fetch #%d: %v", i, err)
+		}
+	}
+	if got := loginCalls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 AppRole login across 3 fetches; got %d", got)
+	}
+}
+
 func TestFetch_MissingSecret_V2(t *testing.T) {
 	srv := stubServer(t, map[string]http.HandlerFunc{
 		"GET /v1/secret/data/missing": func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Closes #133. See commit.