### PR TITLE
fix(agent/peer_windows): use ImpersonateNamedPipeClient (#132)

### DIFF
--- a/internal/agent/peer_windows.go
+++ b/internal/agent/peer_windows.go
@@ -5,6 +5,8 @@ package agent
 import (
 	"fmt"
 	"net"
+	"runtime"
+	"syscall"
 
 	"golang.org/x/sys/windows"
 )
@@ -17,20 +19,42 @@ type fdConn interface {
 	Fd() uintptr
 }
 
+// advapi32.dll exports we don't get from x/sys/windows directly.
+var (
+	modAdvapi32                  = windows.NewLazySystemDLL("advapi32.dll")
+	procImpersonateNamedPipeClnt = modAdvapi32.NewProc("ImpersonateNamedPipeClient")
+)
+
+// impersonateNamedPipeClient binds the current OS thread's effective
+// token to the client of the supplied named pipe. Pair with
+// RevertToSelf inside a runtime.LockOSThread region — Win32 thread
+// tokens live on the OS thread, and Go's scheduler is free to migrate
+// goroutines between threads otherwise.
+func impersonateNamedPipeClient(pipe windows.Handle) error {
+	r1, _, e1 := syscall.SyscallN(procImpersonateNamedPipeClnt.Addr(), uintptr(pipe))
+	if r1 == 0 {
+		return error(e1)
+	}
+	return nil
+}
+
 // checkPeerUid enforces that the connecting named-pipe client runs as
-// the same user as the agent.
+// the same user as the agent. As of security #132 the check uses
+// ImpersonateNamedPipeClient — the standard Win32 idiom — rather than
+// a PID-based OpenProcess lookup. The previous approach had a TOCTOU
+// race: between GetNamedPipeClientProcessId and OpenProcess the PID
+// could be reused by an unrelated process, and the SID check would
+// then be made against the wrong token. Impersonation binds the
+// credential check to the transport layer directly.
 //
 // The pipe ACL set in socket_windows.go already restricts the pipe to
-// the current user SID, but that is a perimeter check. We still grab
-// the client's process ID via GetNamedPipeClientProcessId, open its
-// token, and compare the token's user SID against the agent's own. A
-// matching SID is the load-bearing peer-auth guarantee — anything else
-// (the ACL, the pipe path containing the SID) is defence in depth.
+// the current user SID; the thread-token comparison is the
+// load-bearing peer-auth guarantee on top of that perimeter check.
 //
 // Note: this comparison is same-user, not same-session. A second
-// process running under the same user account (e.g. another shell
-// session) is treated as authorised, exactly as on Unix where multiple
-// shells of the same uid all pass SO_PEERCRED.
+// process running under the same user account is treated as
+// authorised, exactly as on Unix where multiple shells of the same
+// uid all pass SO_PEERCRED.
 func checkPeerUid(c net.Conn) error {
 	fc, ok := c.(fdConn)
 	if !ok {
@@ -38,25 +62,29 @@ func checkPeerUid(c net.Conn) error {
 	}
 	pipeHandle := windows.Handle(fc.Fd())
 
-	var clientPID uint32
-	if err := windows.GetNamedPipeClientProcessId(pipeHandle, &clientPID); err != nil {
-		return fmt.Errorf("get pipe client pid: %w", err)
-	}
+	// Win32 thread-token APIs operate on the OS thread, not on Go's
+	// goroutine abstraction. Pin this goroutine to its OS thread for
+	// the lifetime of the impersonation so RevertToSelf releases the
+	// right thread's token.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
-	// PROCESS_QUERY_LIMITED_INFORMATION (0x1000) is sufficient to call
-	// OpenProcessToken with TOKEN_QUERY, and unlike
-	// PROCESS_QUERY_INFORMATION it works across integrity levels for the
-	// same user.
-	const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-	procHandle, err := windows.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, clientPID)
-	if err != nil {
-		return fmt.Errorf("open client process %d: %w", clientPID, err)
+	if err := impersonateNamedPipeClient(pipeHandle); err != nil {
+		return fmt.Errorf("impersonate pipe client: %w", err)
 	}
-	defer windows.CloseHandle(procHandle)
+	defer func() {
+		// Best-effort. If RevertToSelf fails the OS thread is still
+		// in the impersonated state — UnlockOSThread doesn't fix
+		// that, but the Go runtime tears the thread down rather than
+		// reusing it for another goroutine when an LockOSThread'd
+		// goroutine exits without a matching unlock — and we always
+		// unlock here, so a normal return is fine.
+		_ = windows.RevertToSelf()
+	}()
 
 	var clientTok windows.Token
-	if err := windows.OpenProcessToken(procHandle, windows.TOKEN_QUERY, &clientTok); err != nil {
-		return fmt.Errorf("open client process token: %w", err)
+	if err := windows.OpenThreadToken(windows.CurrentThread(), windows.TOKEN_QUERY, true, &clientTok); err != nil {
+		return fmt.Errorf("open thread token: %w", err)
 	}
 	defer clientTok.Close()
 


### PR DESCRIPTION
Closes #132. See commit.