### PR TITLE
fix(crypto,cli): mlock/VirtualLock the master key buffer (#127)

### DIFF
--- a/internal/cli/agent_internal.go
+++ b/internal/cli/agent_internal.go
@@ -37,6 +37,7 @@ func newAgentInternalCmd() *cobra.Command {
 				return fmt.Errorf("read key: %w", err)
 			}
 			defer zeroBytes(key)
+			defer lockKey(key)()
 			slog.Info("agent starting", "config", cfgArg, "idle", idle.String())
 
 			loadAndBuild := func() (agent.Resolver, error) {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
@@ -113,4 +114,23 @@ func zeroBytes(b []byte) {
 	for i := range b {
 		b[i] = 0
 	}
+}
+
+// lockKey pins the master-key buffer into RAM so it won't be paged
+// to swap / pagefile (security #127). On failure (RLIMIT_MEMLOCK on
+// Linux, working-set ceilings on Windows) a slog warning is emitted
+// and execution continues — running unlocked is degraded but still
+// works, and dying mid-startup over a kernel-mode tuning issue
+// would be worse UX than the security tightening it represents.
+//
+// Returns a cleanup closure that unlocks the buffer. Callers should
+// defer it next to defer zeroBytes(key) so the unlock + zero run
+// in tandem.
+func lockKey(key []byte) func() {
+	if err := crypto.LockBytes(key); err != nil {
+		slog.Warn("could not mlock master key; running with un-locked key material",
+			"err", err)
+		return func() {}
+	}
+	return func() { _ = crypto.UnlockBytes(key) }
 }

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -39,6 +39,7 @@ func newUnlockCmd() *cobra.Command {
 				return err
 			}
 			defer zeroBytes(key)
+			defer lockKey(key)()
 
 			paths, err := agent.DefaultPaths()
 			if err != nil {

--- a/internal/crypto/mlock.go
+++ b/internal/crypto/mlock.go
@@ -1,0 +1,27 @@
+package crypto
+
+// LockBytes locks the page(s) backing b into RAM so the OS won't
+// page them to disk under memory pressure. Best-effort: failures
+// (e.g. RLIMIT_MEMLOCK on Linux, working-set limits on Windows) are
+// returned as errors but the caller should NOT treat them as fatal
+// — running with un-locked key material is degraded but still
+// works. Pair with UnlockBytes when the key is wiped (security
+// #127).
+//
+// The platform-split implementations live in mlock_unix.go and
+// mlock_windows.go.
+func LockBytes(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	return lockBytes(b)
+}
+
+// UnlockBytes releases an earlier LockBytes lock on b. Always called
+// in defer order alongside the zeroing of b.
+func UnlockBytes(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	return unlockBytes(b)
+}

--- a/internal/crypto/mlock_unix.go
+++ b/internal/crypto/mlock_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package crypto
+
+import "golang.org/x/sys/unix"
+
+// lockBytes pins b into RAM via mlock(2). The kernel locks at page
+// granularity; locking a 32-byte slice pins the whole page (typically
+// 4 KiB on Linux/macOS) — acceptable cost for the master key plus
+// any other small secret buffers we wire through here.
+func lockBytes(b []byte) error {
+	return unix.Mlock(b)
+}
+
+func unlockBytes(b []byte) error {
+	return unix.Munlock(b)
+}

--- a/internal/crypto/mlock_windows.go
+++ b/internal/crypto/mlock_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package crypto
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockBytes pins b into the process working set via VirtualLock.
+// Subject to the per-process working-set ceiling; for small key
+// buffers this is well within default limits.
+func lockBytes(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	return windows.VirtualLock(uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)))
+}
+
+func unlockBytes(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	return windows.VirtualUnlock(uintptr(unsafe.Pointer(&b[0])), uintptr(len(b)))
+}


### PR DESCRIPTION
Closes #127. See commit.