### PR TITLE
fix(agent,sources/local): wipe cached plaintext secrets on Shutdown (#125)

### DIFF
--- a/internal/agent/resolver.go
+++ b/internal/agent/resolver.go
@@ -25,6 +25,36 @@ type bagSink interface {
 	SetBags(map[string]map[string]string)
 }
 
+// wiper is implemented by sources that cache decrypted secret
+// material (the local source's bag map, future caches for remote
+// sources) and need a hook to drop those references on shutdown
+// (security #125). Optional — sources that hold no plaintext
+// secrets don't implement it.
+type wiper interface {
+	Wipe()
+}
+
+// Wipe walks every source the resolver owns and asks it to release
+// any cached plaintext. Then it drops the resolver's own reference
+// to the per-source config map (which still holds the decrypted
+// param strings post-DecryptInPlace). Best-effort: Go strings are
+// immutable, so this can't overwrite the heap bytes — it removes
+// the live reference chain so a future GC can reclaim the memory.
+func (r *resolver) Wipe() {
+	for _, s := range r.sources {
+		if w, ok := s.(wiper); ok {
+			w.Wipe()
+		}
+	}
+	for name, sc := range r.cfg {
+		for k := range sc.Params {
+			sc.Params[k] = ""
+		}
+		r.cfg[name] = sc
+	}
+	r.cfg = nil
+}
+
 // BuildResolver constructs sources from the (already-decrypted) config
 // and returns a Resolver suitable for an Agent.
 func BuildResolver(cfg *config.Config) (Resolver, error) {

--- a/internal/agent/resolver_wipe_test.go
+++ b/internal/agent/resolver_wipe_test.go
@@ -1,0 +1,59 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+)
+
+// TestResolverWipeClearsLocalBags is the regression for security
+// #125: after Wipe, a FetchEnv targeting a local-source bag must
+// produce no secret values — the bag store was released. We don't
+// chase Go heap residue (impossible to observe from inside the
+// process) but we do confirm the live reference chain is severed,
+// which is what enables GC to reclaim the memory.
+func TestResolverWipeClearsLocalBags(t *testing.T) {
+	cfg := &config.Config{
+		Version: config.Version,
+		Sources: map[string]config.SourceConfig{
+			"vault": {Type: "local"},
+		},
+		Mappings: []config.Mapping{
+			{Path: "/x", Vars: []config.VarRef{{Source: "vault", Ref: "stripe"}}},
+		},
+		Secrets: map[string]map[string]string{
+			"stripe": {"PK": "pk_live_x", "SK": "sk_live_y"},
+		},
+	}
+	r, err := BuildResolver(cfg)
+	if err != nil {
+		t.Fatalf("BuildResolver: %v", err)
+	}
+
+	// Pre-wipe: fetch returns the seeded values.
+	got, err := r.FetchEnv(context.Background(), "/x")
+	if err != nil {
+		t.Fatalf("FetchEnv pre-wipe: %v", err)
+	}
+	if got["PK"] != "pk_live_x" || got["SK"] != "sk_live_y" {
+		t.Fatalf("pre-wipe values: %#v", got)
+	}
+
+	// Wipe.
+	w, ok := r.(interface{ Wipe() })
+	if !ok {
+		t.Fatalf("resolver does not implement Wipe()")
+	}
+	w.Wipe()
+
+	// Post-wipe: the local source's bag map is nil; FetchEnv should
+	// surface that as an error rather than silently returning empty.
+	_, err = r.FetchEnv(context.Background(), "/x")
+	if err == nil {
+		t.Errorf("FetchEnv post-wipe must error; bag store is gone")
+	}
+}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -131,7 +131,12 @@ func (a *Agent) Serve(ctx context.Context) error {
 	}
 }
 
-// Shutdown stops accepting and removes socket + pidfile.
+// Shutdown stops accepting and removes socket + pidfile. As of
+// security #125 it also asks the resolver to wipe any cached
+// plaintext secret material so a memory dump immediately after
+// shutdown contains fewer recoverable secrets (Go strings are
+// immutable, so this isn't true zeroing — it drops live references
+// so a future GC can reclaim the memory).
 func (a *Agent) Shutdown() {
 	if a.cancel != nil {
 		a.cancel()
@@ -141,6 +146,12 @@ func (a *Agent) Shutdown() {
 	}
 	_ = os.Remove(a.paths.Socket)
 	_ = RemovePidFile(a.paths.PidFile)
+	a.mu.Lock()
+	if w, ok := a.resolver.(interface{ Wipe() }); ok {
+		w.Wipe()
+	}
+	a.resolver = nil
+	a.mu.Unlock()
 }
 
 func (a *Agent) idleLoop(ctx context.Context) {

--- a/internal/sources/local/local.go
+++ b/internal/sources/local/local.go
@@ -38,6 +38,21 @@ type localSource struct {
 // the decrypted bag store into the source.
 func (l *localSource) SetBags(b map[string]map[string]string) { l.bags = b }
 
+// Wipe overwrites every cached bag value with the empty string and
+// drops the map references so the GC can reclaim the secret-bearing
+// memory (security #125). Go strings are immutable so this isn't
+// true zeroing, but it breaks the live reference chain — the
+// underlying byte arrays become unreachable from this source and
+// from the bag map. Called by the agent's resolver during Shutdown.
+func (l *localSource) Wipe() {
+	for _, bag := range l.bags {
+		for k := range bag {
+			bag[k] = ""
+		}
+	}
+	l.bags = nil
+}
+
 func (l *localSource) Name() string { return TypeName }
 
 func (l *localSource) Schema() []source.ParamField {


### PR DESCRIPTION
Closes #125. See commit.