### PR TITLE
fix(shell,cli): warn on unsupported shells at unlock (#164)

### DIFF
--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -94,21 +95,38 @@ func newUnlockCmd() *cobra.Command {
 }
 
 // warnIfHookMissing prints a yellow notice to w when the shell hook
-// isn't fully wired up. Two failure modes are flagged:
+// isn't fully wired up. Three failure modes are flagged:
+//   - the user is in an unsupported shell (fish / dash / ksh / …) so
+//     the hook will never load — issue #164;
 //   - the eval line is not in the user's interactive rc file at all;
-//   - the eval line is in ~/.bashrc but bash login shells don't end up
-//     sourcing ~/.bashrc, so the hook only fires in interactive shells
-//     (this is the situation that hides the agent-down warning when
-//     the user opens a new terminal as a login shell).
+//   - the eval line is in ~/.bashrc but bash login shells don't end
+//     up sourcing ~/.bashrc, so the hook only fires in interactive
+//     shells.
 func warnIfHookMissing(w interface {
 	Write(p []byte) (n int, err error)
 }) {
 	st, err := shell.CurrentStatus()
-	if err != nil || st.Shell == "" {
+	if err != nil {
 		return
 	}
 	const yellow = "\033[33m"
 	const reset = "\033[0m"
+
+	if st.Shell == "" {
+		// Truly-unknown shell ($SHELL unset) stays silent — nothing
+		// actionable to say. Unsupported shell with a name gets a
+		// dedicated warning so the user knows the agent is running
+		// but the hook will never auto-inject (#164).
+		if st.Unsupported != "" {
+			fmt.Fprintf(w,
+				"%snote:%s detected shell %q (from $SHELL=%q) is not supported by jitenv. "+
+					"Only %s have hooks; the agent is running, but path-mapped commands "+
+					"won't auto-inject env vars in this shell.\n",
+				yellow, reset, st.Unsupported, st.Source,
+				strings.Join(shell.SupportedShells(), ", "))
+		}
+		return
+	}
 	if !st.Installed {
 		fmt.Fprintf(w,
 			"%snote:%s shell hook not installed in %s — run `jitenv hook install` "+

--- a/internal/shell/install.go
+++ b/internal/shell/install.go
@@ -10,25 +10,59 @@ import (
 	"strings"
 )
 
-// DetectShell returns "bash" / "zsh" / "powershell", or "" if the
-// current shell isn't supported. On Windows $SHELL is normally unset,
-// so we assume PowerShell 7+ (the only Windows shell jitenv supports —
-// see issue #39 for the cmd.exe / PowerShell 5.x decision).
+// SupportedShells lists the canonical names jitenv has hook snippets
+// for. Used by user-facing warnings so the wording stays in sync with
+// the actual matrix.
+func SupportedShells() []string {
+	return []string{"bash", "zsh", "powershell"}
+}
+
+// DetectShell returns "bash" / "zsh" / "powershell" when the current
+// shell is one jitenv supports, or "" otherwise. "" collapses both
+// "$SHELL unset / unreadable" and "named-but-unsupported" cases; call
+// DetectShellDetailed when those need to be distinguished (e.g. to
+// warn an unsupported-shell user that their hook will never load).
 func DetectShell() string {
+	canonical, _, _ := DetectShellDetailed()
+	return canonical
+}
+
+// DetectShellDetailed reports what jitenv knows about the calling
+// shell (#164):
+//
+//   - canonical: one of bash/zsh/powershell when supported, "" otherwise.
+//   - raw: the basename of $SHELL when present, "" when the env var
+//     is unset (or, on Windows, "" because no detection happened).
+//   - source: the full $SHELL value (or other origin token) used to
+//     derive raw; surfaced in user-facing warnings so the user can
+//     see what jitenv read.
+//
+// When canonical == "" and raw != "" the caller should treat this as
+// "unsupported shell" and warn the user — the agent will work, but
+// the hook won't load. When canonical == "" and raw == "" there's
+// nothing actionable to say and callers should stay silent.
+//
+// On Windows we keep the historical optimism of assuming pwsh 7+
+// (canonical = "powershell"). Detecting cmd.exe / Windows PowerShell
+// 5.x requires parent-process inspection and is tracked as a follow-
+// up; returning a non-empty raw would imply we'd looked at the
+// process — we haven't — so it stays empty.
+func DetectShellDetailed() (canonical, raw, source string) {
 	if runtime.GOOS == "windows" {
-		return "powershell"
+		return "powershell", "", "runtime.GOOS=windows"
 	}
 	sh := os.Getenv("SHELL")
 	if sh == "" {
-		return ""
+		return "", "", ""
 	}
-	switch filepath.Base(sh) {
+	base := filepath.Base(sh)
+	switch base {
 	case "bash":
-		return "bash"
+		return "bash", base, sh
 	case "zsh":
-		return "zsh"
+		return "zsh", base, sh
 	}
-	return ""
+	return "", base, sh
 }
 
 // RcPath returns the conventional rc file path for shell, or "" if we
@@ -124,22 +158,33 @@ type Status struct {
 	Installed    bool
 	LoginPath    string // login-shell startup file we'd touch (bash only)
 	LoginSources bool   // whether the login file already sources RcPath
+
+	// Unsupported is set to the raw basename of $SHELL (e.g. "fish",
+	// "dash") when the detected shell is one jitenv has no hook
+	// snippet for. Shell stays empty in that case. Unsupported is
+	// only populated when the user has SOMETHING set in $SHELL but
+	// it isn't bash/zsh — "$SHELL unset" stays silent (#164).
+	Unsupported string
+	// Source is the full $SHELL value (or detection origin) that
+	// produced Unsupported. Surfaced verbatim in the warning so the
+	// user can see what jitenv read.
+	Source string
 }
 
 // CurrentStatus returns the status for the user's current shell.
 func CurrentStatus() (Status, error) {
-	sh := DetectShell()
-	if sh == "" {
-		return Status{}, nil
+	canonical, raw, source := DetectShellDetailed()
+	if canonical == "" {
+		return Status{Unsupported: raw, Source: source}, nil
 	}
-	rc := RcPath(sh)
-	line := HookLine(sh)
+	rc := RcPath(canonical)
+	line := HookLine(canonical)
 	installed, err := IsInstalled(rc, line)
 	if err != nil {
 		return Status{}, err
 	}
-	st := Status{Shell: sh, RcPath: rc, Line: line, Installed: installed}
-	switch sh {
+	st := Status{Shell: canonical, RcPath: rc, Line: line, Installed: installed}
+	switch canonical {
 	case "bash":
 		st.LoginPath, st.LoginSources = inspectBashLogin()
 	default:

--- a/internal/shell/install_test.go
+++ b/internal/shell/install_test.go
@@ -300,6 +300,66 @@ func TestDetectShell(t *testing.T) {
 	}
 }
 
+// TestDetectShellDetailed is the regression for #164: DetectShell's "" is
+// the same for unsupported and unknown, but the new detailed variant
+// must distinguish the two so unlock can warn fish/dash/ksh users
+// while staying silent on truly-unknown shells.
+//
+// File is !windows-tagged; on Windows the function always reports
+// powershell from the GOOS branch.
+func TestDetectShellDetailed(t *testing.T) {
+	t.Setenv("SHELL", "/usr/bin/bash")
+	if c, r, _ := DetectShellDetailed(); c != "bash" || r != "bash" {
+		t.Errorf("bash: got canonical=%q raw=%q, want both bash", c, r)
+	}
+
+	t.Setenv("SHELL", "/usr/bin/fish")
+	c, r, s := DetectShellDetailed()
+	if c != "" {
+		t.Errorf("fish canonical: got %q, want \"\"", c)
+	}
+	if r != "fish" {
+		t.Errorf("fish raw: got %q, want \"fish\"", r)
+	}
+	if s != "/usr/bin/fish" {
+		t.Errorf("fish source: got %q, want /usr/bin/fish", s)
+	}
+
+	t.Setenv("SHELL", "/bin/dash")
+	c, r, _ = DetectShellDetailed()
+	if c != "" || r != "dash" {
+		t.Errorf("dash: got canonical=%q raw=%q, want canonical=\"\" raw=dash", c, r)
+	}
+
+	t.Setenv("SHELL", "")
+	c, r, s = DetectShellDetailed()
+	if c != "" || r != "" || s != "" {
+		t.Errorf("empty SHELL: got canonical=%q raw=%q source=%q, want all empty", c, r, s)
+	}
+}
+
+// TestCurrentStatus_UnsupportedShell asserts that an unsupported
+// shell produces a Status with empty Shell + populated Unsupported
+// so warnIfHookMissing in cli/unlock can render the appropriate
+// notice (#164). File is !windows-tagged so the powershell branch
+// doesn't apply here.
+func TestCurrentStatus_UnsupportedShell(t *testing.T) {
+	t.Setenv("SHELL", "/usr/bin/fish")
+	st, err := CurrentStatus()
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st.Shell != "" {
+		t.Errorf("Shell: got %q, want empty for unsupported shell", st.Shell)
+	}
+	if st.Unsupported != "fish" {
+		t.Errorf("Unsupported: got %q, want fish", st.Unsupported)
+	}
+	if st.Source != "/usr/bin/fish" {
+		t.Errorf("Source: got %q, want /usr/bin/fish", st.Source)
+	}
+}
+
 // TestHookLinePowerShell pins the PowerShell activation line. The
 // `Invoke-Expression (& jitenv hook powershell | Out-String)` form is
 // load-bearing — pwsh has no `eval "$(...)"` equivalent.


### PR DESCRIPTION
Closes #164. See commit.