### PR TITLE
feat(release): Homebrew cask for macOS/Linux installs (#13)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,6 +75,53 @@ nfpms:
       postinstall: packaging/postinstall.sh
       preremove: packaging/preremove.sh
 
+# Homebrew tap (#13): goreleaser auto-generates a cask from the
+# macOS tarball artifacts and pushes it to a separate tap repo
+# (`Galvill/homebrew-jitenv`). End users then install with:
+#
+#     brew install Galvill/jitenv/jitenv
+#
+# Cask (not formula) because Homebrew now recommends casks for any
+# pre-built binary distribution and goreleaser is phasing out the
+# `brews:` block.
+#
+# Cross-repo pushes need a PAT scoped to the tap repo; the default
+# GITHUB_TOKEN can only write to the current repo. envOrDefault keeps
+# `goreleaser release --snapshot` working locally when the secret is
+# absent — combined with `skip_upload: auto` it just generates the
+# cask in dist/ without trying to push.
+#
+# Without notarization the cask sets `no_quarantine: true` so the
+# Gatekeeper hard-block doesn't fire on install. Users still see the
+# "downloaded from the internet" warning the first time they invoke
+# jitenv via Spotlight/Finder; running from the terminal is fine.
+homebrew_casks:
+  - name: jitenv
+    repository:
+      owner: Galvill
+      name: homebrew-jitenv
+      branch: main
+      token: '{{ envOrDefault "HOMEBREW_TAP_GITHUB_TOKEN" "" }}'
+    directory: Casks
+    homepage: https://github.com/Galvill/jitenv
+    description: Just-in-time env-var injection from pluggable secret sources, scoped to per-command process trees
+    skip_upload: auto
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew cask update for jitenv {{ .Tag }}"
+    # Bypass Gatekeeper quarantine on install — jitenv isn't yet
+    # Apple-notarized so the default cask install would prompt the
+    # user to override in System Settings. Issue #13 follow-up will
+    # flip this back to default once notarization lands.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/jitenv"]
+          end
+
 checksum:
   name_template: SHA256SUMS
 
@@ -104,6 +151,13 @@ release:
     ## jitenv {{ .Tag }}
 
     Linux, macOS, and Windows artifacts for `amd64` and `arm64`.
+
+    macOS users can install via Homebrew:
+
+    ```sh
+    brew install Galvill/jitenv/jitenv
+    ```
+
     macOS binaries are **not** Apple-notarized — first run requires
     `xattr -d com.apple.quarantine ./jitenv` or a right-click → Open.
     Windows binaries are **not** Authenticode-signed — SmartScreen

--- a/README.md
+++ b/README.md
@@ -82,12 +82,25 @@ git clone https://github.com/gv/jitenv && cd jitenv && make install
 jitenv hook install
 ```
 
-### Homebrew
+### Homebrew (macOS and Linux)
 
-A formula is planned alongside the macOS port (see
-[#13](https://github.com/Galvill/jitenv/issues/13)). When it lands,
-the formula will print caveats with the same `jitenv hook install`
-command — Homebrew formulae do not modify a user's shell rc files.
+```sh
+brew install Galvill/jitenv/jitenv
+```
+
+Distributed as a Homebrew **cask** that downloads the goreleaser
+tarball for your arch. The cask strips the `com.apple.quarantine`
+xattr on install (jitenv is not yet Apple-notarized — tracked in
+[#13](https://github.com/Galvill/jitenv/issues/13)), so the binary
+runs from the terminal without a Gatekeeper override. After install
+activate the shell hook **once** as your normal user:
+
+```sh
+jitenv hook install
+exec $SHELL
+```
+
+Homebrew never modifies your shell rc files on its own.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Adds a `homebrew_casks:` block to `.goreleaser.yaml`. On every release tag, goreleaser auto-generates a Homebrew cask from the macOS + Linux tarballs and pushes it to `Galvill/homebrew-jitenv` (a separate tap repo).
- Without Apple notarization, a `postflight` hook in the cask strips the `com.apple.quarantine` xattr so the terminal binary runs without a Gatekeeper override.
- Plumbs `HOMEBREW_TAP_GITHUB_TOKEN` through `release.yml` (PAT scoped to the tap repo — the default `GITHUB_TOKEN` can only write to the current repo).
- README's Homebrew section now points at the live install command.

Cask was chosen over formula because (a) Homebrew now recommends casks for any pre-built binary distribution, and (b) goreleaser is phasing out the `brews:` block in v2.x.

End-user install:

```sh
brew install Galvill/jitenv/jitenv
```

## Required setup before first release (manual, one-time)

1. **Create the tap repo:** an empty public repo named `Galvill/homebrew-jitenv` on GitHub.
2. **Create a fine-grained PAT:** scoped to `Galvill/homebrew-jitenv` only, with `Contents: Read and write`.
3. **Add the PAT to this repo:** `Settings → Secrets and variables → Actions → New repository secret`, name `HOMEBREW_TAP_GITHUB_TOKEN`, value the PAT from step 2.

Until step 3 lands, releases still succeed — the cask is generated locally and `skip_upload: auto` prevents the push step from running with an empty token. Once the secret is set, the next tag publishes the cask automatically.

## Test plan

- [x] `goreleaser check` passes (no deprecation warnings).
- [x] `goreleaser release --snapshot --clean --skip=sign` generates `dist/homebrew/Casks/jitenv.rb` with correct per-arch SHA256s, postflight xattr-strip, and no spurious completion entries.
- [ ] Manual: after the tap repo + PAT are set up, cut a test pre-release tag (e.g. `v0.7.0-rc1`) and confirm a formula lands at `Galvill/homebrew-jitenv/Casks/jitenv.rb`. (Note: `skip_upload: auto` will skip RC tags; either bump to a real release or use `--snapshot` semantics + check the dist/ artifact.)
- [ ] Manual: on a macOS host, `brew install Galvill/jitenv/jitenv` succeeds and `jitenv version` runs without a Gatekeeper override.