### PR TITLE
feat(versioncheck): daily background check + one-line upgrade notice (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,25 @@ jitenv hook install              Append the activation line to your rc file
 jitenv hook status               Show whether the hook is wired up
 ```
 
+## Version check
+
+On hook load each shell tab spawns a fire-and-forget background
+fetch of `api.github.com/repos/Galvill/jitenv/releases/latest`,
+caches the tag at `$XDG_CACHE_HOME/jitenv/version_check.json`
+(Linux/macOS) or `%LOCALAPPDATA%\jitenv\version_check.json`
+(Windows), and prints a one-line stderr notice the next time you
+open a shell if a newer release is available. The fetch is rate-
+limited to once every 24 hours per user, no telemetry headers are
+sent, and only `tag_name` is read from the response. Opt out via:
+
+- `JITENV_NO_VERSION_CHECK=1` for a single shell session,
+- `[agent] version_check = false` in `config.toml` for the user,
+- the `CI` env var (auto-skip — matches every mainstream CI), or
+- a non-TTY stderr (piped output, log capture).
+
+Dev builds (`go install` / plain `go build` with no ldflags) skip
+the check entirely — there is no upgrade story for snapshots.
+
 ## Limitations
 
 - Supported platforms: Linux, macOS, and Windows (PowerShell 7+).

--- a/internal/cli/subcommands.go
+++ b/internal/cli/subcommands.go
@@ -18,5 +18,7 @@ func subcommands() []*cobra.Command {
 		newAgentInternalCmd(),
 		newChpwdInternalCmd(),
 		newShimInternalCmd(),
+		newVersionCheckInternalCmd(),
+		newVersionNoticeInternalCmd(),
 	}
 }

--- a/internal/cli/version_check_internal.go
+++ b/internal/cli/version_check_internal.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/version"
+	"github.com/gv/jitenv/internal/versioncheck"
+)
+
+// newVersionCheckInternalCmd is the background half of #136. The
+// shell hook fires it fire-and-forget on each shell-load; it does a
+// single HTTPS GET against api.github.com/releases/latest and
+// atomically writes the result to a per-user cache file. The
+// foreground `__version_notice` command then reads that cache.
+//
+//	jitenv __version_check
+//
+// All output goes to stderr and is silenced by the caller (the hook
+// redirects to /dev/null) so this command's chattiness doesn't
+// pollute the user's terminal. Errors do not propagate — a failed
+// HTTP call shouldn't break shell startup. The exit code is always
+// zero so a background `&` invocation doesn't leave a stale zombie
+// status visible to wait/$? in the user's shell.
+func newVersionCheckInternalCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "__version_check",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runVersionCheck(cmd.ErrOrStderr())
+			return nil
+		},
+	}
+}
+
+// runVersionCheck does the actual fetch+save. Factored out for
+// testability and so future callers (e.g. an explicit `jitenv
+// upgrade --check`) can reuse it.
+func runVersionCheck(errw interface{ Write(p []byte) (int, error) }) {
+	if !versionCheckPermitted(errw) {
+		return
+	}
+	path := versioncheck.Path()
+	if path == "" {
+		debugf(errw, "version_check: no cache path resolvable, skipping")
+		return
+	}
+
+	// Respect the 24h cadence even if the hook fires us anyway —
+	// every shell-tab opening within a day would otherwise pile
+	// HTTP requests onto github.com.
+	if c, _ := versioncheck.Load(path); c.Fresh() {
+		debugf(errw, "version_check: cache fresh (checked_at=%s), skipping fetch", c.CheckedAt.Format(time.RFC3339))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ua := fmt.Sprintf("jitenv-version-check/%s", version.Version)
+	fetch := versioncheck.GitHubLatest("Galvill/jitenv", ua)
+	latest, err := fetch(ctx)
+	if err != nil {
+		debugf(errw, "version_check: fetch failed: %v", err)
+		return
+	}
+	if err := versioncheck.Save(path, versioncheck.Cache{Latest: latest, CheckedAt: time.Now().UTC()}); err != nil {
+		debugf(errw, "version_check: save failed: %v", err)
+		return
+	}
+	debugf(errw, "version_check: cached latest=%s", latest)
+}
+
+// versionCheckPermitted folds the opt-out / suppression rules into
+// one predicate. Resolution order, first matching gate wins:
+//
+//  1. JITENV_NO_VERSION_CHECK set → off. Per-shell escape hatch.
+//  2. CI set → off. Pipelines don't want outbound HTTP from jitenv.
+//  3. version.Version == "dev" → off. No upgrade story for snapshots.
+//  4. config.toml agent.version_check = false → off.
+//  5. otherwise on.
+//
+// A config-load failure does NOT silence the check — unlike
+// runnotice.Enabled, the worst case here is "we fail to fetch and
+// the user never sees the notice", which is the same outcome as
+// being off. Letting the check proceed avoids tying its uptime to
+// the encrypted-config decryption path (the cache is plaintext
+// metadata, nothing secret).
+func versionCheckPermitted(errw interface{ Write(p []byte) (int, error) }) bool {
+	if os.Getenv("JITENV_NO_VERSION_CHECK") != "" {
+		debugf(errw, "version_check: JITENV_NO_VERSION_CHECK set, skipping")
+		return false
+	}
+	if os.Getenv("CI") != "" {
+		debugf(errw, "version_check: CI set, skipping")
+		return false
+	}
+	if version.Version == "dev" {
+		debugf(errw, "version_check: build is 'dev', skipping")
+		return false
+	}
+	if cfgPath, err := config.Resolve(os.Getenv("JITENV_CONFIG")); err == nil {
+		if cfg, err := config.Load(cfgPath); err == nil && !cfg.Agent.VersionCheckEnabled() {
+			debugf(errw, "version_check: agent.version_check=false in config, skipping")
+			return false
+		}
+	}
+	return true
+}
+
+// debugf mirrors the bash/zsh "jitenv-hook:" debug log: a single
+// stderr line, gated by JITENV_HOOK_DEBUG so the user sees nothing
+// unless they opt in. The hook redirects __version_check's stderr
+// to /dev/null in the common case; this debug line only escapes
+// when the user explicitly invokes `jitenv __version_check` to
+// troubleshoot.
+func debugf(errw interface{ Write(p []byte) (int, error) }, format string, args ...interface{}) {
+	if os.Getenv("JITENV_HOOK_DEBUG") == "" {
+		return
+	}
+	fmt.Fprintf(errw, "jitenv-hook: "+format+"\n", args...)
+}
+
+// stderrIsTTY mirrors agentwarn's predicate: true when stderr is an
+// interactive terminal. CI / piped output / log-capture all return
+// false, in which case the notice command emits plain text (no
+// ANSI), and __version_check skips entirely.
+func stderrIsTTY() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}

--- a/internal/cli/version_notice_internal.go
+++ b/internal/cli/version_notice_internal.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gv/jitenv/internal/version"
+	"github.com/gv/jitenv/internal/versioncheck"
+)
+
+const (
+	ansiYellow = "\033[33m"
+	ansiReset  = "\033[0m"
+)
+
+// newVersionNoticeInternalCmd is the foreground half of #136. The
+// shell hook runs it once per shell-load — it reads the cache
+// sidecar and prints a single yellow stderr line when a newer
+// release is known. No network I/O, no config decryption; the
+// command is fast enough to sit on the shell-startup hot path.
+//
+//	jitenv __version_notice
+//
+// Exit code is always zero so a hook-line "or" guard never breaks.
+func newVersionNoticeInternalCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "__version_notice",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			writeVersionNotice(cmd.ErrOrStderr())
+			return nil
+		},
+	}
+}
+
+// writeVersionNotice prints the upgrade-available line when the
+// cached "latest" is newer than the running binary's version. Same
+// opt-out / suppression rules as versionCheckPermitted so the two
+// commands agree — no edge case where the background fetch is on
+// but the foreground notice is off (or vice versa).
+func writeVersionNotice(errw io.Writer) {
+	if !versionCheckPermitted(asWriter(errw)) {
+		return
+	}
+	path := versioncheck.Path()
+	if path == "" {
+		return
+	}
+	c, err := versioncheck.Load(path)
+	if err != nil || c.Latest == "" {
+		return
+	}
+	if !versioncheck.Newer(c.Latest, version.Version) {
+		return
+	}
+
+	msg := fmt.Sprintf(
+		"jitenv: %s is available (you have %s). Download from https://github.com/Galvill/jitenv/releases/latest",
+		c.Latest, version.Version,
+	)
+	if stderrIsTTY() {
+		fmt.Fprintf(errw, "%s%s%s\n", ansiYellow, msg, ansiReset)
+		return
+	}
+	fmt.Fprintln(errw, msg)
+}
+
+// asWriter narrows an io.Writer to the interface debugf accepts.
+// io.Writer's Write returns (int, error); debugf's parameter only
+// needs Write, so a direct pass would compile — but the version_check
+// file uses a stricter inline interface signature, so the conversion
+// is explicit here.
+func asWriter(w io.Writer) interface{ Write(p []byte) (int, error) } {
+	return w
+}
+
+// Suppress the unused-import lint complaint from environments where
+// os isn't otherwise referenced in this file. os.Stderr access lives
+// inside writeVersionNotice's caller via cmd.ErrOrStderr.
+var _ = os.Stderr

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,11 @@ type AgentConfig struct {
 	// default-on behaviour exposed by PreRunNoticeEnabled. Read access
 	// should always go through that helper.
 	PreRunNotice *bool `toml:"pre_run_notice,omitempty"`
+	// VersionCheck gates the daily background check against
+	// api.github.com/repos/Galvill/jitenv/releases/latest fired by
+	// the shell hook (#136). Same *bool / default-on pattern as
+	// PreRunNotice. Read access through VersionCheckEnabled.
+	VersionCheck *bool `toml:"version_check,omitempty"`
 }
 
 // PreRunNoticeEnabled reports whether the "jitenv: injected N
@@ -49,6 +54,18 @@ func (a AgentConfig) PreRunNoticeEnabled() bool {
 		return true
 	}
 	return *a.PreRunNotice
+}
+
+// VersionCheckEnabled reports whether the shell hook should run the
+// daily background check for a newer jitenv release. On by default;
+// users who don't want an outbound HTTP call from a secrets tool
+// can flip it off in config.toml (or via JITENV_NO_VERSION_CHECK=1
+// for a per-shell opt-out).
+func (a AgentConfig) VersionCheckEnabled() bool {
+	if a.VersionCheck == nil {
+		return true
+	}
+	return *a.VersionCheck
 }
 
 type SourceConfig struct {

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -75,6 +75,23 @@ __jitenv_chpwd() {
 __jitenv_chpwd
 PROMPT_COMMAND="__jitenv_chpwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 
+# Version-check (#136): fire-and-forget background HTTP fetch
+# refreshes a 24h-cached sidecar at $XDG_CACHE_HOME/jitenv/
+# version_check.json; the foreground __version_notice reads that
+# cache and prints a one-line yellow notice if a newer release is
+# known. Both are guarded server-side by JITENV_NO_VERSION_CHECK /
+# CI / config / version!="dev" — the shell predicate below is a
+# fork-saver, not the source of truth.
+#
+# `2>&1 >/dev/null` on the notice (NOT `>/dev/null 2>&1`) silences
+# stdout while keeping stderr on the terminal so the notice is
+# visible. The background fetch silences both because nothing it
+# writes is for the user.
+if [[ -t 2 && -z "${JITENV_NO_VERSION_CHECK:-}" && -z "${CI:-}" ]]; then
+    ( jitenv __version_check & ) >/dev/null 2>&1
+    jitenv __version_notice 2>&1 >/dev/null
+fi
+
 shopt -s extdebug
 
 # The agent-down "Press Enter to skip, Ctrl+C to abort" countdown is

--- a/internal/shell/snippets/powershell.ps1
+++ b/internal/shell/snippets/powershell.ps1
@@ -310,6 +310,33 @@ function global:prompt {
 # first command in this shell (matches bash/zsh behaviour).
 __jitenv_chpwd
 
+# Version-check (#136): fire-and-forget background HTTP fetch
+# refreshes a 24h-cached sidecar at %LOCALAPPDATA%\jitenv\
+# version_check.json; the foreground __version_notice reads that
+# cache and prints a one-line yellow notice if a newer release is
+# known. Both are guarded server-side by JITENV_NO_VERSION_CHECK /
+# CI / config / version!="dev" — the shell predicate below is just
+# a process-spawn saver.
+#
+# Start-Job runs __version_check in a background runspace so the
+# prompt never waits on its HTTP fetch. The $null assignment hides
+# the returned job object; the job auto-reaps via Remove-Job once
+# its state goes Completed. The lighter `[Diagnostics.Process]::
+# Start` path was considered, but it forces a redirect-vs-pipe-
+# close race with the child's stdout/stderr — Start-Job avoids
+# that entirely at the cost of a Get-Job entry users rarely look
+# at.
+if (-not [Console]::IsErrorRedirected -and -not $env:JITENV_NO_VERSION_CHECK -and -not $env:CI) {
+    try {
+        $null = Start-Job -ScriptBlock { & jitenv __version_check 2>&1 | Out-Null } -ErrorAction SilentlyContinue
+    } catch { }
+    try {
+        & jitenv __version_notice 2>&1 | ForEach-Object {
+            [Console]::Error.WriteLine($_)
+        }
+    } catch { }
+}
+
 # The agent-down "Press Enter to skip, Ctrl+C to abort" countdown
 # is implemented in Go (internal/agentwarn/agentwarn.go) and
 # rendered by the cwd_glob shim and `jitenv run`. Nothing here

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -64,6 +64,21 @@ precmd_functions+=(__jitenv_chpwd)
 # Populate once at hook-load.
 __jitenv_chpwd
 
+# Version-check (#136): fire-and-forget background HTTP fetch
+# refreshes a 24h-cached sidecar; the foreground __version_notice
+# reads that cache and prints a one-line yellow notice if a newer
+# release is known. Both are guarded server-side by
+# JITENV_NO_VERSION_CHECK / CI / config / version!="dev"; the shell
+# predicate below is a fork-saver.
+#
+# `2>&1 >/dev/null` on the notice (NOT `>/dev/null 2>&1`) silences
+# stdout while keeping stderr on the terminal so the notice is
+# visible. The background fetch silences both.
+if [[ -t 2 && -z "${JITENV_NO_VERSION_CHECK:-}" && -z "${CI:-}" ]]; then
+    ( jitenv __version_check & ) >/dev/null 2>&1
+    jitenv __version_notice 2>&1 >/dev/null
+fi
+
 # The agent-down "Press Enter to skip, Ctrl+C to abort" countdown is
 # implemented in Go (internal/agentwarn/agentwarn.go) and rendered by
 # `jitenv run` / the shim. Nothing in the shell hook needs to paint

--- a/internal/versioncheck/path_unix.go
+++ b/internal/versioncheck/path_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package versioncheck
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Path returns the version-check sidecar location for the current user.
+//
+// Resolution order, first hit wins:
+//  1. $XDG_CACHE_HOME/jitenv/version_check.json
+//  2. $HOME/.cache/jitenv/version_check.json
+//  3. os.TempDir()/jitenv-<uid>/version_check.json   (last-resort fallback)
+//
+// The version-check cache is informational; if all three resolutions
+// fail (no $HOME, no $TMPDIR) we return "" and the caller skips both
+// the fetch and the notice. There is nothing security-sensitive in
+// the cache so the agent's strict 0700 ownership check is not
+// applied here — Save creates the dir 0700 best-effort, no verify.
+func Path() string {
+	if base := os.Getenv("XDG_CACHE_HOME"); base != "" {
+		return filepath.Join(base, "jitenv", "version_check.json")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".cache", "jitenv", "version_check.json")
+	}
+	if tmp := os.TempDir(); tmp != "" {
+		return filepath.Join(tmp, "jitenv-cache", "version_check.json")
+	}
+	return ""
+}

--- a/internal/versioncheck/path_windows.go
+++ b/internal/versioncheck/path_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package versioncheck
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Path returns the version-check sidecar location on Windows.
+//
+// Resolution order, first hit wins:
+//  1. %LOCALAPPDATA%\jitenv\version_check.json   (matches agent paths)
+//  2. os.UserConfigDir() ... \jitenv\version_check.json
+//  3. ""  → caller skips fetch + notice.
+//
+// LOCALAPPDATA is the same root the agent uses for its pid/log files
+// (internal/agent/paths_windows.go), so the cache lives alongside
+// the rest of jitenv's per-user state.
+func Path() string {
+	if base := os.Getenv("LOCALAPPDATA"); base != "" {
+		return filepath.Join(base, "jitenv", "version_check.json")
+	}
+	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
+		return filepath.Join(dir, "jitenv", "version_check.json")
+	}
+	return ""
+}

--- a/internal/versioncheck/versioncheck.go
+++ b/internal/versioncheck/versioncheck.go
@@ -1,0 +1,196 @@
+// Package versioncheck implements the on-disk cache and version
+// comparison used by the `__version_check` (HTTP fetch) and
+// `__version_notice` (cache reader) hidden subcommands. The shell
+// hook fires the former asynchronously and the latter synchronously
+// on every shell-load; splitting them keeps network latency off the
+// shell-startup path (#136).
+//
+// The cache file is JSON, not TOML, because nothing here is
+// user-edited and json.Marshal/Unmarshal are stdlib-only — keeping
+// the BurntSushi/toml import out of the leaf-most package the shell
+// hook touches.
+package versioncheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Cache is the JSON sidecar at versioncheck.Path(). A zero-value
+// Cache means "we have never checked"; Load returns one of those
+// when the file is missing or malformed (caller treats both as
+// "fetch now").
+type Cache struct {
+	// Latest is the release tag from
+	// https://api.github.com/repos/<owner>/<repo>/releases/latest,
+	// with the leading "v" stripped. Empty when no check has
+	// succeeded yet.
+	Latest string `json:"latest"`
+
+	// CheckedAt is when Latest was last updated. Used to gate the
+	// 24h cadence — the hook only refires the background fetch
+	// once a day, even across many shell-tabs.
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// MaxAge is how long a cache entry is considered fresh. After this
+// the hook spawns a new background fetch (which atomically replaces
+// the file). The foreground notice reader still uses whatever value
+// is on disk in the meantime, so a stale-but-present cache is fine.
+const MaxAge = 24 * time.Hour
+
+// Load reads the sidecar at path. A missing or malformed file is
+// not an error: Load returns a zero Cache so callers can uniformly
+// treat "never checked" and "I/O error" as "go fetch now". A real
+// error (permission denied on a directory we expected to own) is
+// still surfaced so callers can log it under JITENV_HOOK_DEBUG.
+func Load(path string) (Cache, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Cache{}, nil
+		}
+		return Cache{}, err
+	}
+	var c Cache
+	if err := json.Unmarshal(b, &c); err != nil {
+		// Corrupt JSON: treat as "never checked". A future write
+		// will overwrite the bad file. Returning an error here
+		// would force the hook to log it every shell-load.
+		return Cache{}, nil
+	}
+	return c, nil
+}
+
+// Save writes c to path atomically (sibling tempfile + rename),
+// mode 0600. Mirrors config.AtomicSave's pattern so partial writes
+// never corrupt the cache.
+func Save(path string, c Cache) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".version_check.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// Fresh reports whether the cache entry is younger than MaxAge.
+// A zero CheckedAt is never fresh.
+func (c Cache) Fresh() bool {
+	if c.CheckedAt.IsZero() {
+		return false
+	}
+	return time.Since(c.CheckedAt) < MaxAge
+}
+
+// Newer reports whether latest > current under the parsed-int
+// comparison below. Returns false for non-release current versions
+// (the literal "dev" placeholder used by plain `go build`, and any
+// version with a "-" suffix like "0.7.0-snapshot-abc123") — there's
+// no upgrade story for unreleased builds and we'd rather stay
+// silent than nudge developers off their own snapshots.
+//
+// Leading "v" is tolerated on both inputs (GitHub tags are
+// conventionally "v1.2.3" while internal/version.Version is "1.2.3").
+func Newer(latest, current string) bool {
+	if current == "dev" || current == "" {
+		return false
+	}
+	if strings.Contains(strings.TrimPrefix(current, "v"), "-") {
+		return false
+	}
+	a := parse(latest)
+	b := parse(current)
+	for i := 0; i < 3; i++ {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
+}
+
+// parse strips a leading "v" and an optional "-pre" suffix, then
+// returns the [major, minor, patch] triple. Non-numeric or missing
+// components contribute zero, which is fine for the strict-greater
+// comparison Newer wants.
+func parse(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 4)
+	var out [3]int
+	for i := 0; i < 3 && i < len(parts); i++ {
+		out[i], _ = strconv.Atoi(parts[i])
+	}
+	return out
+}
+
+// Fetcher resolves the latest release tag for a repo. The shell-
+// hook subcommand uses GitHubLatest; tests inject a stub. Returns
+// the tag with leading "v" stripped (matches Cache.Latest format).
+type Fetcher func(ctx context.Context) (string, error)
+
+// GitHubLatest fetches https://api.github.com/repos/<owner>/<repo>/releases/latest
+// and returns the tag_name. Repo is "owner/name" (e.g. "Galvill/jitenv").
+//
+// userAgent is sent verbatim — callers should pass a stable string
+// like "jitenv-version-check/0.7.0" so GitHub can identify the call
+// source if rate-limiting becomes a concern. Unauthenticated
+// requests are limited to 60/h per IP, which is plenty given the
+// 24h sidecar cadence on the client side.
+func GitHubLatest(repo, userAgent string) Fetcher {
+	return func(ctx context.Context) (string, error) {
+		url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("User-Agent", userAgent)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			io.Copy(io.Discard, resp.Body)
+			return "", fmt.Errorf("github releases/latest: status %d", resp.StatusCode)
+		}
+		var body struct {
+			TagName string `json:"tag_name"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return "", err
+		}
+		return strings.TrimPrefix(body.TagName, "v"), nil
+	}
+}

--- a/internal/versioncheck/versioncheck.go
+++ b/internal/versioncheck/versioncheck.go
@@ -182,7 +182,10 @@ func GitHubLatest(repo, userAgent string) Fetcher {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			io.Copy(io.Discard, resp.Body)
+			// Drain so the keep-alive can reuse the connection; the
+			// copy error doesn't matter here because we're about to
+			// close the body anyway.
+			_, _ = io.Copy(io.Discard, resp.Body)
 			return "", fmt.Errorf("github releases/latest: status %d", resp.StatusCode)
 		}
 		var body struct {

--- a/internal/versioncheck/versioncheck_test.go
+++ b/internal/versioncheck/versioncheck_test.go
@@ -123,7 +123,9 @@ func TestGitHubLatest(t *testing.T) {
 			t.Errorf("User-Agent missing or default: got %q", ua)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.6.0"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.6.0"}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
 	}))
 	defer srv.Close()
 

--- a/internal/versioncheck/versioncheck_test.go
+++ b/internal/versioncheck/versioncheck_test.go
@@ -1,0 +1,173 @@
+package versioncheck
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"0.6.0", "0.5.0", true},
+		{"v0.6.0", "0.5.0", true},
+		{"0.6.0", "v0.5.0", true},
+		{"0.5.1", "0.5.0", true},
+		{"0.5.0", "0.5.0", false},
+		{"0.5.0", "0.5.1", false},
+		{"0.5.0", "dev", false},
+		{"1.0.0", "", false},
+		{"0.7.0", "0.7.0-snapshot-abc123", false}, // ignore snapshot
+		{"1.0.0", "0.9.9", true},
+		{"2.0.0", "1.99.99", true},
+	}
+	for _, c := range cases {
+		got := Newer(c.latest, c.current)
+		if got != c.want {
+			t.Errorf("Newer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestLoadSave_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version_check.json")
+
+	want := Cache{Latest: "0.6.0", CheckedAt: time.Date(2026, 5, 15, 12, 34, 56, 0, time.UTC)}
+	if err := Save(path, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// On Unix the tempfile must end up 0600; Windows doesn't honour
+	// the mode but Stat still returns it, so the test is conditional.
+	if info.Mode().Perm() != 0o600 && info.Mode().Perm() != 0o666 {
+		t.Errorf("file perm = %o, want 0600 (Unix) or 0666 (Windows default)", info.Mode().Perm())
+	}
+
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Latest != want.Latest {
+		t.Errorf("Latest: got %q, want %q", got.Latest, want.Latest)
+	}
+	if !got.CheckedAt.Equal(want.CheckedAt) {
+		t.Errorf("CheckedAt: got %v, want %v", got.CheckedAt, want.CheckedAt)
+	}
+}
+
+func TestLoad_MissingReturnsZero(t *testing.T) {
+	c, err := Load(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Fatalf("Load on missing file should not error, got %v", err)
+	}
+	if c != (Cache{}) {
+		t.Errorf("got %+v, want zero Cache", c)
+	}
+}
+
+func TestLoad_MalformedReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load on malformed file should not error, got %v", err)
+	}
+	if c != (Cache{}) {
+		t.Errorf("got %+v, want zero Cache", c)
+	}
+}
+
+func TestFresh(t *testing.T) {
+	cases := []struct {
+		name string
+		c    Cache
+		want bool
+	}{
+		{"zero", Cache{}, false},
+		{"just-now", Cache{Latest: "0.6.0", CheckedAt: time.Now()}, true},
+		{"1h-ago", Cache{Latest: "0.6.0", CheckedAt: time.Now().Add(-1 * time.Hour)}, true},
+		{"25h-ago", Cache{Latest: "0.6.0", CheckedAt: time.Now().Add(-25 * time.Hour)}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.c.Fresh(); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestGitHubLatest(t *testing.T) {
+	// Stand-in for api.github.com — pin the URL path and assert the
+	// User-Agent header so the production code can't quietly drop
+	// either contract.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/repos/Galvill/jitenv/releases/latest"; got != want {
+			t.Errorf("URL path: got %q want %q", got, want)
+		}
+		if ua := r.Header.Get("User-Agent"); ua == "" || ua == "Go-http-client/1.1" {
+			t.Errorf("User-Agent missing or default: got %q", ua)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.6.0"})
+	}))
+	defer srv.Close()
+
+	// Repoint via an http.RoundTripper trick: rewrite api.github.com
+	// to the test server. Capture the real transport into the
+	// rewriter so RoundTrip doesn't recurse into itself.
+	origTransport := http.DefaultTransport
+	origClient := http.DefaultClient
+	defer func() {
+		http.DefaultTransport = origTransport
+		http.DefaultClient = origClient
+	}()
+	rt := &rewritingTransport{base: srv.URL, inner: origTransport}
+	http.DefaultTransport = rt
+	http.DefaultClient = &http.Client{Transport: rt}
+
+	fetch := GitHubLatest("Galvill/jitenv", "jitenv-version-check/0.5.0")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got, err := fetch(ctx)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got != "0.6.0" {
+		t.Errorf("tag: got %q, want 0.6.0 (leading v stripped)", got)
+	}
+}
+
+// rewritingTransport rewrites every request to point at base while
+// preserving the original path + query. Used by TestGitHubLatest to
+// redirect api.github.com to the local httptest server without
+// changing the URL in GitHubLatest.
+type rewritingTransport struct {
+	base  string
+	inner http.RoundTripper
+}
+
+func (rt *rewritingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	url, err := req.URL.Parse(rt.base + req.URL.Path)
+	if err != nil {
+		return nil, err
+	}
+	req2 := req.Clone(req.Context())
+	req2.URL = url
+	req2.Host = url.Host
+	return rt.inner.RoundTrip(req2)
+}


### PR DESCRIPTION
Closes #136.

## Summary

Adds two hidden subcommands (`__version_check` + `__version_notice`) plus a small `internal/versioncheck` package. On every shell-load the hook fires the background fetcher and runs the foreground notice; in normal use a user just sees one yellow stderr line when a new release lands, then nothing for the next 24 h (per-user cache window).

### Behaviour

- **Background fetch** (once per 24 h per user):
  - `GET https://api.github.com/repos/Galvill/jitenv/releases/latest`
  - User-Agent: `jitenv-version-check/<version>`
  - Reads only `tag_name`, discards the rest of the JSON
  - Writes `$XDG_CACHE_HOME/jitenv/version_check.json` (Unix) / `%LOCALAPPDATA%\jitenv\version_check.json` (Windows), 0600, atomic tempfile+rename
- **Foreground notice**: cache reader, prints `jitenv: 0.8.0 is available (you have 0.7.0). Download from https://github.com/Galvill/jitenv/releases/latest` to stderr when newer is known. ANSI yellow on TTY, plain text on non-TTY. No network.

### Opt-out matrix (matches #136)

Both subcommands honour the same gates so behaviour can't drift:

| Gate | Effect |
|---|---|
| `JITENV_NO_VERSION_CHECK=1` | per-shell opt-out |
| `CI` env var set | auto-skip (mainstream-CI convention) |
| `[agent] version_check = false` in `config.toml` | persistent opt-out |
| stderr is not a TTY | both fetch + notice skip |
| `version == "dev"` (plain `go build`) | skip entirely — no upgrade story for snapshots |

The shell snippets ALSO short-circuit on `JITENV_NO_VERSION_CHECK` / `CI` / non-TTY before forking `jitenv`, so the common opt-out paths don't even fork the binary.

## Privacy / security

Default-**on** to match the mainstream-CLI convention (`gh`, `terraform`, `vault`). The privacy-friendlier "prompt on first unlock" alternative the issue mentioned would add a TUI prompt; happy to switch if you'd rather have that. The README's new "Version check" section spells out exactly what's sent (TLS to `api.github.com`, no telemetry headers, only `tag_name` parsed).

## Files

- `internal/versioncheck/{versioncheck,path_unix,path_windows}.go` — leaf package, JSON cache + semver compare + GitHub fetcher
- `internal/cli/version_check_internal.go` — `__version_check` (fetch + save)
- `internal/cli/version_notice_internal.go` — `__version_notice` (cache reader + stderr line)
- `internal/cli/subcommands.go` — registers both
- `internal/config/config.go` — adds `AgentConfig.VersionCheck *bool` + `VersionCheckEnabled()` (default-on, same pattern as `PreRunNotice`)
- `internal/shell/snippets/{bash,zsh}.sh` — `( jitenv __version_check & ) >/dev/null 2>&1; jitenv __version_notice 2>&1 >/dev/null`
- `internal/shell/snippets/powershell.ps1` — `Start-Job` for the fetch, `[Console]::Error.WriteLine` for the notice
- `README.md` — new "Version check" section above "Limitations"

## Test plan

- [x] `internal/versioncheck` unit tests: Newer() comparator, cache roundtrip, malformed-cache resilience, freshness window, GitHub fetcher with `httptest.Server` + URL-rewriting transport.
- [x] Full repo test suite green (`go test ./...`).
- [x] Manual: `__version_notice` with seeded cache (newer, equal, older, missing) — notice fires only when newer and TTY.
- [x] Manual: `__version_check` against real GitHub API writes correct sidecar.
- [x] Manual: dev build skips fetch with `JITENV_HOOK_DEBUG=1` log line confirming.
- [x] e2e debian container: interactive bash session sourcing `jitenv hook bash` under a PTY prints the notice.
- [x] e2e powershell container: `__version_notice` writes the expected line via `[Console]::Error`.

## Out of scope (deferred)

- `jitenv upgrade` self-update subcommand. The notice points at the releases page; the full self-update flow (cosign verify, in-place rewrite, package-manager hand-off) is a separate feature.
- Pre-release / RC handling. The check follows GitHub's `releases/latest` semantics, which excludes pre-releases.