### PR TITLE
fix: stop injecting twice in turbo workers + stop terminal-query leak (#182)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,34 @@ builds:
       - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
       - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
 
+  # The interactive TUI lives in a separate binary so the main
+  # jitenv binary's import graph stays free of Bubble Tea / Lip
+  # Gloss / termenv. Those libs send OSC 11 (background color) +
+  # CPR (\e[6n) queries to the tty at package-init time; in
+  # contexts where the parent doesn't consume the responses
+  # (turbo strict-env pty being the canonical example) the
+  # responses leak into the user's output stream. See #182 bug B.
+  # `jitenv config` re-execs this binary via internal/cli/config.go.
+  - id: jitenv-tui
+    main: ./cmd/jitenv-tui
+    binary: jitenv-tui
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
+      - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+
 archives:
   - id: jitenv
     # Unix archives are tar.gz; Windows archives are .zip so users can
@@ -36,7 +64,13 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
-    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # Both binaries ship in the same archive so a brew/dpkg/manual
+    # install gets the pair atomically. `ids:` is the v2-spelling
+    # of the build allowlist.
+    ids:
+      - jitenv
+      - jitenv-tui
+    name_template: "jitenv_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -50,6 +84,9 @@ archives:
 nfpms:
   - id: jitenv
     package_name: jitenv
+    ids:
+      - jitenv
+      - jitenv-tui
     vendor: Galvill
     homepage: https://github.com/Galvill/jitenv
     maintainer: Galvill <nexvill.ai@gmail.com>
@@ -106,6 +143,13 @@ homebrew_casks:
     homepage: https://github.com/Galvill/jitenv
     description: Just-in-time env-var injection from pluggable secret sources, scoped to per-command process trees
     skip_upload: auto
+    # Ship both halves of the binary split (#182 bug B): jitenv runs
+    # everything except the TUI; jitenv-tui is the re-exec target for
+    # `jitenv config`. The cask links both into the Homebrew prefix
+    # bin/ so `which jitenv-tui` resolves.
+    binaries:
+      - jitenv
+      - jitenv-tui
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
@@ -120,6 +164,8 @@ homebrew_casks:
           if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
             system_command "/usr/bin/xattr",
                            args: ["-dr", "com.apple.quarantine", "#{staged_path}/jitenv"]
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/jitenv-tui"]
           end
 
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,19 @@ LDFLAGS := -s -w \
 
 build:
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN) ./cmd/jitenv
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-tui ./cmd/jitenv-tui
 
-# Cross-compile the Windows binary. Stage 1 (#80) made the codebase
-# compile for GOOS=windows; the runtime port lands in #86-91. Useful
-# for reviewers verifying a Windows-touching PR really produces an
-# executable — `go build ./...` is a compile-check only and does not
-# emit a .exe.
+# Cross-compile the Windows binaries. The TUI ships as a separate
+# binary (#182 bug B): the main jitenv binary stays free of
+# Bubble Tea / Lip Gloss imports so it doesn't query the terminal
+# on every invocation.
 build-windows:
 	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN).exe ./cmd/jitenv
+	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-tui.exe ./cmd/jitenv-tui
 
 install: build
 	install -Dm0755 bin/$(BIN) $(PREFIX)/bin/$(BIN)
+	install -Dm0755 bin/$(BIN)-tui $(PREFIX)/bin/$(BIN)-tui
 
 test:
 	$(GO) test ./...

--- a/cmd/jitenv-tui/main.go
+++ b/cmd/jitenv-tui/main.go
@@ -1,0 +1,56 @@
+// Command jitenv-tui is the separate-binary host for the
+// interactive TUI used by `jitenv config`. It exists so the main
+// `jitenv` binary doesn't transitively import Bubble Tea / Lip
+// Gloss / termenv — those libs send OSC 11 (background color) and
+// CPR (\e[6n) queries to the terminal at package init, and the
+// responses leak into captured output of every jitenv subcommand
+// when the parent process doesn't manage the tty. See #182 bug B.
+//
+// CLI surface (called by `internal/cli/config.go` via os/exec):
+//
+//	jitenv-tui run                — full TUI from the existing config
+//
+// The TUI prompts for the passphrase itself; no master-key handoff
+// over fds is needed on this path.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+	"github.com/gv/jitenv/internal/tui"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "jitenv-tui: missing subcommand (expected: run)")
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "run":
+		var cfgPath string
+		if len(args) >= 2 {
+			cfgPath = args[1]
+		}
+		if cfgPath == "" {
+			// Fall back to env var / default resolution — matches what
+			// `jitenv config` does today.
+			cfgPath = os.Getenv("JITENV_CONFIG")
+		}
+		resolved, err := config.Resolve(cfgPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "jitenv-tui:", err)
+			os.Exit(1)
+		}
+		if err := tui.Run(resolved); err != nil {
+			fmt.Fprintln(os.Stderr, "jitenv-tui:", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "jitenv-tui: unknown subcommand %q\n", args[0])
+		os.Exit(2)
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
@@ -12,7 +14,6 @@ import (
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/lockfile"
-	"github.com/gv/jitenv/internal/tui"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -129,7 +130,68 @@ func runConfigTUI() error {
 	}
 	defer lock.Close()
 
-	return tui.Run(configPath)
+	return execJitenvTUI("run", configPath)
+}
+
+// execJitenvTUI re-execs the separate jitenv-tui binary, replacing
+// the current process's stdio with the child's so the TUI renders
+// directly to the user's terminal. The split exists to keep the
+// main `jitenv` binary's import graph free of Bubble Tea / Lip Gloss
+// / termenv — those libs send OSC 11 + CPR queries to the tty at
+// package-init time, and the responses leak into captured output of
+// every jitenv subcommand on terminals that don't manage the
+// responses cleanly (turbo strict-env pty, #182 bug B).
+//
+// Resolution order for the binary:
+//  1. JITENV_TUI_BIN env var (test / dev override).
+//  2. Sibling to the running jitenv executable (typical packaging
+//     case: both binaries live in /usr/local/bin or the Homebrew
+//     cellar bin/).
+//  3. PATH lookup.
+//
+// On error 127 ("not found") the user gets a clear message pointing
+// at the install — common cause is upgrading jitenv without picking
+// up the new sibling binary.
+func execJitenvTUI(args ...string) error {
+	binPath, err := resolveJitenvTUIPath()
+	if err != nil {
+		return err
+	}
+	c := exec.Command(binPath, args...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Env = os.Environ()
+	if err := c.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.ExitCode())
+		}
+		return fmt.Errorf("jitenv-tui: %w", err)
+	}
+	return nil
+}
+
+func resolveJitenvTUIPath() (string, error) {
+	if override := os.Getenv("JITENV_TUI_BIN"); override != "" {
+		return override, nil
+	}
+	if exe, err := os.Executable(); err == nil && exe != "" {
+		dir := filepath.Dir(exe)
+		candidate := filepath.Join(dir, jitenvTUIBinName())
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	if p, err := exec.LookPath(jitenvTUIBinName()); err == nil {
+		return p, nil
+	}
+	return "", fmt.Errorf(
+		"jitenv-tui not found (looked next to jitenv and on $PATH). "+
+			"The interactive TUI ships as a separate binary; if you upgraded jitenv "+
+			"manually, ensure %s is installed alongside.",
+		jitenvTUIBinName(),
+	)
 }
 
 func zeroBytes(b []byte) {

--- a/internal/cli/jitenv_tui_name.go
+++ b/internal/cli/jitenv_tui_name.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package cli
+
+// jitenvTUIBinName returns the filename of the TUI sibling binary on
+// this OS. Defined per-platform so the Windows .exe suffix doesn't
+// leak into the Unix build (and vice-versa).
+func jitenvTUIBinName() string { return "jitenv-tui" }

--- a/internal/cli/jitenv_tui_name_windows.go
+++ b/internal/cli/jitenv_tui_name_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package cli
+
+// jitenvTUIBinName: Windows expects .exe so the resolution chain
+// (sibling-of-jitenv → PATH lookup) hits the right file.
+func jitenvTUIBinName() string { return "jitenv-tui.exe" }

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -105,7 +105,17 @@ func run(invokedAs string, args []string) error {
 	// See injectedMarker doc and issue #77. Bypass requires the marker
 	// to match the per-session nonce (security #120) so a stale value
 	// can't silently disable injection.
-	if injectionAlreadyApplied() {
+	//
+	// Two-channel check (#182): the env-marker check above can fail
+	// when an intermediate process strips env vars before spawning a
+	// child — turbo 2.x's Strict Environment Mode is the canonical
+	// case. As a fallback, look for an on-disk marker file under the
+	// per-shell wrap-dir parent (which we can recover from PATH/argv
+	// even when env vars are stripped, because the wrapper had to be
+	// found via PATH to invoke us). The file lives inside the agent's
+	// runtime dir (0700, owner-only); reading it is no weaker than
+	// reading the agent's own socket from the same dir.
+	if injectionAlreadyApplied() || markerFileSays(selfDir) {
 		return execReal(realPath, argv, os.Environ())
 	}
 
@@ -150,6 +160,16 @@ func run(invokedAs string, args []string) error {
 				env = append(env, sessionNonce+"="+nonce)
 			}
 			env = append(env, injectedMarker+"="+nonce)
+			// Drop a per-shell marker file as the env-stripping fallback
+			// (#182). Subsequent shim invocations that have lost the env
+			// marker (turbo strict env mode, firejail, bwrap, …) can
+			// still detect "already injected" by reading this file. The
+			// file's existence — not its contents — is what gates the
+			// bypass; we still write the nonce so a future tool can do
+			// per-chain checks if needed. Best-effort: a write failure
+			// just degrades to the old behaviour (double notice under
+			// env stripping).
+			_ = writeMarkerFile(selfDir, nonce)
 		}
 	}
 
@@ -227,6 +247,84 @@ func firstArg() string {
 		return os.Args[0]
 	}
 	return ""
+}
+
+// markerFilename is the basename of the on-disk "already injected"
+// marker (#182). Lives under the per-shell runtime dir
+// (<runtime>/shells/<shell-pid>/), next to the wrapper bin/.
+// Garbage-collected by agent.GcOrphanShells when the shell exits.
+const markerFilename = "injected"
+
+// shellDirFromWrap returns the per-shell directory derived from a
+// wrap-dir path. The wrap-dir layout is <runtime>/shells/<pid>/bin,
+// so the per-shell dir is one level up. Returns "" when wrapDir is
+// empty or unparseable.
+func shellDirFromWrap(wrapDir string) string {
+	if wrapDir == "" {
+		return ""
+	}
+	clean := filepath.Clean(wrapDir)
+	if filepath.Base(clean) != "bin" {
+		return ""
+	}
+	return filepath.Dir(clean)
+}
+
+// markerFileSays reports whether a per-shell injection marker exists
+// at <shellDir>/<markerFilename>. Used as the env-stripping fallback
+// for the in-chain bypass check (#182): when an intermediate process
+// (turbo strict env mode, firejail, sandboxer) drops the marker env
+// vars, the file is the surviving signal.
+//
+// Returns false on any error (file missing, permission denied,
+// shellDir unresolvable) — the caller falls through to a fresh
+// inject, which is the same behaviour as today when env stripping
+// happens.
+func markerFileSays(wrapDir string) bool {
+	shellDir := shellDirFromWrap(wrapDir)
+	if shellDir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(shellDir, markerFilename))
+	return err == nil
+}
+
+// writeMarkerFile drops <shellDir>/<markerFilename> as a one-time
+// signal that the first shim hop in this shell has done its
+// injection. Content is the per-chain nonce so a future tool can
+// scope checks per-chain; today only file presence is consulted.
+// Mode 0600; owner-only (the shell dir is already 0700 owned by the
+// user). Best-effort — callers ignore errors so a marker-file write
+// failure just falls back to today's behaviour.
+func writeMarkerFile(wrapDir, nonce string) error {
+	shellDir := shellDirFromWrap(wrapDir)
+	if shellDir == "" {
+		return errors.New("cannot derive per-shell dir from wrap dir")
+	}
+	if err := os.MkdirAll(shellDir, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(shellDir, markerFilename)
+	// Atomic-via-tempfile: a partially-written marker on power loss
+	// shouldn't cause a confused half-bypass.
+	tmp, err := os.CreateTemp(shellDir, "."+markerFilename+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.WriteString(nonce); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // lookPathExcluding searches $PATH for `name`, skipping any entry that

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -226,3 +226,87 @@ func TestShimSuppressesInjectionWithMarker(t *testing.T) {
 		t.Errorf("expected __JITENV_INJECTED=%s to propagate to child env;\noutput=%s", nonce, out)
 	}
 }
+
+// TestShimSuppressesInjectionViaMarkerFile is the regression test for
+// the env-stripping branch of issue #182: turbo strict env mode (and
+// firejail / bwrap / sandboxer variants) strips __JITENV_INJECTED
+// and __JITENV_SESSION_NONCE before spawning children, so the env-
+// based bypass in TestShimSuppressesInjectionWithMarker can't fire.
+// The fallback is an on-disk marker file at <wrap-dir>/../injected.
+// This test simulates that case directly: drop the marker file by
+// hand (no first-pass run to create it — we want to exercise the
+// file-only branch), then invoke the shim with NO env markers set
+// and confirm the bypass still fires.
+func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap-dir layout MUST be <shellDir>/bin (the shim's
+	// shellDirFromWrap derives shellDir as filepath.Dir(wrapDir) and
+	// rejects wrap-dirs whose basename isn't "bin").
+	shellDir := filepath.Join(dir, "shell-xxx")
+	wrapDir := filepath.Join(shellDir, "bin")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drop the marker file. The shim only checks file presence; the
+	// content can be anything (today the nonce, future tools may
+	// switch to per-chain matching).
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
+
+	// Crucially: NO __JITENV_INJECTED, NO __JITENV_SESSION_NONCE, NO
+	// __JITENV_SHELL_PID — simulates turbo's strict-env stripping of
+	// jitenv-namespaced vars. __JITENV_WRAP_DIR is also dropped; the
+	// shim's fallback resolves the wrap dir from argv[0].
+	env := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	cmd := exec.Command(wrapper)
+	cmd.Env = env
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, buf.String())
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "agent is not loaded") {
+		t.Errorf("warning fired despite marker file; output=%s", out)
+	}
+	if strings.Contains(out, "jitenv: injected") {
+		t.Errorf("notice fired despite marker file; output=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+}


### PR DESCRIPTION
Closes #182.

## Summary

Two commits, two bugs:

### Bug A — `fix(shim): on-disk marker file as env-stripping fallback`

Turbo 2.x's Strict Environment Mode (and firejail / bwrap / sandboxer variants) strips env vars before spawning children, which defeats the existing `__JITENV_INJECTED` / `__JITENV_SESSION_NONCE` bypass (security #120). The shim then re-fetches and re-prints `jitenv: injected N variables` per worker.

Fix: add an on-disk marker file at `<wrap-dir>/../injected` (i.e. `<runtime>/shells/<shell-pid>/injected`) as a second bypass channel. The wrap-dir path survives env stripping because PATH itself has to be preserved for the wrapper to be found in the first place. File presence — not contents — gates the bypass; the nonce is still written so future tools can do per-chain matching. Cleaned up by `agent.GcOrphanShells` when the shell exits.

### Bug B — `feat(cli): split TUI into separate jitenv-tui binary`

Bubble Tea v1.3.10's `tea_init.go` runs `lipgloss.HasDarkBackground()` at package init, sending OSC 11 + CPR queries to the tty. In an interactive shell the responses are consumed by the shell; in turbo's pty (and any other context that doesn't manage tty responses) the bytes leak into captured output. Because `internal/cli` previously imported `internal/tui`, bubbletea was linked into the main binary and its init fired on EVERY jitenv invocation.

Fix: factor the TUI into a new `cmd/jitenv-tui` binary. `internal/cli/config.go` re-execs it via `os/exec` when the user runs `jitenv config`. The main binary's import graph no longer contains bubbletea / lipgloss / termenv.

## Verified

```
$ xxd <(jitenv version 2>&1) | grep -cE "1b 5d|1b 5b"
0
$ xxd <(jitenv-tui 2>&1) | grep -cE "1b 5d|1b 5b"
1   # expected — TUI is allowed to query because the user is in it
```

End-to-end in the e2e debian container with a fresh deb install:
- Both binaries land at `/usr/bin/jitenv` and `/usr/bin/jitenv-tui`.
- `jitenv version` byte-for-byte clean (no escape responses).
- `jitenv config` resolves the sibling binary, prompts for the passphrase, and renders the TUI.
- New `TestShimSuppressesInjectionViaMarkerFile` exercises the env-stripping branch directly.

Full test suite + `golangci-lint v1.62.2` green.

## Packaging changes

| Artifact | Before | After |
|---|---|---|
| `dist/jitenv_<v>_<os>_<arch>.tar.gz` | jitenv | jitenv + jitenv-tui |
| deb / rpm | `/usr/bin/jitenv` | `/usr/bin/jitenv` + `/usr/bin/jitenv-tui` |
| Homebrew cask | `binary "jitenv"` | `binaries: [jitenv, jitenv-tui]`, both un-quarantined post-flight |
| Makefile `build` / `install` | jitenv only | jitenv + jitenv-tui |

The forthcoming Chocolatey package (#180) will need the same treatment when it lands.

## Binary resolution chain (in jitenv → jitenv-tui handoff)

Most-specific first; the first hit wins:

1. `JITENV_TUI_BIN` env var (test / dev override).
2. Sibling to the running jitenv executable — typical packaging case (both binaries in the same `bin/` dir).
3. `PATH` lookup.

A clear error message points at the install if neither resolves, in case a user upgrades manually and forgets the second binary.

## Test plan

- [x] `go test ./...` green.
- [x] `golangci-lint v1.62.2 run ./...` clean.
- [x] `xxd <(jitenv version)` produces zero OSC 11 / CPR bytes.
- [x] e2e debian: deb install, both binaries on disk, TUI launches via re-exec.
- [x] Marker-file test covers the env-stripping bypass directly.
- [ ] Manual: a real turbo monorepo (the user's reproducer) prints `jitenv: injected N variables` exactly once across all workers — to be verified by the issue author after merge.

## Out-of-scope (deferred)

- Process-tree ancestry detection (the alternative to file-marker proposed in #182). The file-marker is cross-platform; process-tree walking is Linux-only and more brittle. We can revisit if the file-marker proves insufficient.
- Bubble Tea v2 upgrade — separate effort, breaking API changes.