### PR TITLE
fix(shim): recover wrap dir from PATH when env vars are stripped (#182)

### DIFF
--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -92,6 +92,24 @@ func run(invokedAs string, args []string) error {
 	if selfDir == "" {
 		selfDir = filepath.Dir(firstArg())
 	}
+	// Env-stripping recovery (#182): when an intermediate process
+	// (turbo strict env mode is the canonical case; firejail / bwrap
+	// / sandboxer variants behave the same) drops __JITENV_WRAP_DIR
+	// before exec, and argv[0] is the bare basename ("npm") because
+	// the caller used execvp-by-name, both lookups above land at "."
+	// — which then breaks both the PATH-exclusion (infinite re-exec
+	// loop) AND the marker-file check (the double-injection symptom
+	// in turbo workers). Recover by scanning PATH for an entry that
+	// lives under the agent's per-user runtime dir and matches the
+	// <runtime>/shells/<pid>/bin shape. The agent verifies that
+	// runtime dir is 0700 owned by the current user (security #117),
+	// so trusting a PATH entry rooted there is no weaker than
+	// reading the agent's socket from the same dir.
+	if !isWrapDirShape(selfDir) {
+		if recovered := findWrapDirInPath(); recovered != "" {
+			selfDir = recovered
+		}
+	}
 	realPath, err := lookPathExcluding(invokedAs, selfDir)
 	if err != nil {
 		return err
@@ -268,6 +286,79 @@ func shellDirFromWrap(wrapDir string) string {
 		return ""
 	}
 	return filepath.Dir(clean)
+}
+
+// isWrapDirShape reports whether p has the structural form of a
+// jitenv per-shell wrapper bin dir: ends in `/bin`, whose parent's
+// basename is a positive integer (the shell pid). Used to detect
+// when the env / argv-derived selfDir is bogus (".", "/usr/bin", a
+// repo subdir, …) and we need to fall back to a PATH scan (#182).
+func isWrapDirShape(p string) bool {
+	if p == "" {
+		return false
+	}
+	clean := filepath.Clean(p)
+	if filepath.Base(clean) != "bin" {
+		return false
+	}
+	pidPart := filepath.Base(filepath.Dir(clean))
+	if pidPart == "." || pidPart == "/" || pidPart == "" {
+		return false
+	}
+	// Must parse as a positive int; the agent only ever creates
+	// dirs named with the shell's pid (decimal).
+	pid, err := strconv.Atoi(pidPart)
+	return err == nil && pid > 0
+}
+
+// findWrapDirInPath scans $PATH for the first entry that matches
+// the wrap-dir shape (<runtime>/shells/<pid>/bin) AND is rooted in
+// the agent's per-user runtime dir. Used as the env-stripping
+// recovery path (#182) — without it, a turbo / firejail / sandboxer
+// worker can't locate its wrap dir and the bypass machinery fails.
+//
+// Constraining to "rooted in the agent runtime dir" closes a
+// hypothetical PATH-prepended-by-attacker downgrade: an attacker
+// who can write /tmp/shells/<pid>/bin and drop a forged "injected"
+// marker file would otherwise be able to suppress env injection.
+// Tying the recovery to the agent's runtime dir (already 0700
+// owned by the user, verified at agent startup per security #117)
+// means a successful recovery is no weaker than reading the
+// agent's own socket from the same dir.
+func findWrapDirInPath() string {
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		return ""
+	}
+	shellsAbs, err := filepath.Abs(paths.ShellsDir)
+	if err != nil {
+		return ""
+	}
+	sep := string(os.PathSeparator)
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		// abs must sit STRICTLY under <runtime>/shells/ — equal or
+		// outside is rejected. The trailing separator on the prefix
+		// prevents a sibling like <runtime>/shells-evil from sneaking
+		// in.
+		if !strings.HasPrefix(abs+sep, shellsAbs+sep) || abs == shellsAbs {
+			continue
+		}
+		if !isWrapDirShape(abs) {
+			continue
+		}
+		if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+			continue
+		}
+		return abs
+	}
+	return ""
 }
 
 // markerFileSays reports whether a per-shell injection marker exists

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -227,6 +227,99 @@ func TestShimSuppressesInjectionWithMarker(t *testing.T) {
 	}
 }
 
+// TestShimRecoversWrapDirFromPath is the regression for the second
+// half of #182: when turbo's strict env mode strips __JITENV_WRAP_DIR
+// AND the wrapper is invoked via execvp-by-name (argv[0]="npm", not
+// the full path), the shim's old fallback `filepath.Dir(argv[0])`
+// produces "." — which broke both the PATH-exclusion (infinite
+// re-exec loop) and the marker-file bypass added by the first
+// half of the fix. Recovery scans PATH for an entry strictly under
+// the agent's runtime dir <runtime>/shells/<pid>/bin.
+//
+// Simulates the turbo-worker environment by:
+//   - placing the wrapper under a runtime / shells/<pid>/ bin layout
+//     (so the recovery scan recognises the shape);
+//   - setting XDG_RUNTIME_DIR so agent.DefaultPaths().ShellsDir
+//     resolves to the test's runtime tree;
+//   - dropping the injection marker file in <shellDir>/injected;
+//   - launching the wrapper with argv[0]="fakecmd" (basename only —
+//     mirrors how execvp("npm", argv) passes argv[0]) and env
+//     stripped of __JITENV_WRAP_DIR.
+//
+// The shim must recover the wrap dir via the PATH scan, find the
+// marker, and short-circuit.
+func TestShimRecoversWrapDirFromPath(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// XDG_RUNTIME_DIR is the root agent.DefaultPaths() resolves
+	// against; the recovery scan walks PATH for entries strictly
+	// under <runtimeDir>/jitenv/shells/, so build the per-shell
+	// tree at that location.
+	runtimeDir := filepath.Join(dir, "runtime")
+	shellsDir := filepath.Join(runtimeDir, "jitenv", "shells")
+	shellDir := filepath.Join(shellsDir, "12345") // synthetic pid
+	wrapDir := filepath.Join(shellDir, "bin")
+	if err := os.MkdirAll(wrapDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// PATH: wrap dir first (so PATH-lookup of "fakecmd" finds the
+	// wrapper), then the real-cmd dir (so lookPathExcluding finds
+	// the real one once the wrap dir is correctly excluded).
+	pathEnv := wrapDir + string(os.PathListSeparator) + fakeBin
+
+	env := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	// argv[0]="fakecmd" (basename, not wrapper path) — mirrors how
+	// execvp("npm", argv) leaves argv[0] in a turbo-spawned worker.
+	cmd := exec.Command(wrapper)
+	cmd.Args = []string{"fakecmd"}
+	cmd.Env = env
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, buf.String())
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "agent is not loaded") {
+		t.Errorf("warning fired despite recoverable wrap dir + marker file; output=%s", out)
+	}
+	if strings.Contains(out, "jitenv: injected") {
+		t.Errorf("notice fired despite recoverable wrap dir + marker file; output=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+}
+
 // TestShimSuppressesInjectionViaMarkerFile is the regression test for
 // the env-stripping branch of issue #182: turbo strict env mode (and
 // firejail / bwrap / sandboxer variants) strips __JITENV_INJECTED


### PR DESCRIPTION
Stacked on #183.

## Symptom

User reported that the marker-file fix from #183 worked at the top level (no `jitenv: injected N variables` for the outer `npm run dev`) but the turbo workers still emitted the notice twice:

```
gv@BEAST:~/Code/NexVill-Project/NexVill (main)$ npm run dev
...
@nextvill/parent-frontend:dev: jitenv: injected 8 variables
@nextvill/web:dev: jitenv: injected 8 variables
```

## Root cause

Turbo strict env strips `__JITENV_WRAP_DIR` *as well as* `__JITENV_INJECTED` / `__JITENV_SESSION_NONCE`. Combined with the worker's `argv[0] = "npm"` (execvp-by-name semantics), the shim's fallback `filepath.Dir(argv[0])` produces `"."`. That value then breaks:

1. **PATH exclusion** in `lookPathExcluding(".", invokedAs)` — the wrap dir doesn't equal `"."`, so it's not excluded, so the wrapper is what the lookup returns. Infinite shim re-exec in theory.
2. **Marker-file check** — `shellDirFromWrap(".")` returns `""` because `Base(".")` ≠ `"bin"`, so `markerFileSays(".")` is false, so the bypass doesn't fire, so the worker re-injects and re-prints the notice.

## Fix

When neither `__JITENV_WRAP_DIR` nor `filepath.Dir(argv[0])` produces a wrap-dir-shaped path, scan `$PATH` for an entry that:

- lives **strictly** under the agent's per-user runtime dir (the `HasPrefix(abs+sep, shellsAbs+sep)` + `abs != shellsAbs` check rejects sibling-dir downgrades like `<runtime>/shells-evil`),
- matches the shape `<…>/<positive-int>/bin`, AND
- actually exists on disk.

The runtime dir is already 0700 owned by the user (security #117 verifies this at agent startup), so a recovered PATH entry rooted there is no weaker to trust than the agent's socket from the same dir.

## Test

New `TestShimRecoversWrapDirFromPath` builds the full turbo-worker reproducer:

- wrap dir under `<XDG_RUNTIME_DIR>/jitenv/shells/<pid>/bin`,
- marker file in `<shellDir>/injected`,
- env stripped of all `__JITENV_*` vars,
- `argv[0]="fakecmd"` (basename, mirroring how `execvp("npm", argv)` leaves it).

The shim must short-circuit via the recovered marker. Passes.

## Test plan

- [x] New + existing shim tests green (`go test ./internal/shim/`).
- [x] Full repo test suite green (`go test ./...`).
- [x] `golangci-lint v1.62.2` clean.
- [ ] Manual: the issue author re-runs `npm run dev` and confirms exactly one notice (or zero, if a previous run in the same shell already dropped the marker file).