### PR TITLE
fix(shim): scope injection marker to one command chain via pgid (#182)

### DIFF
--- a/internal/shim/pgid_unix.go
+++ b/internal/shim/pgid_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package shim
+
+import "syscall"
+
+// currentPgid returns the calling process's process-group id. Used
+// by the marker-file machinery (#182) to identify a command chain:
+// children of the first shim hop inherit its pgid through fork +
+// execve, so they all see the same value, while a new command from
+// the typing shell gets a fresh pgid via bash/zsh job-control
+// setpgid(2) — exactly the granularity we want.
+//
+// Returns 0 on any error; callers treat 0 as "no chain identity" so
+// the marker bypass simply doesn't fire and the shim falls back to
+// fresh injection.
+func currentPgid() int {
+	pgid, err := syscall.Getpgid(syscall.Getpid())
+	if err != nil {
+		return 0
+	}
+	return pgid
+}

--- a/internal/shim/pgid_windows.go
+++ b/internal/shim/pgid_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package shim
+
+// currentPgid is a no-op on Windows: there's no process-group
+// concept in the Win32 API and the cwd_glob wrapper UX that drives
+// the marker-file machinery is gated by issue #182 needing process-
+// tree identity. Returning 0 makes markerFileSays / writeMarkerFile
+// silently no-op on Windows (the env-marker channel still works
+// where strict-env hosts aren't in play).
+func currentPgid() int { return 0 }

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -187,7 +187,7 @@ func run(invokedAs string, args []string) error {
 			// per-chain checks if needed. Best-effort: a write failure
 			// just degrades to the old behaviour (double notice under
 			// env stripping).
-			_ = writeMarkerFile(selfDir, nonce)
+			_ = writeMarkerFile(selfDir)
 		}
 	}
 
@@ -361,33 +361,54 @@ func findWrapDirInPath() string {
 	return ""
 }
 
-// markerFileSays reports whether a per-shell injection marker exists
-// at <shellDir>/<markerFilename>. Used as the env-stripping fallback
-// for the in-chain bypass check (#182): when an intermediate process
-// (turbo strict env mode, firejail, sandboxer) drops the marker env
-// vars, the file is the surviving signal.
+// markerFileSays reports whether the shim should bypass injection
+// based on the on-disk marker (#182 env-stripping fallback).
 //
-// Returns false on any error (file missing, permission denied,
-// shellDir unresolvable) — the caller falls through to a fresh
-// inject, which is the same behaviour as today when env stripping
-// happens.
+// The marker's content is the process-group id (pgid) of the first
+// shim hop in a command chain. The current shim only treats the
+// marker as a bypass signal when its own pgid matches the file's
+// content — that scopes the bypass to ONE command-chain identity:
+//
+//   - Workers descended from the first shim share its pgid through
+//     fork+execve (kernel inheritance; no explicit setpgrp call),
+//     so they see "match" and bypass cleanly.
+//   - A different command in the same shell (the user's next `npm
+//     run dev` after the previous one ended; or a `git push` running
+//     between two `npm` invocations) gets a fresh pgid from bash's
+//     job-control setpgid(2) call, so it sees "mismatch" → re-inject.
+//
+// Without the pgid match, a stale marker from a previous chain would
+// silently suppress injection — which is the bug the user filed:
+// "after one time the injected file marker is not cleaned and no
+// more injections happen."
+//
+// Returns false on any error (file missing, malformed content,
+// shellDir unresolvable). The caller falls through to a fresh inject.
 func markerFileSays(wrapDir string) bool {
 	shellDir := shellDirFromWrap(wrapDir)
 	if shellDir == "" {
 		return false
 	}
-	_, err := os.Stat(filepath.Join(shellDir, markerFilename))
-	return err == nil
+	b, err := os.ReadFile(filepath.Join(shellDir, markerFilename))
+	if err != nil {
+		return false
+	}
+	want, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || want <= 0 {
+		return false
+	}
+	return currentPgid() == want
 }
 
-// writeMarkerFile drops <shellDir>/<markerFilename> as a one-time
-// signal that the first shim hop in this shell has done its
-// injection. Content is the per-chain nonce so a future tool can
-// scope checks per-chain; today only file presence is consulted.
+// writeMarkerFile drops <shellDir>/<markerFilename> with the caller's
+// process-group id as the file's content. The pgid is what
+// markerFileSays compares against — see that function's doc for the
+// chain-scoping rationale.
+//
 // Mode 0600; owner-only (the shell dir is already 0700 owned by the
 // user). Best-effort — callers ignore errors so a marker-file write
 // failure just falls back to today's behaviour.
-func writeMarkerFile(wrapDir, nonce string) error {
+func writeMarkerFile(wrapDir string) error {
 	shellDir := shellDirFromWrap(wrapDir)
 	if shellDir == "" {
 		return errors.New("cannot derive per-shell dir from wrap dir")
@@ -396,8 +417,8 @@ func writeMarkerFile(wrapDir, nonce string) error {
 		return err
 	}
 	path := filepath.Join(shellDir, markerFilename)
-	// Atomic-via-tempfile: a partially-written marker on power loss
-	// shouldn't cause a confused half-bypass.
+	// Atomic-via-tempfile: a partially-written marker shouldn't
+	// cause a confused half-bypass under a concurrent reader.
 	tmp, err := os.CreateTemp(shellDir, "."+markerFilename+".*.tmp")
 	if err != nil {
 		return err
@@ -408,7 +429,7 @@ func writeMarkerFile(wrapDir, nonce string) error {
 		tmp.Close()
 		return err
 	}
-	if _, err := tmp.WriteString(nonce); err != nil {
+	if _, err := fmt.Fprintf(tmp, "%d", currentPgid()); err != nil {
 		tmp.Close()
 		return err
 	}

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -4,13 +4,29 @@ package shim_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 )
+
+// pgidForChild returns the process-group id a freshly exec.Command-
+// spawned child will inherit from this test process. Used by the
+// marker-file tests (#182) — the marker's content is compared to
+// the child's pgid, so the file we drop has to record the exact
+// number the child will read.
+func pgidForChild(t *testing.T) int {
+	t.Helper()
+	pgid, err := syscall.Getpgid(os.Getpid())
+	if err != nil {
+		t.Fatalf("Getpgid: %v", err)
+	}
+	return pgid
+}
 
 // buildBinary compiles the jitenv binary into the test's temp dir so
 // we can drop wrapper symlinks pointing at it. Mirrors the helper in
@@ -278,7 +294,10 @@ func TestShimRecoversWrapDirFromPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+	// Marker content must be the child's pgid for markerFileSays to
+	// honour it (pgid-based scoping fixes the "stale marker bypasses
+	// next command" bug from #182).
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -357,10 +376,10 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Drop the marker file. The shim only checks file presence; the
-	// content can be anything (today the nonce, future tools may
-	// switch to per-chain matching).
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+	// Marker content is the chain's process-group id. Children
+	// spawned by exec.Command inherit this test's pgid, so writing
+	// our pgid here makes the bypass fire under the child.
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -402,4 +421,97 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 	if !strings.Contains(out, "RAN") {
 		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
 	}
+}
+
+// TestShimMarkerFromForeignPgidDoesNotBypass is the regression for
+// the user-reported follow-up on #182: after one foreground command
+// chain wrote the marker file, the user's next `npm run dev` in the
+// same shell found the marker still on disk and short-circuited —
+// no notice, no injection.
+//
+// Fix: the marker's content is the first shim's process-group id;
+// bypass only fires when the current process's pgid matches. A new
+// command from bash starts in a fresh pgid (job-control setpgid) so
+// the stale marker mismatches → fresh inject.
+//
+// This test drops a marker file with a deliberately-wrong pgid
+// (1 — the init process; guaranteed not to be this test's pgrp)
+// and expects the shim to re-inject (notice prints, real binary
+// runs).
+func TestShimMarkerFromForeignPgidDoesNotBypass(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Layout for shellDirFromWrap to accept: <shellDir>/bin.
+	shellDir := filepath.Join(dir, "shell-xxx")
+	wrapDir := filepath.Join(shellDir, "bin")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	// Foreign pgid in marker. Child's actual pgid (inherited from
+	// this test process) is guaranteed != 1 unless the test is
+	// running as PID 1, which doesn't happen under `go test`.
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
+	// __JITENV_SHELL_PID present and matching so shouldInject() takes
+	// the inject branch when the marker correctly fails to bypass.
+	shellPID := strconv.Itoa(os.Getpid())
+
+	env := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"__JITENV_WRAP_DIR=" + wrapDir,
+		"__JITENV_SHELL_PID=" + shellPID,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	cmd := exec.Command(wrapper)
+	cmd.Env = env
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, buf.String())
+	}
+	out := buf.String()
+
+	// The shim should re-inject (agent is down here so the warning
+	// fires instead of the notice; either way the bypass MUST NOT
+	// have suppressed both).
+	if !strings.Contains(out, "agent is not loaded") {
+		t.Errorf("expected agent-down warning (proves no bypass);\noutput=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+
+	// The agent-down branch doesn't rewrite the marker (the rewrite
+	// only happens when fetch succeeds), so we don't assert on the
+	// marker content here. The "no bypass" semantics — proven by the
+	// warning firing above — are what this test guards.
 }


### PR DESCRIPTION
Stacked on #184. Closes the user-reported follow-up on #182.

## Symptom

After PRs #183/#184 fixed the per-worker double-inject, the user reported a new regression:

> after one time the injected file marker is not cleaned and no more injections happen.

Sequence:
1. `npm run dev` → first shim writes marker file → workers bypass cleanly → notice fires exactly once. ✓
2. Ctrl+C the tree.
3. `npm run dev` again → marker file still on disk → first shim short-circuits → **no notice, no env injection**, downstream code crashes on missing `SESSION_SECRET`.

## Root cause

The marker's lifetime was "per shell session" (cleaned up by `agent.GcOrphanShells` only on shell exit). Correct lifetime is "per command chain". The mismatch let stale markers suppress unrelated follow-on commands.

## Fix

Scope the marker to the chain's process-group id (pgid). Write the caller's pgid into the file at first-inject; bypass only fires when the reader's own pgid matches the file content.

**Why pgid works:**

- Bash/zsh job-control puts each foreground command in its own process group via `setpgid(2)`. All descendants of that command — `npm → sh → turbo → workers → re-wrapped npm` — share the pgid unless they explicitly `setpgrp` (well-behaved tools don't). Workers in the same chain see "match" → bypass cleanly.
- A different command in the same shell (the user's next `npm run dev`, or a `git push` between two npms) is a fresh job with a fresh pgid. Reading the stale marker yields a "mismatch" → fresh inject → notice fires.

**Cleanup**: nothing extra needed. Stale markers from finished chains just mismatch, get overwritten on the next inject, and are removed with the shell dir by `agent.GcOrphanShells` at shell exit.

## Tests

- New `TestShimMarkerFromForeignPgidDoesNotBypass` reproduces the user's failure mode directly: drop a marker with a wrong pgid (1, init), confirm the shim does NOT bypass (warning fires, real binary runs).
- Updated `TestShimSuppressesInjectionViaMarkerFile` and `TestShimRecoversWrapDirFromPath` to write the test's own pgid into the marker so they still exercise the bypass path under the new contract.
- Full repo `go test ./...` + `golangci-lint v1.62.2` clean.

## Platform

`pgid` is a Unix concept. `currentPgid()` returns 0 on Windows so `markerFileSays`/`writeMarkerFile` silently no-op there; the env-marker channel still works under any Windows context that doesn't strip env (which is the common case — Windows has no real strict-env analog at the shell level).