### PR TITLE
fix(shim,chpwd): scope injection marker via PROMPT_COMMAND cleanup (#182)

### DIFF
--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -69,6 +69,28 @@ func Run(args []string) error {
 	wrapDir := paths.ShellWrapDir(pid)
 	mtimePath := lastMtimePath(paths, pid)
 
+	// Scope the shim's on-disk injection marker (#182) to "one user
+	// command" by unlinking it on every prompt fire. The marker
+	// lives at <shellsDir>/<pid>/injected; the shim creates it after
+	// a successful first-hop inject so descendants (turbo workers,
+	// chained interpreters) bypass instead of double-fetching. Once
+	// the user's command tree has exited and bash/zsh fires
+	// PROMPT_COMMAND → __chpwd, we delete the file so the NEXT
+	// command starts clean and gets a fresh injection + notice.
+	//
+	// Best-effort: a stat/unlink failure (file missing — first
+	// prompt of the session, or already cleaned up) is fine. Run
+	// BEFORE the short-circuit-on-unchanged-state below: the marker
+	// must be cleaned even when pwd + cfg mtime didn't change, which
+	// is the common case for a foreground `npm run dev` that
+	// completes in the same dir.
+	markerPath := filepath.Join(filepath.Dir(wrapDir), "injected")
+	if err := os.Remove(markerPath); err == nil {
+		debugLog("removed injection marker %s", markerPath)
+	} else if !os.IsNotExist(err) {
+		debugLog("remove injection marker %s: %v", markerPath, err)
+	}
+
 	cfgPath, cfgErr := config.Resolve(os.Getenv("JITENV_CONFIG"))
 	curMtime := statMtime(cfgPath)
 	lastMtime := readLastMtime(mtimePath)

--- a/internal/chpwd/chpwd_test.go
+++ b/internal/chpwd/chpwd_test.go
@@ -101,3 +101,58 @@ func TestLastMtimeSidecarLivesUnderShellDir(t *testing.T) {
 		t.Errorf("lastMtimePath: got %q want %q", got, want)
 	}
 }
+
+// TestRunUnlinksInjectionMarker covers the #182 follow-up: the
+// injection marker file at <shellsDir>/<pid>/injected is what the
+// shim uses to gate the bypass for downstream re-wrapped commands
+// (turbo workers etc.), and `__chpwd` is responsible for unlinking
+// it on every prompt fire so the marker's lifetime is scoped to
+// "one user command" — between two prompts. A leftover marker
+// would silently suppress injection in the user's next command.
+//
+// The test drops a marker file by hand, calls Run, and confirms
+// the file is gone. The cleanup runs BEFORE the unchanged-state
+// short-circuit, so this works even when pwd + cfg mtime didn't
+// change since the last call (the common case for a foreground
+// `npm run dev` that completes in the same dir).
+func TestRunUnlinksInjectionMarker(t *testing.T) {
+	tmp := t.TempDir()
+	runtimeDir := filepath.Join(tmp, "runtime")
+	cfgPath := filepath.Join(tmp, "config.toml")
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("JITENV_CONFIG", cfgPath)
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Minimal valid config so the cfg-load branches don't error.
+	cfg := config.Config{Version: 1}
+	cf, err := os.Create(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := toml.NewEncoder(cf).Encode(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	cf.Close()
+
+	pid := os.Getpid()
+	paths, _ := agent.DefaultPaths()
+	wrapDir := paths.ShellWrapDir(pid)
+	shellDir := filepath.Dir(wrapDir)
+	if err := os.MkdirAll(shellDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	markerPath := filepath.Join(shellDir, "injected")
+	if err := os.WriteFile(markerPath, []byte("any-content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same pwd both sides — exercises the cleanup BEFORE the
+	// short-circuit. The marker must be gone afterwards regardless.
+	if err := Run([]string{strconv.Itoa(pid), tmp, tmp}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Errorf("injection marker still exists after chpwd run: stat err=%v", err)
+	}
+}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -364,46 +364,39 @@ func findWrapDirInPath() string {
 // markerFileSays reports whether the shim should bypass injection
 // based on the on-disk marker (#182 env-stripping fallback).
 //
-// The marker's content is the process-group id (pgid) of the first
-// shim hop in a command chain. The current shim only treats the
-// marker as a bypass signal when its own pgid matches the file's
-// content — that scopes the bypass to ONE command-chain identity:
+// Bypass on file presence alone. The marker's lifetime is scoped to
+// "one user command" by the shell hook's PROMPT_COMMAND-driven
+// __chpwd, which unlinks the file between every prompt (see
+// internal/chpwd.Run). So inside a running command tree the file
+// exists → workers bypass; between two prompts the file is gone →
+// the next command re-injects.
 //
-//   - Workers descended from the first shim share its pgid through
-//     fork+execve (kernel inheritance; no explicit setpgrp call),
-//     so they see "match" and bypass cleanly.
-//   - A different command in the same shell (the user's next `npm
-//     run dev` after the previous one ended; or a `git push` running
-//     between two `npm` invocations) gets a fresh pgid from bash's
-//     job-control setpgid(2) call, so it sees "mismatch" → re-inject.
+// Earlier iterations of this fix scoped the bypass by writing the
+// caller's pgid into the file and matching it on read. That broke
+// when intermediate tools (turbo's task runner being the canonical
+// example) put each worker in its own process group via setpgid(2)
+// for signal isolation — the workers' pgid didn't match the top-
+// level shim's, so they re-injected and the notice fired per
+// worker. The chpwd-driven cleanup is independent of whether
+// downstream tools fork into new pgrps, so it survives both cases.
 //
-// Without the pgid match, a stale marker from a previous chain would
-// silently suppress injection — which is the bug the user filed:
-// "after one time the injected file marker is not cleaned and no
-// more injections happen."
-//
-// Returns false on any error (file missing, malformed content,
-// shellDir unresolvable). The caller falls through to a fresh inject.
+// Returns false on any error (file missing, shellDir unresolvable).
+// The caller falls through to a fresh inject.
 func markerFileSays(wrapDir string) bool {
 	shellDir := shellDirFromWrap(wrapDir)
 	if shellDir == "" {
 		return false
 	}
-	b, err := os.ReadFile(filepath.Join(shellDir, markerFilename))
-	if err != nil {
-		return false
-	}
-	want, err := strconv.Atoi(strings.TrimSpace(string(b)))
-	if err != nil || want <= 0 {
-		return false
-	}
-	return currentPgid() == want
+	_, err := os.Stat(filepath.Join(shellDir, markerFilename))
+	return err == nil
 }
 
-// writeMarkerFile drops <shellDir>/<markerFilename> with the caller's
-// process-group id as the file's content. The pgid is what
-// markerFileSays compares against — see that function's doc for the
-// chain-scoping rationale.
+// writeMarkerFile drops <shellDir>/<markerFilename> as a one-shot
+// signal that the first shim hop in this command chain has done its
+// injection. Content is informational only — markerFileSays gates
+// on existence. Writing the pgid keeps the file useful for ad-hoc
+// debugging ("which pgrp dropped this?") and is a stable identifier
+// of the first shim that injected.
 //
 // Mode 0600; owner-only (the shell dir is already 0700 owned by the
 // user). Best-effort — callers ignore errors so a marker-file write

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -4,29 +4,13 @@ package shim_test
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 )
-
-// pgidForChild returns the process-group id a freshly exec.Command-
-// spawned child will inherit from this test process. Used by the
-// marker-file tests (#182) — the marker's content is compared to
-// the child's pgid, so the file we drop has to record the exact
-// number the child will read.
-func pgidForChild(t *testing.T) int {
-	t.Helper()
-	pgid, err := syscall.Getpgid(os.Getpid())
-	if err != nil {
-		t.Fatalf("Getpgid: %v", err)
-	}
-	return pgid
-}
 
 // buildBinary compiles the jitenv binary into the test's temp dir so
 // we can drop wrapper symlinks pointing at it. Mirrors the helper in
@@ -297,7 +281,7 @@ func TestShimRecoversWrapDirFromPath(t *testing.T) {
 	// Marker content must be the child's pgid for markerFileSays to
 	// honour it (pgid-based scoping fixes the "stale marker bypasses
 	// next command" bug from #182).
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-content"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -379,7 +363,7 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 	// Marker content is the chain's process-group id. Children
 	// spawned by exec.Command inherit this test's pgid, so writing
 	// our pgid here makes the bypass fire under the child.
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-content"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -421,97 +405,4 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 	if !strings.Contains(out, "RAN") {
 		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
 	}
-}
-
-// TestShimMarkerFromForeignPgidDoesNotBypass is the regression for
-// the user-reported follow-up on #182: after one foreground command
-// chain wrote the marker file, the user's next `npm run dev` in the
-// same shell found the marker still on disk and short-circuited —
-// no notice, no injection.
-//
-// Fix: the marker's content is the first shim's process-group id;
-// bypass only fires when the current process's pgid matches. A new
-// command from bash starts in a fresh pgid (job-control setpgid) so
-// the stale marker mismatches → fresh inject.
-//
-// This test drops a marker file with a deliberately-wrong pgid
-// (1 — the init process; guaranteed not to be this test's pgrp)
-// and expects the shim to re-inject (notice prints, real binary
-// runs).
-func TestShimMarkerFromForeignPgidDoesNotBypass(t *testing.T) {
-	bin := buildBinary(t)
-
-	dir := t.TempDir()
-
-	fakeBin := filepath.Join(dir, "bin")
-	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	realCmd := filepath.Join(fakeBin, "fakecmd")
-	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Layout for shellDirFromWrap to accept: <shellDir>/bin.
-	shellDir := filepath.Join(dir, "shell-xxx")
-	wrapDir := filepath.Join(shellDir, "bin")
-	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	wrapper := filepath.Join(wrapDir, "fakecmd")
-	if err := os.Symlink(bin, wrapper); err != nil {
-		t.Fatal(err)
-	}
-
-	// Foreign pgid in marker. Child's actual pgid (inherited from
-	// this test process) is guaranteed != 1 unless the test is
-	// running as PID 1, which doesn't happen under `go test`.
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("1"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	runtimeDir := filepath.Join(dir, "runtime")
-	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
-	// __JITENV_SHELL_PID present and matching so shouldInject() takes
-	// the inject branch when the marker correctly fails to bypass.
-	shellPID := strconv.Itoa(os.Getpid())
-
-	env := []string{
-		"PATH=" + pathEnv,
-		"XDG_RUNTIME_DIR=" + runtimeDir,
-		"__JITENV_WRAP_DIR=" + wrapDir,
-		"__JITENV_SHELL_PID=" + shellPID,
-		"JITENV_HOOK_DELAY=0",
-	}
-	if home := os.Getenv("HOME"); home != "" {
-		env = append(env, "HOME="+home)
-	}
-
-	cmd := exec.Command(wrapper)
-	cmd.Env = env
-	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("run: %v\noutput=%s", err, buf.String())
-	}
-	out := buf.String()
-
-	// The shim should re-inject (agent is down here so the warning
-	// fires instead of the notice; either way the bypass MUST NOT
-	// have suppressed both).
-	if !strings.Contains(out, "agent is not loaded") {
-		t.Errorf("expected agent-down warning (proves no bypass);\noutput=%s", out)
-	}
-	if !strings.Contains(out, "RAN") {
-		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
-	}
-
-	// The agent-down branch doesn't rewrite the marker (the rewrite
-	// only happens when fetch succeeds), so we don't assert on the
-	// marker content here. The "no bypass" semantics — proven by the
-	// warning firing above — are what this test guards.
 }


### PR DESCRIPTION
Stacked on #185. Closes the user-reported follow-up to that PR.

## Symptom

After #185's pgid-scoping fix, the user re-tested with `npm run preview` (`turbo`-based command not previously exercised) and double-injection came back:

```
gv@BEAST:~$ npm run preview
jitenv: injected 8 variables                       # ← top-level, fine
...
@nextvill/parent-frontend:preview: jitenv: injected 8 variables    # ← duplicate
@nextvill/web:preview: jitenv: injected 8 variables                # ← duplicate
```

## Root cause

Turbo puts each worker in its own process group — probably for signal isolation, so a SIGINT to one worker doesn't propagate to siblings. So the worker's pgid is NOT the top-level shim's pgid, the pgid-match in `markerFileSays` returns false, the worker re-injects, the notice fires per worker.

**pgid was the wrong granularity.** Too narrow. Session-id would be too broad (one session = one shell = many commands). The right scope is exactly what bash/zsh themselves call "one command": **between two `PROMPT_COMMAND` fires**. The shell hook already fires `jitenv __chpwd` there for cwd_glob wrapper reconciliation — piggy-back on it.

## Fix

1. **`internal/shim/shim.go`** — `markerFileSays` reverts to file-presence (no content match).
2. **`internal/chpwd/chpwd.go`** — `Run` unlinks `<shellsDir>/<pid>/injected` at the top, BEFORE the unchanged-state short-circuit. The cleanup must run even when pwd + cfg mtime didn't change (which is the common `npm run dev` foreground case).

## Lifetime semantics

| When | Marker | Bypass? |
|---|---|---|
| First shim hop of a command | written | n/a (first hop fetches) |
| Worker / chained interpreter, same command | present | yes — bypass |
| `PROMPT_COMMAND` fires (command done) | unlinked by chpwd | n/a |
| Next user command's first hop | absent | n/a (fresh inject) |

## Tests

- New `TestRunUnlinksInjectionMarker` in `internal/chpwd/chpwd_test.go` drops a marker by hand, calls `Run` with same-pwd same-mtime (short-circuit branch), confirms the marker is gone afterward.
- Dropped `TestShimMarkerFromForeignPgidDoesNotBypass` (#185's regression test) — the foreign-pgid distinction no longer exists; file-presence is the contract.
- Existing marker-bypass tests now write `"any-content"` into the file since content is informational only.
- Full repo `go test ./...` + `golangci-lint v1.62.2` clean.

## What about non-interactive contexts?

Scripts / CI jobs without the shell hook → no `PROMPT_COMMAND` → no chpwd cleanup. But:

- The marker dir lives under `<runtime>/jitenv/shells/<pid>/`, and `agent.GcOrphanShells` removes the whole dir when the shell exits.
- CI jobs typically run one command per shell anyway, so the cross-command suppression bug doesn't apply.

## Code that survived the iteration

`internal/shim/pgid_unix.go` + `pgid_windows.go` stay — `writeMarkerFile` still records the pgid as the file's content for ad-hoc debugging ("which pgrp dropped this?"). Not load-bearing; harmless if removed in a future cleanup.