### PR TITLE
fix: close all symptoms of #182 (TUI binary split + injection-marker lifecycle)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,34 @@ builds:
       - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
       - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
 
+  # The interactive TUI lives in a separate binary so the main
+  # jitenv binary's import graph stays free of Bubble Tea / Lip
+  # Gloss / termenv. Those libs send OSC 11 (background color) +
+  # CPR (\e[6n) queries to the tty at package-init time; in
+  # contexts where the parent doesn't consume the responses
+  # (turbo strict-env pty being the canonical example) the
+  # responses leak into the user's output stream. See #182 bug B.
+  # `jitenv config` re-execs this binary via internal/cli/config.go.
+  - id: jitenv-tui
+    main: ./cmd/jitenv-tui
+    binary: jitenv-tui
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
+      - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+
 archives:
   - id: jitenv
     # Unix archives are tar.gz; Windows archives are .zip so users can
@@ -36,7 +64,13 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
-    name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    # Both binaries ship in the same archive so a brew/dpkg/manual
+    # install gets the pair atomically. `ids:` is the v2-spelling
+    # of the build allowlist.
+    ids:
+      - jitenv
+      - jitenv-tui
+    name_template: "jitenv_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -50,6 +84,9 @@ archives:
 nfpms:
   - id: jitenv
     package_name: jitenv
+    ids:
+      - jitenv
+      - jitenv-tui
     vendor: Galvill
     homepage: https://github.com/Galvill/jitenv
     maintainer: Galvill <nexvill.ai@gmail.com>
@@ -106,6 +143,13 @@ homebrew_casks:
     homepage: https://github.com/Galvill/jitenv
     description: Just-in-time env-var injection from pluggable secret sources, scoped to per-command process trees
     skip_upload: auto
+    # Ship both halves of the binary split (#182 bug B): jitenv runs
+    # everything except the TUI; jitenv-tui is the re-exec target for
+    # `jitenv config`. The cask links both into the Homebrew prefix
+    # bin/ so `which jitenv-tui` resolves.
+    binaries:
+      - jitenv
+      - jitenv-tui
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
@@ -120,6 +164,8 @@ homebrew_casks:
           if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
             system_command "/usr/bin/xattr",
                            args: ["-dr", "com.apple.quarantine", "#{staged_path}/jitenv"]
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/jitenv-tui"]
           end
 
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,19 @@ LDFLAGS := -s -w \
 
 build:
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN) ./cmd/jitenv
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-tui ./cmd/jitenv-tui
 
-# Cross-compile the Windows binary. Stage 1 (#80) made the codebase
-# compile for GOOS=windows; the runtime port lands in #86-91. Useful
-# for reviewers verifying a Windows-touching PR really produces an
-# executable — `go build ./...` is a compile-check only and does not
-# emit a .exe.
+# Cross-compile the Windows binaries. The TUI ships as a separate
+# binary (#182 bug B): the main jitenv binary stays free of
+# Bubble Tea / Lip Gloss imports so it doesn't query the terminal
+# on every invocation.
 build-windows:
 	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN).exe ./cmd/jitenv
+	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-tui.exe ./cmd/jitenv-tui
 
 install: build
 	install -Dm0755 bin/$(BIN) $(PREFIX)/bin/$(BIN)
+	install -Dm0755 bin/$(BIN)-tui $(PREFIX)/bin/$(BIN)-tui
 
 test:
 	$(GO) test ./...

--- a/cmd/jitenv-tui/main.go
+++ b/cmd/jitenv-tui/main.go
@@ -1,0 +1,56 @@
+// Command jitenv-tui is the separate-binary host for the
+// interactive TUI used by `jitenv config`. It exists so the main
+// `jitenv` binary doesn't transitively import Bubble Tea / Lip
+// Gloss / termenv — those libs send OSC 11 (background color) and
+// CPR (\e[6n) queries to the terminal at package init, and the
+// responses leak into captured output of every jitenv subcommand
+// when the parent process doesn't manage the tty. See #182 bug B.
+//
+// CLI surface (called by `internal/cli/config.go` via os/exec):
+//
+//	jitenv-tui run                — full TUI from the existing config
+//
+// The TUI prompts for the passphrase itself; no master-key handoff
+// over fds is needed on this path.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+	"github.com/gv/jitenv/internal/tui"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "jitenv-tui: missing subcommand (expected: run)")
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "run":
+		var cfgPath string
+		if len(args) >= 2 {
+			cfgPath = args[1]
+		}
+		if cfgPath == "" {
+			// Fall back to env var / default resolution — matches what
+			// `jitenv config` does today.
+			cfgPath = os.Getenv("JITENV_CONFIG")
+		}
+		resolved, err := config.Resolve(cfgPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "jitenv-tui:", err)
+			os.Exit(1)
+		}
+		if err := tui.Run(resolved); err != nil {
+			fmt.Fprintln(os.Stderr, "jitenv-tui:", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "jitenv-tui: unknown subcommand %q\n", args[0])
+		os.Exit(2)
+	}
+}

--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -69,6 +69,28 @@ func Run(args []string) error {
 	wrapDir := paths.ShellWrapDir(pid)
 	mtimePath := lastMtimePath(paths, pid)
 
+	// Scope the shim's on-disk injection marker (#182) to "one user
+	// command" by unlinking it on every prompt fire. The marker
+	// lives at <shellsDir>/<pid>/injected; the shim creates it after
+	// a successful first-hop inject so descendants (turbo workers,
+	// chained interpreters) bypass instead of double-fetching. Once
+	// the user's command tree has exited and bash/zsh fires
+	// PROMPT_COMMAND → __chpwd, we delete the file so the NEXT
+	// command starts clean and gets a fresh injection + notice.
+	//
+	// Best-effort: a stat/unlink failure (file missing — first
+	// prompt of the session, or already cleaned up) is fine. Run
+	// BEFORE the short-circuit-on-unchanged-state below: the marker
+	// must be cleaned even when pwd + cfg mtime didn't change, which
+	// is the common case for a foreground `npm run dev` that
+	// completes in the same dir.
+	markerPath := filepath.Join(filepath.Dir(wrapDir), "injected")
+	if err := os.Remove(markerPath); err == nil {
+		debugLog("removed injection marker %s", markerPath)
+	} else if !os.IsNotExist(err) {
+		debugLog("remove injection marker %s: %v", markerPath, err)
+	}
+
 	cfgPath, cfgErr := config.Resolve(os.Getenv("JITENV_CONFIG"))
 	curMtime := statMtime(cfgPath)
 	lastMtime := readLastMtime(mtimePath)

--- a/internal/chpwd/chpwd_test.go
+++ b/internal/chpwd/chpwd_test.go
@@ -101,3 +101,58 @@ func TestLastMtimeSidecarLivesUnderShellDir(t *testing.T) {
 		t.Errorf("lastMtimePath: got %q want %q", got, want)
 	}
 }
+
+// TestRunUnlinksInjectionMarker covers the #182 follow-up: the
+// injection marker file at <shellsDir>/<pid>/injected is what the
+// shim uses to gate the bypass for downstream re-wrapped commands
+// (turbo workers etc.), and `__chpwd` is responsible for unlinking
+// it on every prompt fire so the marker's lifetime is scoped to
+// "one user command" — between two prompts. A leftover marker
+// would silently suppress injection in the user's next command.
+//
+// The test drops a marker file by hand, calls Run, and confirms
+// the file is gone. The cleanup runs BEFORE the unchanged-state
+// short-circuit, so this works even when pwd + cfg mtime didn't
+// change since the last call (the common case for a foreground
+// `npm run dev` that completes in the same dir).
+func TestRunUnlinksInjectionMarker(t *testing.T) {
+	tmp := t.TempDir()
+	runtimeDir := filepath.Join(tmp, "runtime")
+	cfgPath := filepath.Join(tmp, "config.toml")
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("JITENV_CONFIG", cfgPath)
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Minimal valid config so the cfg-load branches don't error.
+	cfg := config.Config{Version: 1}
+	cf, err := os.Create(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := toml.NewEncoder(cf).Encode(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	cf.Close()
+
+	pid := os.Getpid()
+	paths, _ := agent.DefaultPaths()
+	wrapDir := paths.ShellWrapDir(pid)
+	shellDir := filepath.Dir(wrapDir)
+	if err := os.MkdirAll(shellDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	markerPath := filepath.Join(shellDir, "injected")
+	if err := os.WriteFile(markerPath, []byte("any-content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same pwd both sides — exercises the cleanup BEFORE the
+	// short-circuit. The marker must be gone afterwards regardless.
+	if err := Run([]string{strconv.Itoa(pid), tmp, tmp}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Errorf("injection marker still exists after chpwd run: stat err=%v", err)
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
@@ -12,7 +14,6 @@ import (
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/lockfile"
-	"github.com/gv/jitenv/internal/tui"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -129,7 +130,68 @@ func runConfigTUI() error {
 	}
 	defer lock.Close()
 
-	return tui.Run(configPath)
+	return execJitenvTUI("run", configPath)
+}
+
+// execJitenvTUI re-execs the separate jitenv-tui binary, replacing
+// the current process's stdio with the child's so the TUI renders
+// directly to the user's terminal. The split exists to keep the
+// main `jitenv` binary's import graph free of Bubble Tea / Lip Gloss
+// / termenv — those libs send OSC 11 + CPR queries to the tty at
+// package-init time, and the responses leak into captured output of
+// every jitenv subcommand on terminals that don't manage the
+// responses cleanly (turbo strict-env pty, #182 bug B).
+//
+// Resolution order for the binary:
+//  1. JITENV_TUI_BIN env var (test / dev override).
+//  2. Sibling to the running jitenv executable (typical packaging
+//     case: both binaries live in /usr/local/bin or the Homebrew
+//     cellar bin/).
+//  3. PATH lookup.
+//
+// On error 127 ("not found") the user gets a clear message pointing
+// at the install — common cause is upgrading jitenv without picking
+// up the new sibling binary.
+func execJitenvTUI(args ...string) error {
+	binPath, err := resolveJitenvTUIPath()
+	if err != nil {
+		return err
+	}
+	c := exec.Command(binPath, args...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Env = os.Environ()
+	if err := c.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.ExitCode())
+		}
+		return fmt.Errorf("jitenv-tui: %w", err)
+	}
+	return nil
+}
+
+func resolveJitenvTUIPath() (string, error) {
+	if override := os.Getenv("JITENV_TUI_BIN"); override != "" {
+		return override, nil
+	}
+	if exe, err := os.Executable(); err == nil && exe != "" {
+		dir := filepath.Dir(exe)
+		candidate := filepath.Join(dir, jitenvTUIBinName())
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	if p, err := exec.LookPath(jitenvTUIBinName()); err == nil {
+		return p, nil
+	}
+	return "", fmt.Errorf(
+		"jitenv-tui not found (looked next to jitenv and on $PATH). "+
+			"The interactive TUI ships as a separate binary; if you upgraded jitenv "+
+			"manually, ensure %s is installed alongside.",
+		jitenvTUIBinName(),
+	)
 }
 
 func zeroBytes(b []byte) {

--- a/internal/cli/jitenv_tui_name.go
+++ b/internal/cli/jitenv_tui_name.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package cli
+
+// jitenvTUIBinName returns the filename of the TUI sibling binary on
+// this OS. Defined per-platform so the Windows .exe suffix doesn't
+// leak into the Unix build (and vice-versa).
+func jitenvTUIBinName() string { return "jitenv-tui" }

--- a/internal/cli/jitenv_tui_name_windows.go
+++ b/internal/cli/jitenv_tui_name_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package cli
+
+// jitenvTUIBinName: Windows expects .exe so the resolution chain
+// (sibling-of-jitenv → PATH lookup) hits the right file.
+func jitenvTUIBinName() string { return "jitenv-tui.exe" }

--- a/internal/shim/pgid_unix.go
+++ b/internal/shim/pgid_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package shim
+
+import "syscall"
+
+// currentPgid returns the calling process's process-group id. Used
+// by the marker-file machinery (#182) to identify a command chain:
+// children of the first shim hop inherit its pgid through fork +
+// execve, so they all see the same value, while a new command from
+// the typing shell gets a fresh pgid via bash/zsh job-control
+// setpgid(2) — exactly the granularity we want.
+//
+// Returns 0 on any error; callers treat 0 as "no chain identity" so
+// the marker bypass simply doesn't fire and the shim falls back to
+// fresh injection.
+func currentPgid() int {
+	pgid, err := syscall.Getpgid(syscall.Getpid())
+	if err != nil {
+		return 0
+	}
+	return pgid
+}

--- a/internal/shim/pgid_windows.go
+++ b/internal/shim/pgid_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package shim
+
+// currentPgid is a no-op on Windows: there's no process-group
+// concept in the Win32 API and the cwd_glob wrapper UX that drives
+// the marker-file machinery is gated by issue #182 needing process-
+// tree identity. Returning 0 makes markerFileSays / writeMarkerFile
+// silently no-op on Windows (the env-marker channel still works
+// where strict-env hosts aren't in play).
+func currentPgid() int { return 0 }

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -187,7 +187,7 @@ func run(invokedAs string, args []string) error {
 			// per-chain checks if needed. Best-effort: a write failure
 			// just degrades to the old behaviour (double notice under
 			// env stripping).
-			_ = writeMarkerFile(selfDir, nonce)
+			_ = writeMarkerFile(selfDir)
 		}
 	}
 
@@ -361,33 +361,54 @@ func findWrapDirInPath() string {
 	return ""
 }
 
-// markerFileSays reports whether a per-shell injection marker exists
-// at <shellDir>/<markerFilename>. Used as the env-stripping fallback
-// for the in-chain bypass check (#182): when an intermediate process
-// (turbo strict env mode, firejail, sandboxer) drops the marker env
-// vars, the file is the surviving signal.
+// markerFileSays reports whether the shim should bypass injection
+// based on the on-disk marker (#182 env-stripping fallback).
 //
-// Returns false on any error (file missing, permission denied,
-// shellDir unresolvable) — the caller falls through to a fresh
-// inject, which is the same behaviour as today when env stripping
-// happens.
+// The marker's content is the process-group id (pgid) of the first
+// shim hop in a command chain. The current shim only treats the
+// marker as a bypass signal when its own pgid matches the file's
+// content — that scopes the bypass to ONE command-chain identity:
+//
+//   - Workers descended from the first shim share its pgid through
+//     fork+execve (kernel inheritance; no explicit setpgrp call),
+//     so they see "match" and bypass cleanly.
+//   - A different command in the same shell (the user's next `npm
+//     run dev` after the previous one ended; or a `git push` running
+//     between two `npm` invocations) gets a fresh pgid from bash's
+//     job-control setpgid(2) call, so it sees "mismatch" → re-inject.
+//
+// Without the pgid match, a stale marker from a previous chain would
+// silently suppress injection — which is the bug the user filed:
+// "after one time the injected file marker is not cleaned and no
+// more injections happen."
+//
+// Returns false on any error (file missing, malformed content,
+// shellDir unresolvable). The caller falls through to a fresh inject.
 func markerFileSays(wrapDir string) bool {
 	shellDir := shellDirFromWrap(wrapDir)
 	if shellDir == "" {
 		return false
 	}
-	_, err := os.Stat(filepath.Join(shellDir, markerFilename))
-	return err == nil
+	b, err := os.ReadFile(filepath.Join(shellDir, markerFilename))
+	if err != nil {
+		return false
+	}
+	want, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || want <= 0 {
+		return false
+	}
+	return currentPgid() == want
 }
 
-// writeMarkerFile drops <shellDir>/<markerFilename> as a one-time
-// signal that the first shim hop in this shell has done its
-// injection. Content is the per-chain nonce so a future tool can
-// scope checks per-chain; today only file presence is consulted.
+// writeMarkerFile drops <shellDir>/<markerFilename> with the caller's
+// process-group id as the file's content. The pgid is what
+// markerFileSays compares against — see that function's doc for the
+// chain-scoping rationale.
+//
 // Mode 0600; owner-only (the shell dir is already 0700 owned by the
 // user). Best-effort — callers ignore errors so a marker-file write
 // failure just falls back to today's behaviour.
-func writeMarkerFile(wrapDir, nonce string) error {
+func writeMarkerFile(wrapDir string) error {
 	shellDir := shellDirFromWrap(wrapDir)
 	if shellDir == "" {
 		return errors.New("cannot derive per-shell dir from wrap dir")
@@ -396,8 +417,8 @@ func writeMarkerFile(wrapDir, nonce string) error {
 		return err
 	}
 	path := filepath.Join(shellDir, markerFilename)
-	// Atomic-via-tempfile: a partially-written marker on power loss
-	// shouldn't cause a confused half-bypass.
+	// Atomic-via-tempfile: a partially-written marker shouldn't
+	// cause a confused half-bypass under a concurrent reader.
 	tmp, err := os.CreateTemp(shellDir, "."+markerFilename+".*.tmp")
 	if err != nil {
 		return err
@@ -408,7 +429,7 @@ func writeMarkerFile(wrapDir, nonce string) error {
 		tmp.Close()
 		return err
 	}
-	if _, err := tmp.WriteString(nonce); err != nil {
+	if _, err := fmt.Fprintf(tmp, "%d", currentPgid()); err != nil {
 		tmp.Close()
 		return err
 	}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -105,7 +105,17 @@ func run(invokedAs string, args []string) error {
 	// See injectedMarker doc and issue #77. Bypass requires the marker
 	// to match the per-session nonce (security #120) so a stale value
 	// can't silently disable injection.
-	if injectionAlreadyApplied() {
+	//
+	// Two-channel check (#182): the env-marker check above can fail
+	// when an intermediate process strips env vars before spawning a
+	// child — turbo 2.x's Strict Environment Mode is the canonical
+	// case. As a fallback, look for an on-disk marker file under the
+	// per-shell wrap-dir parent (which we can recover from PATH/argv
+	// even when env vars are stripped, because the wrapper had to be
+	// found via PATH to invoke us). The file lives inside the agent's
+	// runtime dir (0700, owner-only); reading it is no weaker than
+	// reading the agent's own socket from the same dir.
+	if injectionAlreadyApplied() || markerFileSays(selfDir) {
 		return execReal(realPath, argv, os.Environ())
 	}
 
@@ -150,6 +160,16 @@ func run(invokedAs string, args []string) error {
 				env = append(env, sessionNonce+"="+nonce)
 			}
 			env = append(env, injectedMarker+"="+nonce)
+			// Drop a per-shell marker file as the env-stripping fallback
+			// (#182). Subsequent shim invocations that have lost the env
+			// marker (turbo strict env mode, firejail, bwrap, …) can
+			// still detect "already injected" by reading this file. The
+			// file's existence — not its contents — is what gates the
+			// bypass; we still write the nonce so a future tool can do
+			// per-chain checks if needed. Best-effort: a write failure
+			// just degrades to the old behaviour (double notice under
+			// env stripping).
+			_ = writeMarkerFile(selfDir, nonce)
 		}
 	}
 
@@ -227,6 +247,84 @@ func firstArg() string {
 		return os.Args[0]
 	}
 	return ""
+}
+
+// markerFilename is the basename of the on-disk "already injected"
+// marker (#182). Lives under the per-shell runtime dir
+// (<runtime>/shells/<shell-pid>/), next to the wrapper bin/.
+// Garbage-collected by agent.GcOrphanShells when the shell exits.
+const markerFilename = "injected"
+
+// shellDirFromWrap returns the per-shell directory derived from a
+// wrap-dir path. The wrap-dir layout is <runtime>/shells/<pid>/bin,
+// so the per-shell dir is one level up. Returns "" when wrapDir is
+// empty or unparseable.
+func shellDirFromWrap(wrapDir string) string {
+	if wrapDir == "" {
+		return ""
+	}
+	clean := filepath.Clean(wrapDir)
+	if filepath.Base(clean) != "bin" {
+		return ""
+	}
+	return filepath.Dir(clean)
+}
+
+// markerFileSays reports whether a per-shell injection marker exists
+// at <shellDir>/<markerFilename>. Used as the env-stripping fallback
+// for the in-chain bypass check (#182): when an intermediate process
+// (turbo strict env mode, firejail, sandboxer) drops the marker env
+// vars, the file is the surviving signal.
+//
+// Returns false on any error (file missing, permission denied,
+// shellDir unresolvable) — the caller falls through to a fresh
+// inject, which is the same behaviour as today when env stripping
+// happens.
+func markerFileSays(wrapDir string) bool {
+	shellDir := shellDirFromWrap(wrapDir)
+	if shellDir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(shellDir, markerFilename))
+	return err == nil
+}
+
+// writeMarkerFile drops <shellDir>/<markerFilename> as a one-time
+// signal that the first shim hop in this shell has done its
+// injection. Content is the per-chain nonce so a future tool can
+// scope checks per-chain; today only file presence is consulted.
+// Mode 0600; owner-only (the shell dir is already 0700 owned by the
+// user). Best-effort — callers ignore errors so a marker-file write
+// failure just falls back to today's behaviour.
+func writeMarkerFile(wrapDir, nonce string) error {
+	shellDir := shellDirFromWrap(wrapDir)
+	if shellDir == "" {
+		return errors.New("cannot derive per-shell dir from wrap dir")
+	}
+	if err := os.MkdirAll(shellDir, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(shellDir, markerFilename)
+	// Atomic-via-tempfile: a partially-written marker on power loss
+	// shouldn't cause a confused half-bypass.
+	tmp, err := os.CreateTemp(shellDir, "."+markerFilename+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.WriteString(nonce); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // lookPathExcluding searches $PATH for `name`, skipping any entry that

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -92,6 +92,24 @@ func run(invokedAs string, args []string) error {
 	if selfDir == "" {
 		selfDir = filepath.Dir(firstArg())
 	}
+	// Env-stripping recovery (#182): when an intermediate process
+	// (turbo strict env mode is the canonical case; firejail / bwrap
+	// / sandboxer variants behave the same) drops __JITENV_WRAP_DIR
+	// before exec, and argv[0] is the bare basename ("npm") because
+	// the caller used execvp-by-name, both lookups above land at "."
+	// — which then breaks both the PATH-exclusion (infinite re-exec
+	// loop) AND the marker-file check (the double-injection symptom
+	// in turbo workers). Recover by scanning PATH for an entry that
+	// lives under the agent's per-user runtime dir and matches the
+	// <runtime>/shells/<pid>/bin shape. The agent verifies that
+	// runtime dir is 0700 owned by the current user (security #117),
+	// so trusting a PATH entry rooted there is no weaker than
+	// reading the agent's socket from the same dir.
+	if !isWrapDirShape(selfDir) {
+		if recovered := findWrapDirInPath(); recovered != "" {
+			selfDir = recovered
+		}
+	}
 	realPath, err := lookPathExcluding(invokedAs, selfDir)
 	if err != nil {
 		return err
@@ -268,6 +286,79 @@ func shellDirFromWrap(wrapDir string) string {
 		return ""
 	}
 	return filepath.Dir(clean)
+}
+
+// isWrapDirShape reports whether p has the structural form of a
+// jitenv per-shell wrapper bin dir: ends in `/bin`, whose parent's
+// basename is a positive integer (the shell pid). Used to detect
+// when the env / argv-derived selfDir is bogus (".", "/usr/bin", a
+// repo subdir, …) and we need to fall back to a PATH scan (#182).
+func isWrapDirShape(p string) bool {
+	if p == "" {
+		return false
+	}
+	clean := filepath.Clean(p)
+	if filepath.Base(clean) != "bin" {
+		return false
+	}
+	pidPart := filepath.Base(filepath.Dir(clean))
+	if pidPart == "." || pidPart == "/" || pidPart == "" {
+		return false
+	}
+	// Must parse as a positive int; the agent only ever creates
+	// dirs named with the shell's pid (decimal).
+	pid, err := strconv.Atoi(pidPart)
+	return err == nil && pid > 0
+}
+
+// findWrapDirInPath scans $PATH for the first entry that matches
+// the wrap-dir shape (<runtime>/shells/<pid>/bin) AND is rooted in
+// the agent's per-user runtime dir. Used as the env-stripping
+// recovery path (#182) — without it, a turbo / firejail / sandboxer
+// worker can't locate its wrap dir and the bypass machinery fails.
+//
+// Constraining to "rooted in the agent runtime dir" closes a
+// hypothetical PATH-prepended-by-attacker downgrade: an attacker
+// who can write /tmp/shells/<pid>/bin and drop a forged "injected"
+// marker file would otherwise be able to suppress env injection.
+// Tying the recovery to the agent's runtime dir (already 0700
+// owned by the user, verified at agent startup per security #117)
+// means a successful recovery is no weaker than reading the
+// agent's own socket from the same dir.
+func findWrapDirInPath() string {
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		return ""
+	}
+	shellsAbs, err := filepath.Abs(paths.ShellsDir)
+	if err != nil {
+		return ""
+	}
+	sep := string(os.PathSeparator)
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		// abs must sit STRICTLY under <runtime>/shells/ — equal or
+		// outside is rejected. The trailing separator on the prefix
+		// prevents a sibling like <runtime>/shells-evil from sneaking
+		// in.
+		if !strings.HasPrefix(abs+sep, shellsAbs+sep) || abs == shellsAbs {
+			continue
+		}
+		if !isWrapDirShape(abs) {
+			continue
+		}
+		if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+			continue
+		}
+		return abs
+	}
+	return ""
 }
 
 // markerFileSays reports whether a per-shell injection marker exists

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -154,6 +154,15 @@ func run(invokedAs string, args []string) error {
 			// so chained shim entries (e.g. npm → node via shebang)
 			// don't re-prompt.
 			env = append(env, warnedMarker+"=1")
+			// Also drop the on-disk marker (#182 env-stripping
+			// fallback). Without this, turbo-style strict-env workers
+			// strip __JITENV_AGENT_WARNED and re-prompt the user with
+			// the agent-down countdown per worker. Reusing the same
+			// "injected" file is intentional — its semantics are
+			// "this command tree has already done its first-hop
+			// jitenv work (either injected or warn-and-continued)"
+			// and either way descendants should pass through.
+			_ = writeMarkerFile(selfDir)
 		case fetchErr != nil:
 			// Other error (config parse, fetch failure). Surface to
 			// stderr but don't block — the user explicitly invoked the

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -364,46 +364,39 @@ func findWrapDirInPath() string {
 // markerFileSays reports whether the shim should bypass injection
 // based on the on-disk marker (#182 env-stripping fallback).
 //
-// The marker's content is the process-group id (pgid) of the first
-// shim hop in a command chain. The current shim only treats the
-// marker as a bypass signal when its own pgid matches the file's
-// content — that scopes the bypass to ONE command-chain identity:
+// Bypass on file presence alone. The marker's lifetime is scoped to
+// "one user command" by the shell hook's PROMPT_COMMAND-driven
+// __chpwd, which unlinks the file between every prompt (see
+// internal/chpwd.Run). So inside a running command tree the file
+// exists → workers bypass; between two prompts the file is gone →
+// the next command re-injects.
 //
-//   - Workers descended from the first shim share its pgid through
-//     fork+execve (kernel inheritance; no explicit setpgrp call),
-//     so they see "match" and bypass cleanly.
-//   - A different command in the same shell (the user's next `npm
-//     run dev` after the previous one ended; or a `git push` running
-//     between two `npm` invocations) gets a fresh pgid from bash's
-//     job-control setpgid(2) call, so it sees "mismatch" → re-inject.
+// Earlier iterations of this fix scoped the bypass by writing the
+// caller's pgid into the file and matching it on read. That broke
+// when intermediate tools (turbo's task runner being the canonical
+// example) put each worker in its own process group via setpgid(2)
+// for signal isolation — the workers' pgid didn't match the top-
+// level shim's, so they re-injected and the notice fired per
+// worker. The chpwd-driven cleanup is independent of whether
+// downstream tools fork into new pgrps, so it survives both cases.
 //
-// Without the pgid match, a stale marker from a previous chain would
-// silently suppress injection — which is the bug the user filed:
-// "after one time the injected file marker is not cleaned and no
-// more injections happen."
-//
-// Returns false on any error (file missing, malformed content,
-// shellDir unresolvable). The caller falls through to a fresh inject.
+// Returns false on any error (file missing, shellDir unresolvable).
+// The caller falls through to a fresh inject.
 func markerFileSays(wrapDir string) bool {
 	shellDir := shellDirFromWrap(wrapDir)
 	if shellDir == "" {
 		return false
 	}
-	b, err := os.ReadFile(filepath.Join(shellDir, markerFilename))
-	if err != nil {
-		return false
-	}
-	want, err := strconv.Atoi(strings.TrimSpace(string(b)))
-	if err != nil || want <= 0 {
-		return false
-	}
-	return currentPgid() == want
+	_, err := os.Stat(filepath.Join(shellDir, markerFilename))
+	return err == nil
 }
 
-// writeMarkerFile drops <shellDir>/<markerFilename> with the caller's
-// process-group id as the file's content. The pgid is what
-// markerFileSays compares against — see that function's doc for the
-// chain-scoping rationale.
+// writeMarkerFile drops <shellDir>/<markerFilename> as a one-shot
+// signal that the first shim hop in this command chain has done its
+// injection. Content is informational only — markerFileSays gates
+// on existence. Writing the pgid keeps the file useful for ad-hoc
+// debugging ("which pgrp dropped this?") and is a stable identifier
+// of the first shim that injected.
 //
 // Mode 0600; owner-only (the shell dir is already 0700 owned by the
 // user). Best-effort — callers ignore errors so a marker-file write

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -4,29 +4,13 @@ package shim_test
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 )
-
-// pgidForChild returns the process-group id a freshly exec.Command-
-// spawned child will inherit from this test process. Used by the
-// marker-file tests (#182) — the marker's content is compared to
-// the child's pgid, so the file we drop has to record the exact
-// number the child will read.
-func pgidForChild(t *testing.T) int {
-	t.Helper()
-	pgid, err := syscall.Getpgid(os.Getpid())
-	if err != nil {
-		t.Fatalf("Getpgid: %v", err)
-	}
-	return pgid
-}
 
 // buildBinary compiles the jitenv binary into the test's temp dir so
 // we can drop wrapper symlinks pointing at it. Mirrors the helper in
@@ -297,7 +281,7 @@ func TestShimRecoversWrapDirFromPath(t *testing.T) {
 	// Marker content must be the child's pgid for markerFileSays to
 	// honour it (pgid-based scoping fixes the "stale marker bypasses
 	// next command" bug from #182).
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-content"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -379,7 +363,7 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 	// Marker content is the chain's process-group id. Children
 	// spawned by exec.Command inherit this test's pgid, so writing
 	// our pgid here makes the bypass fire under the child.
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-content"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -421,97 +405,4 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 	if !strings.Contains(out, "RAN") {
 		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
 	}
-}
-
-// TestShimMarkerFromForeignPgidDoesNotBypass is the regression for
-// the user-reported follow-up on #182: after one foreground command
-// chain wrote the marker file, the user's next `npm run dev` in the
-// same shell found the marker still on disk and short-circuited —
-// no notice, no injection.
-//
-// Fix: the marker's content is the first shim's process-group id;
-// bypass only fires when the current process's pgid matches. A new
-// command from bash starts in a fresh pgid (job-control setpgid) so
-// the stale marker mismatches → fresh inject.
-//
-// This test drops a marker file with a deliberately-wrong pgid
-// (1 — the init process; guaranteed not to be this test's pgrp)
-// and expects the shim to re-inject (notice prints, real binary
-// runs).
-func TestShimMarkerFromForeignPgidDoesNotBypass(t *testing.T) {
-	bin := buildBinary(t)
-
-	dir := t.TempDir()
-
-	fakeBin := filepath.Join(dir, "bin")
-	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	realCmd := filepath.Join(fakeBin, "fakecmd")
-	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Layout for shellDirFromWrap to accept: <shellDir>/bin.
-	shellDir := filepath.Join(dir, "shell-xxx")
-	wrapDir := filepath.Join(shellDir, "bin")
-	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	wrapper := filepath.Join(wrapDir, "fakecmd")
-	if err := os.Symlink(bin, wrapper); err != nil {
-		t.Fatal(err)
-	}
-
-	// Foreign pgid in marker. Child's actual pgid (inherited from
-	// this test process) is guaranteed != 1 unless the test is
-	// running as PID 1, which doesn't happen under `go test`.
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("1"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	runtimeDir := filepath.Join(dir, "runtime")
-	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
-	// __JITENV_SHELL_PID present and matching so shouldInject() takes
-	// the inject branch when the marker correctly fails to bypass.
-	shellPID := strconv.Itoa(os.Getpid())
-
-	env := []string{
-		"PATH=" + pathEnv,
-		"XDG_RUNTIME_DIR=" + runtimeDir,
-		"__JITENV_WRAP_DIR=" + wrapDir,
-		"__JITENV_SHELL_PID=" + shellPID,
-		"JITENV_HOOK_DELAY=0",
-	}
-	if home := os.Getenv("HOME"); home != "" {
-		env = append(env, "HOME="+home)
-	}
-
-	cmd := exec.Command(wrapper)
-	cmd.Env = env
-	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("run: %v\noutput=%s", err, buf.String())
-	}
-	out := buf.String()
-
-	// The shim should re-inject (agent is down here so the warning
-	// fires instead of the notice; either way the bypass MUST NOT
-	// have suppressed both).
-	if !strings.Contains(out, "agent is not loaded") {
-		t.Errorf("expected agent-down warning (proves no bypass);\noutput=%s", out)
-	}
-	if !strings.Contains(out, "RAN") {
-		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
-	}
-
-	// The agent-down branch doesn't rewrite the marker (the rewrite
-	// only happens when fetch succeeds), so we don't assert on the
-	// marker content here. The "no bypass" semantics — proven by the
-	// warning firing above — are what this test guards.
 }

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -227,6 +227,99 @@ func TestShimSuppressesInjectionWithMarker(t *testing.T) {
 	}
 }
 
+// TestShimRecoversWrapDirFromPath is the regression for the second
+// half of #182: when turbo's strict env mode strips __JITENV_WRAP_DIR
+// AND the wrapper is invoked via execvp-by-name (argv[0]="npm", not
+// the full path), the shim's old fallback `filepath.Dir(argv[0])`
+// produces "." — which broke both the PATH-exclusion (infinite
+// re-exec loop) and the marker-file bypass added by the first
+// half of the fix. Recovery scans PATH for an entry strictly under
+// the agent's runtime dir <runtime>/shells/<pid>/bin.
+//
+// Simulates the turbo-worker environment by:
+//   - placing the wrapper under a runtime / shells/<pid>/ bin layout
+//     (so the recovery scan recognises the shape);
+//   - setting XDG_RUNTIME_DIR so agent.DefaultPaths().ShellsDir
+//     resolves to the test's runtime tree;
+//   - dropping the injection marker file in <shellDir>/injected;
+//   - launching the wrapper with argv[0]="fakecmd" (basename only —
+//     mirrors how execvp("npm", argv) passes argv[0]) and env
+//     stripped of __JITENV_WRAP_DIR.
+//
+// The shim must recover the wrap dir via the PATH scan, find the
+// marker, and short-circuit.
+func TestShimRecoversWrapDirFromPath(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// XDG_RUNTIME_DIR is the root agent.DefaultPaths() resolves
+	// against; the recovery scan walks PATH for entries strictly
+	// under <runtimeDir>/jitenv/shells/, so build the per-shell
+	// tree at that location.
+	runtimeDir := filepath.Join(dir, "runtime")
+	shellsDir := filepath.Join(runtimeDir, "jitenv", "shells")
+	shellDir := filepath.Join(shellsDir, "12345") // synthetic pid
+	wrapDir := filepath.Join(shellDir, "bin")
+	if err := os.MkdirAll(wrapDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// PATH: wrap dir first (so PATH-lookup of "fakecmd" finds the
+	// wrapper), then the real-cmd dir (so lookPathExcluding finds
+	// the real one once the wrap dir is correctly excluded).
+	pathEnv := wrapDir + string(os.PathListSeparator) + fakeBin
+
+	env := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	// argv[0]="fakecmd" (basename, not wrapper path) — mirrors how
+	// execvp("npm", argv) leaves argv[0] in a turbo-spawned worker.
+	cmd := exec.Command(wrapper)
+	cmd.Args = []string{"fakecmd"}
+	cmd.Env = env
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, buf.String())
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "agent is not loaded") {
+		t.Errorf("warning fired despite recoverable wrap dir + marker file; output=%s", out)
+	}
+	if strings.Contains(out, "jitenv: injected") {
+		t.Errorf("notice fired despite recoverable wrap dir + marker file; output=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+}
+
 // TestShimSuppressesInjectionViaMarkerFile is the regression test for
 // the env-stripping branch of issue #182: turbo strict env mode (and
 // firejail / bwrap / sandboxer variants) strips __JITENV_INJECTED

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -226,3 +226,87 @@ func TestShimSuppressesInjectionWithMarker(t *testing.T) {
 		t.Errorf("expected __JITENV_INJECTED=%s to propagate to child env;\noutput=%s", nonce, out)
 	}
 }
+
+// TestShimSuppressesInjectionViaMarkerFile is the regression test for
+// the env-stripping branch of issue #182: turbo strict env mode (and
+// firejail / bwrap / sandboxer variants) strips __JITENV_INJECTED
+// and __JITENV_SESSION_NONCE before spawning children, so the env-
+// based bypass in TestShimSuppressesInjectionWithMarker can't fire.
+// The fallback is an on-disk marker file at <wrap-dir>/../injected.
+// This test simulates that case directly: drop the marker file by
+// hand (no first-pass run to create it — we want to exercise the
+// file-only branch), then invoke the shim with NO env markers set
+// and confirm the bypass still fires.
+func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap-dir layout MUST be <shellDir>/bin (the shim's
+	// shellDirFromWrap derives shellDir as filepath.Dir(wrapDir) and
+	// rejects wrap-dirs whose basename isn't "bin").
+	shellDir := filepath.Join(dir, "shell-xxx")
+	wrapDir := filepath.Join(shellDir, "bin")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drop the marker file. The shim only checks file presence; the
+	// content can be anything (today the nonce, future tools may
+	// switch to per-chain matching).
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
+
+	// Crucially: NO __JITENV_INJECTED, NO __JITENV_SESSION_NONCE, NO
+	// __JITENV_SHELL_PID — simulates turbo's strict-env stripping of
+	// jitenv-namespaced vars. __JITENV_WRAP_DIR is also dropped; the
+	// shim's fallback resolves the wrap dir from argv[0].
+	env := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	cmd := exec.Command(wrapper)
+	cmd.Env = env
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, buf.String())
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "agent is not loaded") {
+		t.Errorf("warning fired despite marker file; output=%s", out)
+	}
+	if strings.Contains(out, "jitenv: injected") {
+		t.Errorf("notice fired despite marker file; output=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+}

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -4,13 +4,29 @@ package shim_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 )
+
+// pgidForChild returns the process-group id a freshly exec.Command-
+// spawned child will inherit from this test process. Used by the
+// marker-file tests (#182) — the marker's content is compared to
+// the child's pgid, so the file we drop has to record the exact
+// number the child will read.
+func pgidForChild(t *testing.T) int {
+	t.Helper()
+	pgid, err := syscall.Getpgid(os.Getpid())
+	if err != nil {
+		t.Fatalf("Getpgid: %v", err)
+	}
+	return pgid
+}
 
 // buildBinary compiles the jitenv binary into the test's temp dir so
 // we can drop wrapper symlinks pointing at it. Mirrors the helper in
@@ -278,7 +294,10 @@ func TestShimRecoversWrapDirFromPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+	// Marker content must be the child's pgid for markerFileSays to
+	// honour it (pgid-based scoping fixes the "stale marker bypasses
+	// next command" bug from #182).
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -357,10 +376,10 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Drop the marker file. The shim only checks file presence; the
-	// content can be anything (today the nonce, future tools may
-	// switch to per-chain matching).
-	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("any-nonce"), 0o600); err != nil {
+	// Marker content is the chain's process-group id. Children
+	// spawned by exec.Command inherit this test's pgid, so writing
+	// our pgid here makes the bypass fire under the child.
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte(fmt.Sprintf("%d", pgidForChild(t))), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -402,4 +421,97 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 	if !strings.Contains(out, "RAN") {
 		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
 	}
+}
+
+// TestShimMarkerFromForeignPgidDoesNotBypass is the regression for
+// the user-reported follow-up on #182: after one foreground command
+// chain wrote the marker file, the user's next `npm run dev` in the
+// same shell found the marker still on disk and short-circuited —
+// no notice, no injection.
+//
+// Fix: the marker's content is the first shim's process-group id;
+// bypass only fires when the current process's pgid matches. A new
+// command from bash starts in a fresh pgid (job-control setpgid) so
+// the stale marker mismatches → fresh inject.
+//
+// This test drops a marker file with a deliberately-wrong pgid
+// (1 — the init process; guaranteed not to be this test's pgrp)
+// and expects the shim to re-inject (notice prints, real binary
+// runs).
+func TestShimMarkerFromForeignPgidDoesNotBypass(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Layout for shellDirFromWrap to accept: <shellDir>/bin.
+	shellDir := filepath.Join(dir, "shell-xxx")
+	wrapDir := filepath.Join(shellDir, "bin")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+
+	// Foreign pgid in marker. Child's actual pgid (inherited from
+	// this test process) is guaranteed != 1 unless the test is
+	// running as PID 1, which doesn't happen under `go test`.
+	if err := os.WriteFile(filepath.Join(shellDir, "injected"), []byte("1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
+	// __JITENV_SHELL_PID present and matching so shouldInject() takes
+	// the inject branch when the marker correctly fails to bypass.
+	shellPID := strconv.Itoa(os.Getpid())
+
+	env := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"__JITENV_WRAP_DIR=" + wrapDir,
+		"__JITENV_SHELL_PID=" + shellPID,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	cmd := exec.Command(wrapper)
+	cmd.Env = env
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, buf.String())
+	}
+	out := buf.String()
+
+	// The shim should re-inject (agent is down here so the warning
+	// fires instead of the notice; either way the bypass MUST NOT
+	// have suppressed both).
+	if !strings.Contains(out, "agent is not loaded") {
+		t.Errorf("expected agent-down warning (proves no bypass);\noutput=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+
+	// The agent-down branch doesn't rewrite the marker (the rewrite
+	// only happens when fetch succeeds), so we don't assert on the
+	// marker content here. The "no bypass" semantics — proven by the
+	// warning firing above — are what this test guards.
 }

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -406,3 +406,88 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
 	}
 }
+
+// TestShimWarnPathWritesMarkerFile covers the second symptom of
+// #182: when the agent is locked, the first shim in a command tree
+// hits the warn path (agent-down countdown), the user dismisses it,
+// and the command runs without env injection. Without the on-disk
+// marker, turbo workers strip __JITENV_AGENT_WARNED and re-prompt
+// the countdown per worker (real user bug). This test asserts the
+// shim drops the marker file on the warn path too, so downstream
+// shim hops bypass via markerFileSays() even when env is stripped.
+//
+// We can't drive the interactive countdown from a test, so we
+// detach stdin from a TTY (cmd.Stdin = nil — the agentwarn.WarnAndWait
+// non-TTY fast path runs and returns immediately). That path is the
+// CI / non-interactive flow but exercises the same warn-marker
+// write code below it.
+func TestShimWarnPathWritesMarkerFile(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+
+	fakeBin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realCmd := filepath.Join(fakeBin, "fakecmd")
+	if err := os.WriteFile(realCmd, []byte("#!/bin/sh\necho RAN\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// <shellDir>/bin layout so shellDirFromWrap accepts it.
+	shellDir := filepath.Join(dir, "shell-xxx")
+	wrapDir := filepath.Join(shellDir, "bin")
+	if err := os.MkdirAll(wrapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(wrapDir, "fakecmd")
+	if err := os.Symlink(bin, wrapper); err != nil {
+		t.Fatal(err)
+	}
+	// Empty runtime dir → no agent socket → shim hits the warn path.
+	runtimeDir := filepath.Join(dir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pathEnv := fakeBin + string(os.PathListSeparator) + os.Getenv("PATH")
+	shellPID := strconv.Itoa(os.Getpid())
+
+	env := []string{
+		"PATH=" + pathEnv,
+		"XDG_RUNTIME_DIR=" + runtimeDir,
+		"__JITENV_WRAP_DIR=" + wrapDir,
+		"__JITENV_SHELL_PID=" + shellPID,
+		"JITENV_HOOK_DELAY=0",
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		env = append(env, "HOME="+home)
+	}
+
+	cmd := exec.Command(wrapper)
+	cmd.Env = env
+	// Non-TTY stdin = agentwarn's fast path returns immediately
+	// (it prints the warn and continues without the countdown).
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "agent is not loaded") {
+		t.Errorf("expected agent-down warning;\noutput=%s", out)
+	}
+	if !strings.Contains(out, "RAN") {
+		t.Errorf("expected fakecmd to exec ('RAN');\noutput=%s", out)
+	}
+
+	// The fix: marker file is present after a warn-path traversal so
+	// downstream re-wrapped commands (turbo workers) bypass instead of
+	// re-prompting the countdown.
+	markerPath := filepath.Join(shellDir, "injected")
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Errorf("expected marker file at %s after warn-path; stat err=%v;\noutput=%s",
+			markerPath, err, out)
+	}
+}


### PR DESCRIPTION
Closes #182. Consolidates the 6-commit stack that fully addresses the issue.

## Commit order

| Commit | What | Closed PR |
|---|---|---|
| `4a986c3` | `fix(shim): on-disk marker file as env-stripping fallback` | #183 (part) |
| `f963aaf` | `feat(cli): split TUI into separate jitenv-tui binary` | #183 (part) |
| `2ec02cf` | `fix(shim): recover wrap dir from PATH when env vars are stripped` | #184 |
| `2de02d2` | `fix(shim): scope injection marker to one command chain via pgid` | #185 (logic superseded by next commit; helpers remain as informational) |
| `fa86260` | `fix(shim,chpwd): scope injection marker via PROMPT_COMMAND cleanup` | #186 |
| `edec2a7` | `fix(shim): write marker file on warn-path too` | #187 (original scope) |

## Final design

**Issue had two distinct symptoms (#182 bug A + bug B).**

### Bug B — terminal-query leak from `jitenv` startup

Bubble Tea v1.x's `tea_init.go` runs `lipgloss.HasDarkBackground()` at package import time, which sends OSC 11 + CPR (`\e[6n`) queries to the tty. Because `internal/cli` imported `internal/tui`, every jitenv subcommand triggered the query. In turbo's child-pty model the responses leaked into captured output.

**Fix:** factor the TUI into a separate `cmd/jitenv-tui` binary. `internal/cli/config.go` re-execs `jitenv-tui run <cfgPath>` via `os/exec`. Main jitenv binary's import graph no longer contains bubbletea/lipgloss/termenv. Verified: `xxd <(jitenv version)` produces zero OSC11/CPR bytes.

Packaging changes: goreleaser builds both binaries into one archive per OS/arch; deb/rpm install both to `/usr/bin`; Homebrew cask declares `binaries: [jitenv, jitenv-tui]`; Makefile `build`/`install` produces both.

### Bug A — double injection in turbo workers

Five distinct failure modes layered on each other; each needed its own fix:

1. **Turbo Strict Environment Mode strips `__JITENV_INJECTED` and `__JITENV_SESSION_NONCE`** → env-based bypass fails → workers re-inject. **Fix:** on-disk marker file at `<runtime>/shells/<pid>/injected` as the second bypass channel.

2. **Turbo also strips `__JITENV_WRAP_DIR`**, AND workers' `argv[0]="npm"` (execvp-by-name) → `filepath.Dir("npm")="."` → both PATH-exclusion AND marker lookup break. **Fix:** scan `$PATH` for an entry strictly under `<runtime>/shells/<pid>/bin` (security #117 verifies that dir is 0700 owner-only at agent startup).

3. **Marker survived across commands in the same shell** → next `npm run dev` short-circuited with no injection. **Fix:** scope marker to "one user command" via `__chpwd` cleanup on every `PROMPT_COMMAND`.

4. **Pgid-based scoping (interim) failed** because turbo puts each worker in its own process group for signal isolation. **Fix:** rely on file-presence + chpwd cleanup. (Pgid helpers retained — `writeMarkerFile` records pgid as informational content for debugging.)

5. **Locked-agent symmetric bug:** turbo also strips `__JITENV_AGENT_WARNED` → workers re-prompt the countdown. **Fix:** warn-path now drops the same marker file. Marker semantics broaden from "we injected" to "we did the first-hop jitenv work".

## Tests

New regression coverage in `internal/shim/shim_test.go` and `internal/chpwd/chpwd_test.go`:

- `TestShimSuppressesInjectionViaMarkerFile` — bypass via file presence when env is stripped
- `TestShimRecoversWrapDirFromPath` — PATH scan recovers wrap-dir under env+argv worst case
- `TestRunUnlinksInjectionMarker` — chpwd unlinks marker before the short-circuit branch
- `TestShimWarnPathWritesMarkerFile` — warn-path drops the marker too

Full repo `go test ./...` + `golangci-lint v1.62.2` green across all 6 commits.

## E2e verification by issue author

Confirmed by the user across the regression sequence:
- Bug B fix: `xxd <(jitenv version)` clean.
- Bug A injection: `npm run preview` with cleared turbo cache → exactly one `jitenv: injected N variables`.
- Bug A warn path: with agent locked, exactly one countdown prompt.

## Non-interactive contexts

CI / scripts without the shell hook don't fire `__chpwd`, so the marker persists for the shell's lifetime. `agent.GcOrphanShells` removes the whole `<shellsDir>/<pid>/` when the shell exits. CI jobs typically run one command per shell anyway.

## Required follow-up for distribution

Split into `jitenv` + `jitenv-tui` → installers need both binaries:
- Goreleaser: done
- deb/rpm/Homebrew cask: done
- Chocolatey package (#180) will need the same treatment when implemented