### PR TITLE
fix(release): use index .Env for homebrew cask token

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -123,10 +123,10 @@ nfpms:
 # `brews:` block.
 #
 # Cross-repo pushes need a PAT scoped to the tap repo; the default
-# GITHUB_TOKEN can only write to the current repo. envOrDefault keeps
-# `goreleaser release --snapshot` working locally when the secret is
-# absent — combined with `skip_upload: auto` it just generates the
-# cask in dist/ without trying to push.
+# GITHUB_TOKEN can only write to the current repo. `index .Env "..."`
+# returns "" when the secret is absent, so `goreleaser release
+# --snapshot` keeps working locally — combined with `skip_upload:
+# auto` it just generates the cask in dist/ without trying to push.
 #
 # Without notarization the cask sets `no_quarantine: true` so the
 # Gatekeeper hard-block doesn't fire on install. Users still see the
@@ -138,7 +138,7 @@ homebrew_casks:
       owner: Galvill
       name: homebrew-jitenv
       branch: main
-      token: '{{ envOrDefault "HOMEBREW_TAP_GITHUB_TOKEN" "" }}'
+      token: '{{ index .Env "HOMEBREW_TAP_GITHUB_TOKEN" }}'
     directory: Casks
     homepage: https://github.com/Galvill/jitenv
     description: Just-in-time env-var injection from pluggable secret sources, scoped to per-command process trees


### PR DESCRIPTION
## Summary
- `envOrDefault` is not a goreleaser template function; it was an undocumented sprig-ism. The v0.8.0 release succeeded at publishing the GitHub release + binaries but failed at the homebrew cask publish step with `function "envOrDefault" not defined`.
- Replace with `{{ index .Env "HOMEBREW_TAP_GITHUB_TOKEN" }}` — the canonical goreleaser-template-safe env read: returns "" when the var is unset, so the same template works in CI (secret present) and `goreleaser release --snapshot` locally (no secret, `skip_upload: auto` suppresses the push).
- v0.8.0 itself is already published on GitHub Releases; the homebrew-jitenv tap needs a one-time manual cask update for v0.8.0. The next release after this lands will publish correctly end-to-end.

## Test plan
- [x] Diff verified — only template-syntax change
- [x] CI passes
- [ ] Next release publishes the cask successfully (verified when v0.8.1+ ships)