### PR TITLE
fix(cli): mkdir config parent before TUI lockfile acquire (#190)

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -121,6 +121,15 @@ func runConfigTUI() error {
 	if err != nil {
 		return err
 	}
+	// Fresh installs hit this before the TUI's loadOrInit flow has a
+	// chance to mkdir the parent (#190 regression from #166). The
+	// lockfile open uses O_CREATE but not MkdirAll, so without the
+	// parent dir we fail with ENOENT before the "no config — create a
+	// new one?" prompt can run. Mode 0700 matches what config.InitNew
+	// uses, so we're not introducing a new permission surface.
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
 	lock, lockErr := lockfile.Acquire(cfgPath + ".tui.lock")
 	if lockErr != nil {
 		if errors.Is(lockErr, os.ErrExist) {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -22,10 +23,17 @@ func TestRunConfigTUICreatesConfigDirOnFreshInstall(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows uses %LOCALAPPDATA% pathing + a different no-op binary; covered by manual repro")
 	}
+	// Locate `true` portably: macOS runners ship it at /usr/bin/true,
+	// most Linux distros at /bin/true (some at both). exec.LookPath
+	// hits PATH, which is reliable across both.
+	noop, err := exec.LookPath("true")
+	if err != nil {
+		t.Skipf("no `true` binary on PATH: %v", err)
+	}
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("JITENV_CONFIG", "")
-	t.Setenv("JITENV_TUI_BIN", "/bin/true")
+	t.Setenv("JITENV_TUI_BIN", noop)
 
 	saved := configPath
 	configPath = ""

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestRunConfigTUICreatesConfigDirOnFreshInstall covers the #190
+// regression: on a fresh machine where the user has never run
+// jitenv before, $XDG_CONFIG_HOME/jitenv/ does not exist. The
+// lockfile.Acquire call in runConfigTUI opens the lock file with
+// O_CREATE (but not MkdirAll), so without an explicit MkdirAll
+// before the acquire we fail with ENOENT before the TUI's
+// loadOrInit "create a new config?" prompt can run.
+//
+// We stub the TUI binary with a no-op command so runConfigTUI
+// completes end-to-end; the assertion is simply that it succeeds
+// and that the parent dir is now present.
+func TestRunConfigTUICreatesConfigDirOnFreshInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows uses %LOCALAPPDATA% pathing + a different no-op binary; covered by manual repro")
+	}
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("JITENV_CONFIG", "")
+	t.Setenv("JITENV_TUI_BIN", "/bin/true")
+
+	saved := configPath
+	configPath = ""
+	t.Cleanup(func() { configPath = saved })
+
+	cfgDir := filepath.Join(tmp, "jitenv")
+	if _, err := os.Stat(cfgDir); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s must not exist, got err=%v", cfgDir, err)
+	}
+
+	if err := runConfigTUI(); err != nil {
+		t.Fatalf("runConfigTUI failed on fresh install: %v", err)
+	}
+
+	st, err := os.Stat(cfgDir)
+	if err != nil {
+		t.Fatalf("config dir not created: %v", err)
+	}
+	if !st.IsDir() {
+		t.Fatalf("expected dir, got %v", st.Mode())
+	}
+	if mode := st.Mode().Perm(); mode != 0o700 {
+		t.Errorf("config dir mode = %v, want 0700", mode)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #190. On a fresh install where `~/.config/jitenv/` doesn't yet exist, `jitenv config` aborts at `lockfile.Acquire` (added in #166) before the TUI's first-run "create a new config?" prompt can run. `lockfile.Acquire` opens with `O_CREATE` but not `MkdirAll`, so it fails ENOENT.

The fix is an explicit `os.MkdirAll(filepath.Dir(cfgPath), 0o700)` immediately after `config.Resolve`, before the lock acquire. Mode matches what `config.InitNew` uses internally — we're just moving directory creation milliseconds earlier in the flow.

## Test plan
- [x] New regression test `TestRunConfigTUICreatesConfigDirOnFreshInstall` stubs `JITENV_TUI_BIN=/bin/true` and asserts the dir is created with mode 0700
- [x] Confirmed the test fails on the pre-fix code with the exact ENOENT error from the issue
- [x] `make test` and `go vet ./...` green locally
- [ ] CI passes