### PR TITLE
fix(tui): scroll var-selection tree to keep cursor visible (#194)

### DIFF
--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -52,6 +52,39 @@ func renderApp(w, h int, body, status string) string {
 	return panel + "\n" + statusLine + "\n" + footerLine
 }
 
+// scrollOffset adjusts a list's scroll offset so the cursor stays
+// inside the visible window [off, off+visible), moving the window by
+// the minimal amount needed (so the list doesn't jump on every move).
+// total is the number of rows, visible the number that fit on screen.
+// The returned offset is clamped to a valid range, and is 0 whenever
+// everything fits. Screens hold the offset as state and re-derive it
+// each render; renderApp's bottom clamp already protects against
+// overflow, so callers only need to keep the focused row inside the
+// slice they emit.
+//
+// Lives here (not in a single screen) so the mappings / secrets /
+// sources list screens can adopt the same windowing — see #194.
+func scrollOffset(off, cursor, total, visible int) int {
+	if visible < 1 {
+		visible = 1
+	}
+	if visible >= total {
+		return 0
+	}
+	if cursor < off {
+		off = cursor
+	} else if cursor >= off+visible {
+		off = cursor - visible + 1
+	}
+	if maxOff := total - visible; off > maxOff {
+		off = maxOff
+	}
+	if off < 0 {
+		off = 0
+	}
+	return off
+}
+
 var copyrightStyle = lipgloss.NewStyle().
 	Foreground(colorMuted).
 	Faint(true).

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -28,6 +28,33 @@ func TestRenderFooter_PipeSeparatedSegments(t *testing.T) {
 	}
 }
 
+// TestScrollOffset covers the windowing math behind the var-tree
+// scroll fix (#194): keep the cursor inside [off, off+visible) with
+// minimal movement, clamp to the last page, and treat "everything
+// fits" as offset 0.
+func TestScrollOffset(t *testing.T) {
+	cases := []struct {
+		name                        string
+		off, cursor, total, visible int
+		want                        int
+	}{
+		{"all fits", 0, 5, 8, 10, 0},
+		{"cursor below window scrolls down", 0, 9, 30, 5, 5},
+		{"cursor above window scrolls up", 10, 3, 30, 5, 3},
+		{"cursor inside window no move", 5, 6, 30, 5, 5},
+		{"clamp to last page", 0, 29, 30, 5, 25},
+		{"zero visible treated as 1", 0, 10, 30, 0, 10},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scrollOffset(c.off, c.cursor, c.total, c.visible); got != c.want {
+				t.Errorf("scrollOffset(%d,%d,%d,%d) = %d, want %d",
+					c.off, c.cursor, c.total, c.visible, got, c.want)
+			}
+		})
+	}
+}
+
 // TestRenderFooter_DropsVersionWhenNarrow falls back to the
 // jitenv | copyright | MIT line on tight widths so the footer never
 // wraps or clobbers the status line above it. The version is always

--- a/internal/tui/var_tree_screen.go
+++ b/internal/tui/var_tree_screen.go
@@ -36,6 +36,7 @@ type varTreeScreen struct {
 	mappingIdx int
 	bags       []treeBag
 	cursor     int
+	offset     int  // first visible flat-row index; kept in sync with cursor in View (#194)
 	noBags     bool // true when neither a local source nor any Bagger source has anything to show
 }
 
@@ -424,7 +425,29 @@ func (s *varTreeScreen) View() string {
 	}
 
 	rows := s.flatRows()
-	for i, r := range rows {
+
+	// Window the tree so the focused row is always on screen (#194).
+	// renderApp hands the body innerH = height-6 lines; we spend 2 on
+	// the heading ("Select variables" + blank) and 2 on the trailing
+	// tip block, and reserve up to 2 more for the "↑/↓ more" scroll
+	// affordances. visibleRows accounts for the affordance lines being
+	// drawn so the focused row never collides with them.
+	visible := s.root.height - 6 - 2 - 2 - 2
+	if visible < 1 {
+		visible = 1
+	}
+	s.offset = scrollOffset(s.offset, s.cursor, len(rows), visible)
+	start := s.offset
+	end := start + visible
+	if end > len(rows) {
+		end = len(rows)
+	}
+
+	if start > 0 {
+		b.WriteString(dimText(fmt.Sprintf("  ↑ %d more", start)) + "\n")
+	}
+	for i := start; i < end; i++ {
+		r := rows[i]
 		focused := i == s.cursor
 		marker := "  "
 		if focused {
@@ -436,6 +459,9 @@ func (s *varTreeScreen) View() string {
 		} else {
 			b.WriteString(marker + " " + listItemStyle.Render(line) + "\n")
 		}
+	}
+	if end < len(rows) {
+		b.WriteString(dimText(fmt.Sprintf("  ↓ %d more", len(rows)-end)) + "\n")
 	}
 	b.WriteString("\n" + dimText("Tip: ticking a bag includes every key (including future ones).") + "\n")
 	return b.String()

--- a/internal/tui/var_tree_screen_test.go
+++ b/internal/tui/var_tree_screen_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gv/jitenv/internal/config"
@@ -146,6 +148,81 @@ func TestVarTree_TickBagClearsIndividualKeys(t *testing.T) {
 		if k.sel {
 			t.Fatalf("individual key sel should be cleared when bag goes 'all'")
 		}
+	}
+}
+
+// manyKeysFixture builds a config with a single local bag holding n
+// keys (KEY00, KEY01, …) so the flattened tree (1 header + n keys)
+// comfortably exceeds a short terminal — the #194 repro.
+func manyKeysFixture(n int) *config.Config {
+	keys := map[string]string{}
+	for i := 0; i < n; i++ {
+		keys[fmt.Sprintf("KEY%02d", i)] = "v"
+	}
+	return &config.Config{
+		Sources:  map[string]config.SourceConfig{"local": {Type: "local"}},
+		Secrets:  map[string]map[string]string{"big": keys},
+		Mappings: []config.Mapping{{Path: "/x.sh"}},
+	}
+}
+
+// renderPanelBody drives the full root render path (panel + status +
+// footer, including renderApp's bottom clamp) for one screen at a
+// fixed terminal size, then strips the trailing status + footer lines
+// so assertions on body content aren't confused by the status bar's
+// own "↑/↓: move" help text. This is what catches #194: View() alone
+// emits every row, so the bug only surfaces once renderApp clips the
+// body to the terminal height.
+func renderPanelBody(r *rootModel, s screen, w, h int) string {
+	r.width, r.height = w, h
+	r.stack = []screen{s}
+	lines := strings.Split(r.View(), "\n")
+	if len(lines) > 2 { // drop status + footer
+		lines = lines[:len(lines)-2]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// TestVarTree_ScrollKeepsCursorVisible is the #194 regression: with a
+// tree taller than the terminal, moving the cursor to the last row must
+// still render that row (and its focus marker) inside the clamped body,
+// with an "↑ more" affordance showing the list scrolled.
+func TestVarTree_ScrollKeepsCursorVisible(t *testing.T) {
+	r := makeRoot(manyKeysFixture(30))
+	scr := newVarTreeScreen(r, 0).(*varTreeScreen)
+
+	rows := scr.flatRows()
+	scr.cursor = len(rows) - 1 // last key
+
+	out := renderPanelBody(r, scr, 80, 15) // short terminal
+	if !strings.Contains(out, "▶") {
+		t.Fatalf("focus marker missing when scrolled to bottom:\n%s", out)
+	}
+	if !strings.Contains(out, "KEY29") {
+		t.Fatalf("focused last row KEY29 not in clamped body:\n%s", out)
+	}
+	if !strings.Contains(out, "↑") {
+		t.Fatalf("expected up-scroll affordance at bottom:\n%s", out)
+	}
+	// The bag header (row 0) must have scrolled out of the window.
+	if strings.Contains(out, "(30 keys)") {
+		t.Fatalf("bag header should have scrolled off:\n%s", out)
+	}
+}
+
+// TestVarTree_ScrollAffordanceAtTop confirms the inverse: at the top of
+// a too-tall tree there's a "↓ more" affordance but no "↑ more".
+func TestVarTree_ScrollAffordanceAtTop(t *testing.T) {
+	r := makeRoot(manyKeysFixture(30))
+	scr := newVarTreeScreen(r, 0).(*varTreeScreen)
+	scr.cursor = 0
+
+	out := renderPanelBody(r, scr, 80, 15)
+	if strings.Contains(out, "↑") {
+		t.Errorf("no up affordance expected at top:\n%s", out)
+	}
+	if !strings.Contains(out, "↓") {
+		t.Errorf("expected down affordance at top:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes #194. The "Select variables" tree (`varTreeScreen.View`) rendered every row from index 0 and leaned on `renderApp`'s bottom clamp to fit the terminal. When the bag→key tree was taller than the screen, the focused row scrolled off the bottom and became invisible — the cursor still moved and toggles still landed, but the user couldn't see which row was focused.

### Changes
- `varTreeScreen.View` now windows the flat row list around the cursor: derives a visible-row budget from `root.height` (minus panel chrome / heading / tip / affordance lines), keeps a scroll offset in sync with the cursor, and renders only the visible slice.
- Adds `↑ N more` / `↓ N more` affordances when the list continues above/below the window.
- Extracts the offset math into a reusable `scrollOffset(off, cursor, total, visible)` helper in `layout.go` so the mappings / secrets / sources list screens (same latent overflow, noted in the issue) can adopt it later.

## Test plan
- [x] `TestVarTree_ScrollKeepsCursorVisible` / `TestVarTree_ScrollAffordanceAtTop` drive the **full root render path** (so `renderApp`'s clamp is in play — which is what the bug needs) and assert the focused last row + marker are visible when scrolled to the bottom
- [x] `TestScrollOffset` covers min-movement scrolling + last-page clamp + "everything fits"
- [x] Verified the screen tests **fail** on the pre-fix render loop (focused KEY29 clipped away)
- [x] `make fmt vet` + full `go test ./...` green
- [x] CI passes