### PR TITLE
feat(release): Chocolatey package for Windows installs (#180)

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -1,0 +1,156 @@
+name: chocolatey
+
+# Windows counterpart to the Homebrew cask (#180). Runs on
+# windows-latest because goreleaser's chocolatey packer (and `choco`
+# itself) only exist on Windows, whereas release.yml runs on ubuntu.
+# Fires once a GitHub release is published — by then release.yml has
+# uploaded the windows-amd64 .zip and the SHA256SUMS asset, which this
+# job downloads + checksum-pins into the package before pushing.
+#
+# Pre-releases (the `-rc.N` tags cut by release-rc.yml) are skipped so
+# the chocolatey.org moderation queue isn't flooded with RCs.
+#
+# Until CHOCOLATEY_API_KEY is configured (repo Settings → Secrets and
+# variables → Actions), the job still packs the .nupkg and uploads it
+# as a build artifact for inspection — it just skips the push.
+#
+# Injection hygiene: every release-supplied value (the tag, and the
+# version/url/checksum derived from it) is routed through `env:` and
+# read as `$env:VAR` inside run blocks rather than inlined as
+# `${{ ... }}`, matching release-rc.yml.
+
+on:
+  release:
+    types: [published]
+  # Manual re-run path: pack (and push, if the key is set) for an
+  # already-published tag without re-cutting the release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to package, e.g. v0.9.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chocolatey-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # Skip pre-releases on the automatic trigger; workflow_dispatch is
+    # always allowed (the operator chose the tag deliberately).
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: windows-latest
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      CHOCO_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version, archive URL, and checksum
+        id: meta
+        shell: pwsh
+        run: |
+          $tag = $env:TAG
+          if (-not $tag) { throw "no release tag available" }
+          if ($tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$') {
+            throw "tag '$tag' is not a recognised vMAJOR.MINOR.PATCH[-rc.N] release tag"
+          }
+          $version = $tag.TrimStart('v')
+          $zip = "jitenv_${version}_windows_amd64.zip"
+          $base = "https://github.com/Galvill/jitenv/releases/download/$tag"
+          $url = "$base/$zip"
+
+          # goreleaser creates the release as non-draft, so `published`
+          # can fire while assets are still uploading. Retry the
+          # SHA256SUMS fetch (it's uploaded after the archives, so its
+          # presence implies the zip is up too) with backoff before
+          # giving up.
+          $sums = $null
+          foreach ($attempt in 1..10) {
+            try {
+              $sums = (Invoke-WebRequest -Uri "$base/SHA256SUMS" -UseBasicParsing).Content
+              break
+            } catch {
+              Write-Host "SHA256SUMS not ready (attempt $attempt): $($_.Exception.Message)"
+              Start-Sleep -Seconds (5 * $attempt)
+            }
+          }
+          if (-not $sums) { throw "SHA256SUMS asset never became available for $tag" }
+
+          $line = ($sums -split "`n") |
+            Where-Object { $_ -match [regex]::Escape($zip) } |
+            Select-Object -First 1
+          if (-not $line) { throw "checksum for $zip not found in SHA256SUMS" }
+          $checksum = ($line -split '\s+')[0]
+          if ($checksum -notmatch '^[0-9a-fA-F]{64}$') {
+            throw "parsed checksum '$checksum' is not a SHA256 hex digest"
+          }
+
+          "version=$version"   >> $env:GITHUB_OUTPUT
+          "zip=$zip"           >> $env:GITHUB_OUTPUT
+          "url=$url"           >> $env:GITHUB_OUTPUT
+          "checksum=$checksum" >> $env:GITHUB_OUTPUT
+          Write-Host "Packaging jitenv $version from $url (sha256 $checksum)"
+
+      - name: Render package tokens
+        shell: pwsh
+        env:
+          PKG_VERSION: ${{ steps.meta.outputs.version }}
+          PKG_URL: ${{ steps.meta.outputs.url }}
+          PKG_CHECKSUM: ${{ steps.meta.outputs.checksum }}
+          PKG_ZIP: ${{ steps.meta.outputs.zip }}
+        run: |
+          # Refresh LICENSE.txt from the repo LICENSE so the committed
+          # copy can never drift, then substitute the pack-time tokens.
+          Copy-Item LICENSE packaging/chocolatey/tools/LICENSE.txt -Force
+          $files = @(
+            'packaging/chocolatey/jitenv.nuspec',
+            'packaging/chocolatey/tools/chocolateyInstall.ps1',
+            'packaging/chocolatey/tools/chocolateyUninstall.ps1',
+            'packaging/chocolatey/tools/VERIFICATION.txt'
+          )
+          foreach ($f in $files) {
+            (Get-Content -Raw $f).
+              Replace('__VERSION__',    $env:PKG_VERSION).
+              Replace('__URL64__',      $env:PKG_URL).
+              Replace('__CHECKSUM64__', $env:PKG_CHECKSUM).
+              Replace('__ZIPNAME__',    $env:PKG_ZIP) |
+              Set-Content -NoNewline $f
+          }
+
+      - name: choco pack
+        shell: pwsh
+        env:
+          PKG_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          New-Item -ItemType Directory -Force -Path dist-choco | Out-Null
+          choco pack packaging/chocolatey/jitenv.nuspec --version $env:PKG_VERSION --outputdirectory dist-choco
+          if ($LASTEXITCODE -ne 0) { throw "choco pack failed ($LASTEXITCODE)" }
+
+      - name: Upload nupkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chocolatey-nupkg
+          path: dist-choco/*.nupkg
+          if-no-files-found: error
+
+      - name: choco push
+        if: ${{ env.CHOCO_KEY != '' }}
+        shell: pwsh
+        env:
+          PKG_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          choco push "dist-choco/jitenv.${env:PKG_VERSION}.nupkg" --source https://push.chocolatey.org/ --api-key $env:CHOCO_KEY
+          if ($LASTEXITCODE -ne 0) { throw "choco push failed ($LASTEXITCODE)" }
+          Write-Host "Pushed jitenv ${env:PKG_VERSION} to chocolatey.org (pending moderation)."
+
+      - name: Note when key absent
+        if: ${{ env.CHOCO_KEY == '' }}
+        shell: pwsh
+        run: |
+          Write-Host '::warning::CHOCOLATEY_API_KEY is not set — packed the .nupkg (uploaded as an artifact) but did not push. Configure the secret to publish to chocolatey.org.'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -168,6 +168,14 @@ homebrew_casks:
                            args: ["-dr", "com.apple.quarantine", "#{staged_path}/jitenv-tui"]
           end
 
+# Chocolatey (#180) is intentionally NOT a goreleaser pipe: its
+# packer shells out to the `choco` CLI, which only exists on Windows,
+# while this release runs on ubuntu. The package is built+pushed by a
+# separate windows-latest workflow (.github/workflows/chocolatey.yml)
+# from the hand-authored package under packaging/chocolatey/, which
+# downloads the windows .zip this release uploads and SHA256-verifies
+# it. See that workflow and packaging/chocolatey/ for the details.
+
 checksum:
   name_template: SHA256SUMS
 
@@ -202,6 +210,12 @@ release:
 
     ```sh
     brew install Galvill/jitenv/jitenv
+    ```
+
+    Windows users can install via Chocolatey:
+
+    ```powershell
+    choco install jitenv
     ```
 
     macOS binaries are **not** Apple-notarized — first run requires

--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ exec $SHELL
 
 Homebrew never modifies your shell rc files on its own.
 
+### Chocolatey (Windows)
+
+```powershell
+choco install jitenv
+```
+
+A downloader package that fetches the official `windows_amd64` release
+zip and verifies its SHA256 before extracting; Chocolatey shims both
+`jitenv.exe` and `jitenv-tui.exe` onto `%PATH%`. `choco upgrade jitenv`
+picks up new releases. After install, activate the PowerShell hook
+**once**:
+
+```powershell
+jitenv hook install
+# open a new pwsh tab — the hook is live
+```
+
+The first run of `jitenv.exe` may trip SmartScreen because the binary
+is not yet Authenticode-signed (tracked in
+[#39](https://github.com/Galvill/jitenv/issues/39)) — `Unblock-File`,
+or right-click → Properties → Unblock, clears it. PowerShell 7+ is
+required for the hook.
+
 ## Commands
 
 ```

--- a/packaging/chocolatey/jitenv.nuspec
+++ b/packaging/chocolatey/jitenv.nuspec
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Chocolatey package manifest for jitenv (#180).
+
+  __VERSION__ / __URL64__ / __CHECKSUM64__ / __ZIPNAME__ are placeholder
+  tokens rendered at pack time by .github/workflows/chocolatey.yml from
+  the published GitHub release (tag, windows-amd64 .zip URL, and its
+  SHA256 pulled from the release's SHA256SUMS asset). The file is not
+  pack-able with the tokens unsubstituted — the workflow always renders
+  them first.
+
+  This is a downloader package: tools/chocolateyInstall.ps1 fetches and
+  checksum-verifies the official release .zip at install time rather
+  than embedding the binary, mirroring the Homebrew cask. The .zip
+  carries BOTH jitenv.exe and jitenv-tui.exe, so chocolatey's auto-shim
+  puts the pair on PATH and `jitenv config` (which re-execs jitenv-tui)
+  works.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>jitenv</id>
+    <version>__VERSION__</version>
+    <title>jitenv</title>
+    <authors>Galvill</authors>
+    <owners>Galvill</owners>
+    <projectUrl>https://github.com/Galvill/jitenv</projectUrl>
+    <projectSourceUrl>https://github.com/Galvill/jitenv</projectSourceUrl>
+    <packageSourceUrl>https://github.com/Galvill/jitenv</packageSourceUrl>
+    <docsUrl>https://github.com/Galvill/jitenv/blob/main/README.md</docsUrl>
+    <bugTrackerUrl>https://github.com/Galvill/jitenv/issues</bugTrackerUrl>
+    <licenseUrl>https://github.com/Galvill/jitenv/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>© 2026 Gal Villaret</copyright>
+    <tags>secrets cli environment-variables shell-hook powershell foss cross-platform</tags>
+    <summary>Just-in-time environment variable loader, scoped to per-command process trees</summary>
+    <description>
+jitenv loads environment variables on demand from pluggable sources
+when configured executables are run, keeping secrets out of the parent
+shell. Linux, macOS, and Windows.
+
+After install, activate the PowerShell hook once:
+
+    jitenv hook install
+
+then open a new pwsh tab.
+
+**SmartScreen:** the first run of `jitenv.exe` may trigger SmartScreen
+because the binary is not yet Authenticode-signed (tracked upstream in
+issue #39). Right-click the executable, choose Properties, then
+Unblock — or run `Unblock-File` from PowerShell.
+    </description>
+    <releaseNotes>https://github.com/Galvill/jitenv/releases/tag/v__VERSION__</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/LICENSE.txt
+++ b/packaging/chocolatey/tools/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gal Villaret
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packaging/chocolatey/tools/VERIFICATION.txt
+++ b/packaging/chocolatey/tools/VERIFICATION.txt
@@ -1,0 +1,35 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and any
+user in verifying that this package's contents are authentic.
+
+This package does not embed the jitenv binaries. At install time
+tools\chocolateyInstall.ps1 downloads the official release archive
+directly from the upstream GitHub release and verifies its SHA256
+checksum before extracting:
+
+  Package version: __VERSION__
+  Archive:         __ZIPNAME__
+  Download URL:    __URL64__
+  SHA256:          __CHECKSUM64__
+
+The same checksum is published by the upstream release in its
+SHA256SUMS asset, which is signed with cosign (keyless, GitHub OIDC):
+
+  https://github.com/Galvill/jitenv/releases/download/v__VERSION__/SHA256SUMS
+  https://github.com/Galvill/jitenv/releases/download/v__VERSION__/SHA256SUMS.sig
+  https://github.com/Galvill/jitenv/releases/download/v__VERSION__/SHA256SUMS.pem
+
+To verify the archive yourself:
+
+  1. Download __ZIPNAME__ from
+     https://github.com/Galvill/jitenv/releases/tag/v__VERSION__
+  2. Compute its SHA256:
+       PS> Get-FileHash __ZIPNAME__ -Algorithm SHA256
+  3. Confirm it matches the SHA256 above and the SHA256SUMS asset.
+
+The archive is built reproducibly from source by
+.github/workflows/release.yml via GoReleaser. Source and license:
+
+  https://github.com/Galvill/jitenv
+  https://github.com/Galvill/jitenv/blob/main/LICENSE

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,30 @@
+$ErrorActionPreference = 'Stop'
+
+# Downloader install: pull the official windows-amd64 release .zip from
+# GitHub and verify its SHA256 before extracting. __URL64__ /
+# __CHECKSUM64__ are rendered at pack time by chocolatey.yml from the
+# published release + its SHA256SUMS asset. Extracting into $toolsDir
+# lets chocolatey's auto-shim put BOTH jitenv.exe and jitenv-tui.exe on
+# PATH (the latter is the re-exec target for `jitenv config`, #182).
+
+$packageName = 'jitenv'
+$toolsDir    = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+$packageArgs = @{
+  packageName    = $packageName
+  unzipLocation  = $toolsDir
+  url64bit       = '__URL64__'
+  checksum64     = '__CHECKSUM64__'
+  checksumType64 = 'sha256'
+}
+
+Install-ChocolateyZipPackage @packageArgs
+
+Write-Host ''
+Write-Host 'jitenv installed. Activate the PowerShell hook once:'
+Write-Host ''
+Write-Host '    jitenv hook install'
+Write-Host ''
+Write-Host 'Then open a new pwsh tab. The first run of jitenv.exe may trigger'
+Write-Host 'SmartScreen (the binary is not yet Authenticode-signed) - run'
+Write-Host 'Unblock-File, or right-click > Properties > Unblock, if prompted.'

--- a/packaging/chocolatey/tools/chocolateyUninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyUninstall.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+
+# Counterpart to chocolateyInstall.ps1: remove the shims chocolatey
+# created for the extracted executables. Uninstall-ChocolateyZipPackage
+# reads the extracted-files register that Install-ChocolateyZipPackage
+# wrote (keyed by the .zip's leaf name, rendered at pack time) and
+# tears down the shims + extracted files. __ZIPNAME__ is the same
+# windows-amd64 archive name used in chocolateyInstall.ps1.
+
+$packageName = 'jitenv'
+
+Uninstall-ChocolateyZipPackage -PackageName $packageName -ZipFileName '__ZIPNAME__'


### PR DESCRIPTION
Closes #180.

## Summary
Gives Windows users `choco install jitenv` / `choco upgrade jitenv` — the counterpart to the macOS Homebrew cask. Today Windows users have to download the release `.zip`, extract it, and put the binary on `%PATH%` by hand.

**Why not a goreleaser `chocolateys:` pipe?** goreleaser's chocolatey packer shells out to the Windows-only `choco` CLI, but `release.yml` runs on `ubuntu-latest` (confirmed locally: snapshot build fails with `exec: "choco": executable file not found`). So this uses a dedicated **windows-latest** workflow + a hand-authored package, leaving the proven Linux release pipeline (cosign, deb/rpm, cask) untouched.

## What's here
- **`.github/workflows/chocolatey.yml`** — fires on `release: published` (skips `-rc.N` pre-releases), resolves version + windows-amd64 `.zip` URL + its SHA256 from the release's `SHA256SUMS` asset (with retry, since goreleaser publishes non-draft while assets may still be uploading), renders package tokens, `choco pack`s, uploads the `.nupkg` artifact, and `choco push`es **only when `CHOCOLATEY_API_KEY` is set**. Also has `workflow_dispatch` for manual re-runs. Release-supplied values routed through `env:` for injection hygiene.
- **`packaging/chocolatey/`** — `jitenv.nuspec` + `tools/`. `chocolateyInstall.ps1` uses `Install-ChocolateyZipPackage` to download + SHA256-verify the official release `.zip` at install time (mirrors the cask downloading the macOS tarball) rather than embedding the binary. The `.zip` carries **both** `jitenv.exe` and `jitenv-tui.exe`, so chocolatey's auto-shim puts the pair on `%PATH%` and `jitenv config` (which re-execs `jitenv-tui`, #182) works. `VERIFICATION.txt` documents the upstream URL + checksum for moderators.
- **`.goreleaser.yaml`** — chocolateys block intentionally absent (comment points at the workflow); release header gains a `choco install jitenv` line.
- **`README.md`** — new "Chocolatey (Windows)" install subsection.

Decisions (per the issue's recommendations): **amd64 only** for now; **hook install stays manual**; SmartScreen/Unblock workaround documented until signing (#39) lands.

## ⚠️ One-time maintainer setup required before the first push
The package builds on every release, but **pushing to chocolatey.org needs a secret**:
1. Create an account at https://community.chocolatey.org/account/Register
2. Verify email, grab the API key from https://community.chocolatey.org/account
3. Add it as a repo secret named **`CHOCOLATEY_API_KEY`** (Settings → Secrets and variables → Actions)

Until then, each release packs the `.nupkg` and uploads it as a workflow artifact for inspection, but skips the push (a `::warning::` notes this). The first chocolatey.org submission goes through a moderation queue; subsequent updates fast-track.

## Test plan
- [x] `goreleaser check` passes (chocolateys block removed cleanly)
- [x] `actionlint` clean on the new workflow (and all workflows)
- [x] Token render dry-run: nuspec renders to **valid XML**, no leftover `__TOKEN__`s in any package file
- [x] Workflow YAML parses
- [ ] First real release after `CHOCOLATEY_API_KEY` is set: confirm the `.nupkg` lands on chocolatey.org (first push pends moderation)
- [ ] Manual: `choco install jitenv -s <local dir>` on a Windows host — `jitenv version` + `jitenv config` run; `choco uninstall jitenv` removes cleanly

## Out of scope (per issue)
winget, Scoop, custom NuGet feed, arm64 package, Authenticode signing (#39).