### PR TITLE
fix(agent/windows): authenticate pipe peer via impersonation, not PID (#132)

### DIFF
--- a/internal/agent/dial_windows.go
+++ b/internal/agent/dial_windows.go
@@ -8,15 +8,20 @@ import (
 	"time"
 
 	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
 )
 
 // dialAgent opens a client connection to the per-user agent over its
 // named pipe. The pipe name is whatever ResolvePaths() put in
 // Paths.Socket — on Windows that is \\.\pipe\jitenv-<sid>.
 //
-// winio.DialPipe respects ctx via a poll-loop internally but also
-// honours the timeout; we pass both so an explicit context deadline
-// short-circuits a long timeout.
+// We dial at PipeImpLevelImpersonation (SECURITY_SQOS_PRESENT |
+// SECURITY_IMPERSONATION) rather than via the plain winio.DialPipe,
+// which defaults to PipeImpLevelAnonymous. The agent authenticates the
+// peer by ImpersonateNamedPipeClient + reading the impersonation
+// token's SID (security #132, see peer_windows.go); under an anonymous
+// SQOS that token is unusable and OpenThreadToken fails, so the dial
+// level and the server's check are a matched pair.
 func dialAgent(ctx context.Context, path string, timeout time.Duration) (net.Conn, error) {
 	// Prefer the context deadline if one was set; otherwise fall back to
 	// the per-call timeout the Client was configured with.
@@ -26,5 +31,12 @@ func dialAgent(ctx context.Context, path string, timeout time.Duration) (net.Con
 			timeout = remaining
 		}
 	}
-	return winio.DialPipe(path, &timeout)
+	dctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return winio.DialPipeAccessImpLevel(
+		dctx,
+		path,
+		uint32(windows.GENERIC_READ|windows.GENERIC_WRITE),
+		winio.PipeImpLevelImpersonation,
+	)
 }

--- a/internal/agent/peer_windows.go
+++ b/internal/agent/peer_windows.go
@@ -5,8 +5,19 @@ package agent
 import (
 	"fmt"
 	"net"
+	"runtime"
 
 	"golang.org/x/sys/windows"
+)
+
+// advapi32!ImpersonateNamedPipeClient isn't exported by
+// golang.org/x/sys/windows or go-winio, so bind it directly. It's the
+// standard Win32 idiom for authenticating a named-pipe peer: it binds
+// the credential check to the pipe connection itself rather than to an
+// indirectly-resolved PID.
+var (
+	modadvapi32                    = windows.NewLazySystemDLL("advapi32.dll")
+	procImpersonateNamedPipeClient = modadvapi32.NewProc("ImpersonateNamedPipeClient")
 )
 
 // fdConn is satisfied by *winio.win32Pipe (the conn type produced by
@@ -20,30 +31,32 @@ type fdConn interface {
 // checkPeerUid enforces that the connecting named-pipe client runs as
 // the same user as the agent.
 //
-// History: an earlier revision tried to use ImpersonateNamedPipeClient
-// + OpenThreadToken (security #132) to bind the credential check to
-// the pipe handle itself rather than to a resolved PID. Production
-// pipe clients open via go-winio.DialPipe which does not set
-// SECURITY_SQOS_PRESENT, so the impersonation token came back at
-// "Anonymous" level — OpenThreadToken on an anonymous token fails
-// with "Cannot open an anonymous level security token", breaking
-// every legitimate same-user connection. Until go-winio exposes a
-// CreateFile path that lets us pass SECURITY_IMPERSONATION, the
-// PID-based check below is the working option. The pipe ACL on the
-// listener side (D:(A;;GA;;;<sid>) — see socket_windows.go) is the
-// primary perimeter; the SID comparison here is defence in depth.
+// It impersonates the client on the pipe and compares the impersonation
+// token's user SID against the agent's own (security #132). This binds
+// the check to the connection rather than resolving the client PID via
+// GetNamedPipeClientProcessId + OpenProcess, which had a PID-reuse
+// TOCTOU window (PID recycled between the two calls → wrong process
+// inspected).
 //
-// PID-reuse TOCTOU: between GetNamedPipeClientProcessId and
-// OpenProcess the client's PID could in principle be reused by an
-// unrelated process. In practice the SDDL ACL already restricts
-// connects to our SID, so any same-SID PID-reuse would have been
-// legitimately authorised anyway; an attacker-SID replacement
-// triggers a false reject, not a false accept.
+// Why this works now where an earlier attempt didn't: impersonation
+// only yields a usable (SecurityImpersonation-level) token if the
+// CLIENT opened the pipe with SECURITY_SQOS_PRESENT | impersonation
+// SQOS. go-winio's plain DialPipe dials at PipeImpLevelAnonymous, under
+// which OpenThreadToken fails with "Cannot open an anonymous level
+// security token" — which is exactly why the first cut was reverted to
+// the PID approach. dial_windows.go now dials via
+// DialPipeAccessImpLevel(..., PipeImpLevelImpersonation), so the token
+// comes back at the right level. The peer_windows_test.go same-user
+// test dials the same way and is the end-to-end regression guard.
+//
+// The pipe ACL on the listener side (D:(A;;GA;;;<sid>) — see
+// socket_windows.go) remains the primary perimeter; this SID
+// comparison is defence in depth.
 //
 // Note: this comparison is same-user, not same-session. A second
 // process running under the same user account is treated as
-// authorised, exactly as on Unix where multiple shells of the same
-// uid all pass SO_PEERCRED.
+// authorised, exactly as on Unix where multiple shells of the same uid
+// all pass SO_PEERCRED.
 func checkPeerUid(c net.Conn) error {
 	fc, ok := c.(fdConn)
 	if !ok {
@@ -51,43 +64,63 @@ func checkPeerUid(c net.Conn) error {
 	}
 	pipeHandle := windows.Handle(fc.Fd())
 
-	var clientPID uint32
-	if err := windows.GetNamedPipeClientProcessId(pipeHandle, &clientPID); err != nil {
-		return fmt.Errorf("get pipe client pid: %w", err)
-	}
+	// Impersonation is a per-OS-thread property. Without locking, Go
+	// could reschedule this goroutine onto a different thread between
+	// ImpersonateNamedPipeClient and OpenThreadToken/RevertToSelf —
+	// reading an un-impersonated context and, worse, leaving the
+	// impersonation token attached to a thread we then hand back to the
+	// runtime. Lock for the whole impersonate → read → revert sequence.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
-	// PROCESS_QUERY_LIMITED_INFORMATION (0x1000) is sufficient to call
-	// OpenProcessToken with TOKEN_QUERY, and unlike
-	// PROCESS_QUERY_INFORMATION it works across integrity levels for the
-	// same user.
-	const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-	procHandle, err := windows.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, clientPID)
+	clientSID, err := pipeClientSID(pipeHandle)
 	if err != nil {
-		return fmt.Errorf("open client process %d: %w", clientPID, err)
+		return err
 	}
-	defer windows.CloseHandle(procHandle)
 
-	var clientTok windows.Token
-	if err := windows.OpenProcessToken(procHandle, windows.TOKEN_QUERY, &clientTok); err != nil {
-		return fmt.Errorf("open client process token: %w", err)
-	}
-	defer clientTok.Close()
-
-	clientUser, err := clientTok.GetTokenUser()
-	if err != nil {
-		return fmt.Errorf("get client token user: %w", err)
-	}
-	clientSID := clientUser.User.Sid
-
-	ownTok := windows.GetCurrentProcessToken()
-	ownUser, err := ownTok.GetTokenUser()
+	ownUser, err := windows.GetCurrentProcessToken().GetTokenUser()
 	if err != nil {
 		return fmt.Errorf("get agent token user: %w", err)
 	}
-	ownSID := ownUser.User.Sid
+	if !windows.EqualSid(clientSID, ownUser.User.Sid) {
+		return fmt.Errorf("peer sid %s != %s", clientSID, ownUser.User.Sid)
+	}
+	return nil
+}
 
-	if !windows.EqualSid(clientSID, ownSID) {
-		return fmt.Errorf("peer sid %s != %s", clientSID, ownSID)
+// pipeClientSID impersonates the connected named-pipe client on the
+// current (caller-OS-locked) thread, reads the user SID off the
+// resulting impersonation token, then reverts. Must be called with the
+// goroutine pinned to its OS thread.
+func pipeClientSID(pipeHandle windows.Handle) (*windows.SID, error) {
+	if err := impersonateNamedPipeClient(pipeHandle); err != nil {
+		return nil, fmt.Errorf("impersonate pipe client: %w", err)
+	}
+	defer func() { _ = windows.RevertToSelf() }()
+
+	// openAsSelf=true: run the token-open access check against the
+	// agent's own process context, not the (possibly lower-integrity)
+	// client we're currently impersonating.
+	var tok windows.Token
+	if err := windows.OpenThreadToken(windows.CurrentThread(), windows.TOKEN_QUERY, true, &tok); err != nil {
+		return nil, fmt.Errorf("open impersonation thread token: %w", err)
+	}
+	defer tok.Close()
+
+	user, err := tok.GetTokenUser()
+	if err != nil {
+		return nil, fmt.Errorf("get client token user: %w", err)
+	}
+	// user.User.Sid points into a Go-managed buffer kept alive by the
+	// returned pointer, so it stays valid after tok.Close().
+	return user.User.Sid, nil
+}
+
+func impersonateNamedPipeClient(h windows.Handle) error {
+	r1, _, e1 := procImpersonateNamedPipeClient.Call(uintptr(h))
+	if r1 == 0 {
+		// e1 is the wrapped GetLastError; non-nil on the failure path.
+		return e1
 	}
 	return nil
 }

--- a/internal/agent/peer_windows_test.go
+++ b/internal/agent/peer_windows_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -17,14 +18,18 @@ import (
 // listener via listenSocket and connects to it from the same process.
 // checkPeerUid must accept the connection — both sides share the
 // current process's user SID. This exercises the
-// GetNamedPipeClientProcessId -> OpenProcess -> token-SID path against
-// a live OS-managed pipe.
+// ImpersonateNamedPipeClient -> OpenThreadToken -> token-SID path
+// against a live OS-managed pipe, and is the end-to-end guard for
+// security #132: the client must dial at PipeImpLevelImpersonation
+// (as dial_windows.go does) or the agent's impersonation token comes
+// back anonymous and OpenThreadToken fails.
 //
 // Cross-user rejection is the other half of the contract but is
 // impractical to test from a single-process unit test (it requires a
 // second user account and an impersonation token). The same-user path
-// is the regression-catcher: a broken handle extraction, a wrong
-// access mask on OpenProcess, or a missing EqualSid all fail here.
+// is the regression-catcher: a broken handle extraction, a missing
+// OS-thread lock, an anonymous-level dial, or a missing EqualSid all
+// fail here.
 func TestPeerCheckSameUserPipe(t *testing.T) {
 	sid, err := currentUserSID()
 	if err != nil {
@@ -57,8 +62,14 @@ func TestPeerCheckSameUserPipe(t *testing.T) {
 		acceptC <- c
 	}()
 
-	timeout := 5 * time.Second
-	client, err := winio.DialPipe(pipePath, &timeout)
+	dctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, err := winio.DialPipeAccessImpLevel(
+		dctx,
+		pipePath,
+		uint32(windows.GENERIC_READ|windows.GENERIC_WRITE),
+		winio.PipeImpLevelImpersonation,
+	)
 	if err != nil {
 		t.Fatalf("dial pipe: %v", err)
 	}


### PR DESCRIPTION
Closes #132.

## Summary
The Windows peer check resolved the client's SID via `GetNamedPipeClientProcessId` → `OpenProcess` → `OpenProcessToken`. The first two calls aren't atomic, so a client exiting + Windows recycling its PID in between meant inspecting the **wrong** process (PID-reuse TOCTOU). Impact was a false *reject* (the pipe SDDL already pins connects to our SID, so a false accept wasn't reachable), but the PID dance is non-standard for pipe auth.

This switches to the standard idiom — `ImpersonateNamedPipeClient` → `OpenThreadToken` → compare SID → `RevertToSelf` — binding the check to the connection itself.

## The subtlety (why the first attempt at #132 was reverted)
There's a comment in the old code explaining a prior cut of exactly this fix was reverted: impersonation only yields a usable token if the **client** opens the pipe with `SECURITY_SQOS_PRESENT | SECURITY_IMPERSONATION`. go-winio's `DialPipe` dials at `PipeImpLevelAnonymous`, under which the server's `OpenThreadToken` fails with *"Cannot open an anonymous level security token"*.

go-winio **v0.6.2 (already our dependency)** exposes `DialPipeAccessImpLevel` + `PipeImpLevelImpersonation`, so this lands as a matched client/server pair:

- **`dial_windows.go`** — dial via `DialPipeAccessImpLevel(..., PipeImpLevelImpersonation)`.
- **`peer_windows.go`** — impersonate + read the impersonation token's SID. `ImpersonateNamedPipeClient` isn't exported by `x/sys/windows` or go-winio, so it's bound directly off `advapi32`.

## Correctness details
- **`runtime.LockOSThread`** wraps the impersonate→read→revert sequence: impersonation is a per-OS-thread property, and Go can otherwise migrate the goroutine mid-sequence (reading an un-impersonated context, and leaking the impersonation token onto a thread handed back to the runtime).
- **`OpenThreadToken(openAsSelf=true)`** so the token-open access check runs as the agent, not the (possibly lower-integrity) client being impersonated.
- The listener SDDL (`D:(A;;GA;;;<sid>)`) remains the primary perimeter; this SID compare is defence in depth.

## Test plan
- [x] `GOOS=windows go build ./...`, `GOOS=windows go vet ./internal/agent/`, and `GOOS=windows go test -c` (test-binary compile) all pass locally
- [x] Linux `go build` / `go test ./internal/agent/` / `make fmt vet` unaffected
- [x] `TestPeerCheckSameUserPipe` updated to dial at impersonation level — it's now the **end-to-end guard**: same-user pipe, client dials `PipeImpLevelImpersonation`, server impersonates + reads SID. If the `test (windows)` CI job goes green, the dial-level/server-check pair is validated on a live OS-managed pipe.
- [x] `TestPeerCheckRejectsNonPipeConn` still covers the non-pipe-conn rejection path (returns before any impersonation)

No dependency bump (go-winio already v0.6.2). No changes outside `internal/agent` Windows files.