### PR TITLE
fix(chpwd): rehash shell command table when the cwd_glob wrapper set changes

### DIFF
--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -51,20 +51,29 @@ import (
 // Run is the chpwd entrypoint. Args are the verbatim positional args
 // after `jitenv __chpwd` — at least three: shell pid, oldpwd, newpwd.
 // oldpwd may be empty on the very first call from a shell.
-func Run(args []string) error {
+//
+// The bool return reports whether the per-shell wrapper set actually
+// changed (a wrapper was added or removed). The shell hook uses it to
+// decide whether to clear its command-hash table: bash/zsh cache
+// command→path lookups, so a freshly-added wrapper would be masked by a
+// stale hash, and a freshly-removed wrapper would leave a dead hash
+// entry that fails with "command not found". See the exit-code contract
+// in internal/cli/chpwd_internal.go and the `hash -r` / `rehash` call in
+// the bash/zsh snippets.
+func Run(args []string) (bool, error) {
 	if len(args) < 3 {
-		return errors.New("usage: jitenv __chpwd <shell-pid> <oldpwd> <newpwd>")
+		return false, errors.New("usage: jitenv __chpwd <shell-pid> <oldpwd> <newpwd>")
 	}
 	pid, err := strconv.Atoi(args[0])
 	if err != nil || pid <= 0 {
-		return fmt.Errorf("invalid shell pid %q", args[0])
+		return false, fmt.Errorf("invalid shell pid %q", args[0])
 	}
 	oldPwd := args[1]
 	newPwd := args[2]
 
 	paths, err := agent.DefaultPaths()
 	if err != nil {
-		return err
+		return false, err
 	}
 	wrapDir := paths.ShellWrapDir(pid)
 	mtimePath := lastMtimePath(paths, pid)
@@ -105,7 +114,7 @@ func Run(args []string) error {
 	// the shell starts inside an already-mapped cwd_glob dir).
 	if cfgErr == nil && oldPwd == newPwd && lastMtime != 0 && curMtime == lastMtime {
 		debugLog("short-circuit: pwd+mtime unchanged")
-		return nil
+		return false, nil
 	}
 
 	wanted, err := desiredCommandsFor(cfgPath, cfgErr, newPwd)
@@ -114,19 +123,20 @@ func Run(args []string) error {
 		// Config missing or malformed: leave the wrapper dir alone
 		// so a momentary parse error doesn't tear down a working
 		// state. Returning nil keeps the shell hook quiet.
-		return nil
+		return false, nil
 	}
 	debugLog("config reports wanted=%v", wanted)
-	if err := reconcile(wrapDir, wanted); err != nil {
+	changed, err := reconcile(wrapDir, wanted)
+	if err != nil {
 		debugLog("reconcile error: %v", err)
-		return err
+		return false, err
 	}
 	if err := writeLastMtime(mtimePath, curMtime); err != nil {
 		debugLog("writeLastMtime error: %v", err)
 		// Non-fatal: next call will just see a stale state and reconcile again.
 	}
-	debugLog("reconcile ok (%d wrappers)", len(wanted))
-	return nil
+	debugLog("reconcile ok (%d wrappers, changed=%t)", len(wanted), changed)
+	return changed, nil
 }
 
 // lastMtimePath is the per-shell sidecar that records the config-file
@@ -198,30 +208,36 @@ func desiredCommandsFor(cfgPath string, cfgErr error, pwd string) ([]string, err
 //
 // The shape of a "wrapper" is platform-split (symlink on Unix,
 // `.ps1` file on Windows). See reconcile_unix.go / reconcile_windows.go.
-func reconcile(wrapDir string, wanted []string) error {
+// reconcile returns whether it changed the wrapper set (removed or
+// created any entry). A no-op call (dir already matches `wanted`)
+// returns false so the shell hook can skip clearing its command hash.
+func reconcile(wrapDir string, wanted []string) (bool, error) {
 	if len(wanted) == 0 {
 		// No mapping → empty the dir if it exists. We don't remove
 		// the dir itself; the shell hook keeps it in $PATH.
 		entries, err := os.ReadDir(wrapDir)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return nil
+				return false, nil
 			}
-			return err
+			return false, err
 		}
+		changed := false
 		for _, e := range entries {
-			_ = os.Remove(filepath.Join(wrapDir, e.Name()))
+			if err := os.Remove(filepath.Join(wrapDir, e.Name())); err == nil {
+				changed = true
+			}
 		}
-		return nil
+		return changed, nil
 	}
 
 	if err := os.MkdirAll(wrapDir, 0o700); err != nil {
-		return err
+		return false, err
 	}
 
 	target, err := os.Executable()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Build the desired set keyed by on-disk filename (e.g. "npm" on
@@ -232,17 +248,21 @@ func reconcile(wrapDir string, wanted []string) error {
 		want[wrapperFileName(c)] = c
 	}
 
+	changed := false
+
 	// Drop unwanted wrappers.
 	entries, err := os.ReadDir(wrapDir)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 	for _, e := range entries {
 		name := e.Name()
 		if _, ok := want[name]; ok {
 			continue
 		}
-		_ = os.Remove(filepath.Join(wrapDir, name))
+		if err := os.Remove(filepath.Join(wrapDir, name)); err == nil {
+			changed = true
+		}
 	}
 
 	// Add missing ones. isOurs decides whether an existing entry is
@@ -255,10 +275,11 @@ func reconcile(wrapDir string, wanted []string) error {
 			continue
 		}
 		if err := createWrapper(wrapPath, c, target); err != nil {
-			return err
+			return changed, err
 		}
+		changed = true
 	}
-	return nil
+	return changed, nil
 }
 
 // debugLog writes one line to stderr when JITENV_HOOK_DEBUG is set.

--- a/internal/chpwd/chpwd_test.go
+++ b/internal/chpwd/chpwd_test.go
@@ -55,11 +55,11 @@ func TestRunShortCircuitsOnNoChange(t *testing.T) {
 	wrapDir := paths.ShellWrapDir(pid)
 
 	// First call from outside projectDir: nothing wanted, dir stays empty.
-	if err := Run([]string{strconv.Itoa(pid), "", tmp}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), "", tmp}); err != nil {
 		t.Fatalf("first Run: %v", err)
 	}
 	// Second call entering projectDir: firstcmd symlink appears.
-	if err := Run([]string{strconv.Itoa(pid), tmp, projectDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), tmp, projectDir}); err != nil {
 		t.Fatalf("second Run: %v", err)
 	}
 	if _, err := os.Lstat(filepath.Join(wrapDir, "firstcmd")); err != nil {
@@ -71,7 +71,7 @@ func TestRunShortCircuitsOnNoChange(t *testing.T) {
 	if err := os.Remove(filepath.Join(wrapDir, "firstcmd")); err != nil {
 		t.Fatalf("remove symlink: %v", err)
 	}
-	if err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
 		t.Fatalf("third Run: %v", err)
 	}
 	if _, err := os.Lstat(filepath.Join(wrapDir, "firstcmd")); err == nil {
@@ -83,7 +83,7 @@ func TestRunShortCircuitsOnNoChange(t *testing.T) {
 	if err := os.Chtimes(cfgPath, future, future); err != nil {
 		t.Fatal(err)
 	}
-	if err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
 		t.Fatalf("fourth Run: %v", err)
 	}
 	if _, err := os.Lstat(filepath.Join(wrapDir, "firstcmd")); err != nil {
@@ -149,7 +149,7 @@ func TestRunUnlinksInjectionMarker(t *testing.T) {
 
 	// Same pwd both sides — exercises the cleanup BEFORE the
 	// short-circuit. The marker must be gone afterwards regardless.
-	if err := Run([]string{strconv.Itoa(pid), tmp, tmp}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), tmp, tmp}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {

--- a/internal/chpwd/chpwd_windows_test.go
+++ b/internal/chpwd/chpwd_windows_test.go
@@ -61,7 +61,7 @@ func TestReconcileCreatesPs1Wrappers(t *testing.T) {
 	paths, _ := agent.DefaultPaths()
 	wrapDir := paths.ShellWrapDir(pid)
 
-	if err := Run([]string{strconv.Itoa(pid), "", projectDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), "", projectDir}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -115,7 +115,7 @@ func TestReconcileIsNoopOnRepeat(t *testing.T) {
 	paths, _ := agent.DefaultPaths()
 	wrapDir := paths.ShellWrapDir(pid)
 
-	if err := Run([]string{strconv.Itoa(pid), "", projectDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), "", projectDir}); err != nil {
 		t.Fatalf("first Run: %v", err)
 	}
 	wrap := filepath.Join(wrapDir, "npm.ps1")
@@ -136,7 +136,7 @@ func TestReconcileIsNoopOnRepeat(t *testing.T) {
 	if err := os.Chtimes(cfgPath, future, future); err != nil {
 		t.Fatal(err)
 	}
-	if err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), projectDir, projectDir}); err != nil {
 		t.Fatalf("second Run: %v", err)
 	}
 	st2, err := os.Stat(wrap)
@@ -180,7 +180,7 @@ func TestReconcileRemovesUnmappedWrapper(t *testing.T) {
 	wrapDir := paths.ShellWrapDir(pid)
 
 	// First call inside the mapped dir: npm.ps1 is created.
-	if err := Run([]string{strconv.Itoa(pid), "", projectDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), "", projectDir}); err != nil {
 		t.Fatalf("first Run: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(wrapDir, "npm.ps1")); err != nil {
@@ -193,7 +193,7 @@ func TestReconcileRemovesUnmappedWrapper(t *testing.T) {
 	if err := os.Chtimes(cfgPath, future, future); err != nil {
 		t.Fatal(err)
 	}
-	if err := Run([]string{strconv.Itoa(pid), projectDir, otherDir}); err != nil {
+	if _, err := Run([]string{strconv.Itoa(pid), projectDir, otherDir}); err != nil {
 		t.Fatalf("second Run: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(wrapDir, "npm.ps1")); err == nil {

--- a/internal/cli/chpwd_internal.go
+++ b/internal/cli/chpwd_internal.go
@@ -1,22 +1,46 @@
 package cli
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/gv/jitenv/internal/chpwd"
 )
 
+// exitWrapperSetChanged is the load-bearing exit code __chpwd returns
+// when it added or removed a per-shell wrapper. The bash/zsh hooks
+// switch on it to clear their command-hash table (`hash -r` / `rehash`)
+// so a freshly-added wrapper is actually used and a freshly-removed one
+// doesn't leave a dead hash entry. Any other exit code means "no wrapper
+// change" (0) or a genuine error (non-zero, non-10), and the hooks leave
+// the hash table alone.
+const exitWrapperSetChanged = 10
+
 // newChpwdInternalCmd is the entrypoint shells call from their chpwd /
 // PROMPT_COMMAND hook. Hidden because end-users never run it directly.
 //
 //	jitenv __chpwd <shell-pid> <oldpwd> <newpwd>
+//
+// Exit codes:
+//
+//	0   reconcile ran (or short-circuited); wrapper set unchanged
+//	10  wrapper set changed — shell should clear its command hash
+//	*   error (printed by cobra)
 func newChpwdInternalCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:    "__chpwd <shell-pid> <oldpwd> <newpwd>",
 		Hidden: true,
 		Args:   cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return chpwd.Run(args)
+			changed, err := chpwd.Run(args)
+			if err != nil {
+				return err
+			}
+			if changed {
+				os.Exit(exitWrapperSetChanged)
+			}
+			return nil
 		},
 	}
 }

--- a/internal/shell/cwd_path_change_e2e_test.go
+++ b/internal/shell/cwd_path_change_e2e_test.go
@@ -1,0 +1,439 @@
+//go:build !windows
+
+package shell_test
+
+// End-to-end characterization of what happens when a mapping's target is
+// changed while a shell is already live — the "issues after modifying
+// the path of a cwd mapping" report. Investigation surfaced THREE
+// independent staleness layers for cwd_glob mappings, none of which
+// affect path mappings:
+//
+//  1. Wrapper reconcile timing. __chpwd only rebuilds the per-shell
+//     wrapper symlinks on a prompt fire (PROMPT_COMMAND) or a cd. An
+//     external edit at an idle prompt is not seen until the next prompt.
+//     (TestCwdGlob_ExternalEditStaleUntilReconcile)
+//
+//  2. Agent config staleness. The shim fetches env values from the
+//     agent's IN-MEMORY config, which only reloads on an explicit
+//     reload op (TUI save / clone / lock-unlock) — never on a hand-edit
+//     of config.toml. A stale agent + a stale wrapper can inject in a
+//     directory that is no longer mapped on disk. Modelled by pointing
+//     the daemon at its own --config (agent's view) separate from the
+//     shell's JITENV_CONFIG (disk view).
+//
+//  3. Bash/zsh command hashing. bash/zsh cache command→path lookups, so
+//     a command hashed to its real path before a wrapper appeared used
+//     to keep bypassing the wrapper (silent no-inject), and a command
+//     hashed to a wrapper later removed failed with "No such file or
+//     directory" (exit 127). Fixed: `jitenv __chpwd` now returns exit 10
+//     when it adds or removes a wrapper, and the bash/zsh hooks clear
+//     their command hash (`hash -r` / `rehash`) on that signal.
+//     (TestCwdGlob_AddedWrapperTakesEffectAfterReconcile,
+//      TestCwdGlob_RemovedWrapperRecoversAfterReconcile)
+//
+// Path mappings have none of these: routing is decided by `jitenv
+// is-mapped`, which reads the config from disk on every command.
+// (TestPathMapping_ChangeTakesEffectImmediately)
+//
+// PROMPT_COMMAND does not fire under `bash -c`, so each script calls
+// __jitenv_chpwd by hand exactly where a real interactive prompt would
+// fire. `hash -r` is used in the timing tests to factor out layer (3)
+// so the reconcile behavior can be observed in isolation.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+)
+
+type cpcFixture struct {
+	t            *testing.T
+	bin          string
+	binDir       string
+	dir          string
+	projA        string
+	projB        string
+	fakeBin      string
+	runtimeDir   string
+	agentCfgPath string
+	shellCfgPath string
+}
+
+func newCPCFixture(t *testing.T) *cpcFixture {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	f := &cpcFixture{
+		t:            t,
+		bin:          bin,
+		binDir:       filepath.Dir(bin),
+		dir:          dir,
+		projA:        filepath.Join(dir, "projA"),
+		projB:        filepath.Join(dir, "projB"),
+		fakeBin:      filepath.Join(dir, "bin"),
+		runtimeDir:   filepath.Join(dir, "runtime"),
+		agentCfgPath: filepath.Join(dir, "agent.toml"),
+		shellCfgPath: filepath.Join(dir, "shell.toml"),
+	}
+	for _, d := range []string{f.projA, f.projB, f.fakeBin, f.runtimeDir} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(f.fakeBin, "fakecmd"),
+		[]byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"${FOO:-MISSING}\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func cpcConfig(mappings []config.Mapping) *config.Config {
+	return &config.Config{
+		Sources: map[string]config.SourceConfig{
+			"n": {Type: "noop", Params: map[string]any{"my-secret": "from-cwd"}},
+		},
+		Mappings: mappings,
+	}
+}
+
+// writeConfig InitNew's a fresh encrypted file (valid Meta + salt) then
+// rewrites it with plaintext-params content, matching the existing e2e
+// tests. Returns the master key for that file (only the agent's key is
+// ever used). Bumps mtime forward 2s so a same-second rewrite is still
+// seen by __chpwd's mtime check.
+func (f *cpcFixture) writeConfig(path string, cfg *config.Config) []byte {
+	f.t.Helper()
+	pw := []byte("hunter2-pathchange")
+	if err := config.InitNew(path, pw); err != nil {
+		f.t.Fatalf("init %s: %v", path, err)
+	}
+	loaded, err := config.Load(path)
+	if err != nil {
+		f.t.Fatalf("load %s: %v", path, err)
+	}
+	key, err := config.DeriveKeyFromMeta(loaded, pw)
+	if err != nil {
+		f.t.Fatalf("derive key %s: %v", path, err)
+	}
+	loaded.Sources = cfg.Sources
+	loaded.Mappings = cfg.Mappings
+	tmp, err := os.CreateTemp(f.dir, "cfg-*.toml")
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if err := toml.NewEncoder(tmp).Encode(loaded); err != nil {
+		f.t.Fatalf("encode %s: %v", path, err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		f.t.Fatalf("rename %s: %v", path, err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	_ = os.Chtimes(path, future, future)
+	return key
+}
+
+func (f *cpcFixture) startAgent(key []byte) func() {
+	f.t.Helper()
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	daemon := exec.Command(f.bin, "__agent", "--key-fd=3", "--config="+f.agentCfgPath, "--idle=20s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+f.runtimeDir)
+	if err := daemon.Start(); err != nil {
+		f.t.Fatalf("daemon start: %v", err)
+	}
+	pr.Close()
+	if _, err := pw.Write(key); err != nil {
+		f.t.Fatalf("write key: %v", err)
+	}
+	pw.Close()
+
+	f.t.Setenv("XDG_RUNTIME_DIR", f.runtimeDir)
+	paths, _ := agent.DefaultPaths()
+	cli := agent.NewClient(paths.Socket)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return func() { _ = daemon.Process.Kill() }
+}
+
+// runBash runs script with the hook sourced; fails the test on a
+// non-zero exit. JITENV_CONFIG points at shellCfg.
+func (f *cpcFixture) runBash(script string) string {
+	f.t.Helper()
+	out, code := f.runBashAllowErr(script)
+	if code != 0 {
+		f.t.Fatalf("bash exited %d\noutput=%s", code, out)
+	}
+	return out
+}
+
+// runBashAllowErr is runBash but returns the exit code instead of
+// failing — used where a stale command hash is expected to make a
+// command fail (exit 127).
+func (f *cpcFixture) runBashAllowErr(script string) (string, int) {
+	f.t.Helper()
+	full := fmt.Sprintf(
+		`PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook bash)"
+%s`, f.binDir, f.fakeBin, f.shellCfgPath, f.binDir, script)
+	cmd := exec.Command("bash", "-c", full)
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+f.runtimeDir,
+		"JITENV_HOOK_DELAY=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(out), 0
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return string(out), ee.ExitCode()
+	}
+	f.t.Fatalf("bash run failed to start: %v\noutput=%s", err, out)
+	return "", -1
+}
+
+func cwdGlobMapping(dir string) []config.Mapping {
+	return []config.Mapping{{
+		CwdGlob:  dir,
+		Commands: []string{"fakecmd"},
+		Vars:     []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+	}}
+}
+
+// TestPathMapping_ChangeTakesEffectImmediately is the correct-behavior
+// baseline: removing a PATH mapping takes effect on the very next
+// command, with no prompt fire, no cd, and no dependence on the agent
+// reloading — because `jitenv is-mapped` reads the config file fresh on
+// every command. Contrast with all the cwd_glob cases below.
+func TestPathMapping_ChangeTakesEffectImmediately(t *testing.T) {
+	f := newCPCFixture(t)
+
+	scriptPath := filepath.Join(f.dir, "script.sh")
+	if err := os.WriteFile(scriptPath,
+		[]byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"${FOO:-MISSING}\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mapped := cpcConfig([]config.Mapping{{
+		Path: scriptPath,
+		Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+	}})
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	f.writeConfig(f.shellCfgPath, mapped)
+	edited := filepath.Join(f.dir, "shell-after.toml")
+	f.writeConfig(edited, cpcConfig(nil))
+
+	out := f.runBash(fmt.Sprintf(`
+echo '--- mapped ---'
+%q
+echo '--- unmapped ---'
+cp %q %q
+touch -d "+5 seconds" %q
+%q
+`, scriptPath, edited, f.shellCfgPath, f.shellCfgPath, scriptPath))
+	t.Logf("output:\n%s", out)
+
+	if mapped := sectionBetween(out, "--- mapped ---", "--- unmapped ---"); !strings.Contains(mapped, "FOO=from-cwd") {
+		t.Errorf("mapped: expected FOO=from-cwd; got:\n%s", mapped)
+	}
+	if unmapped := sectionBetween(out, "--- unmapped ---", ""); !strings.Contains(unmapped, "FOO=MISSING") {
+		t.Errorf("after removing mapping: expected FOO=MISSING on the next command (no prompt fire); got:\n%s", unmapped)
+	}
+}
+
+// TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent shows the
+// correct behavior of the two non-stale facets: the wrapper reconcile
+// reads only the config file (so it works with no agent), and the
+// injection fails closed when the agent is down (warn + parent env).
+func TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(cwdGlobMapping(f.projA))
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+
+	// Agent DOWN: wrapper still builds; shim hits the agent-down path.
+	locked := f.runBash(fmt.Sprintf(`
+cd %q
+__jitenv_chpwd
+echo '--- locked ---'
+ls "$__JITENV_WRAP_DIR"
+fakecmd
+`, f.projA))
+	t.Logf("locked:\n%s", locked)
+	lk := sectionBetween(locked, "--- locked ---", "")
+	if !strings.Contains(lk, "fakecmd") {
+		t.Errorf("locked: expected the fakecmd wrapper to be built without an agent; got:\n%s", lk)
+	}
+	if !strings.Contains(lk, "agent is not loaded") {
+		t.Errorf("locked: expected the agent-down warning; got:\n%s", lk)
+	}
+	if !strings.Contains(lk, "FOO=MISSING") {
+		t.Errorf("locked: expected command to run with parent env; got:\n%s", lk)
+	}
+
+	// Agent UP: injection succeeds.
+	defer f.startAgent(key)()
+	unlocked := f.runBash(fmt.Sprintf(`
+cd %q
+__jitenv_chpwd
+echo '--- unlocked ---'
+fakecmd
+`, f.projA))
+	t.Logf("unlocked:\n%s", unlocked)
+	if u := sectionBetween(unlocked, "--- unlocked ---", ""); !strings.Contains(u, "FOO=from-cwd") {
+		t.Errorf("unlocked: expected FOO=from-cwd; got:\n%s", u)
+	}
+}
+
+// TestCwdGlob_AddedWrapperTakesEffectAfterReconcile is the regression
+// test for the ADD case of the command-hash fix. A command run before
+// its wrapper exists (the realistic `cd mappeddir && cmd` trigger) gets
+// hashed to its real path. Before the fix, __chpwd building the wrapper
+// did not help — bash kept using the stale hash and the command was
+// silently not intercepted. Now __chpwd returns exit 10 on a wrapper
+// change and the hook clears the command hash, so the very next command
+// is intercepted with NO manual `hash -r`.
+func TestCwdGlob_AddedWrapperTakesEffectAfterReconcile(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(cwdGlobMapping(f.projA))
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	out := f.runBash(fmt.Sprintf(`
+cd %q
+echo '--- before-reconcile ---'
+fakecmd                    # run BEFORE the wrapper exists → bash hashes bin/fakecmd
+echo '--- after-reconcile ---'
+__jitenv_chpwd             # builds $WRAP_DIR/fakecmd AND clears the hash (exit 10)
+fakecmd                    # wrapper used → inject, no manual hash -r
+`, f.projA))
+	t.Logf("output:\n%s", out)
+
+	before := sectionBetween(out, "--- before-reconcile ---", "--- after-reconcile ---")
+	after := sectionBetween(out, "--- after-reconcile ---", "")
+	if !strings.Contains(before, "FOO=MISSING") {
+		t.Errorf("before reconcile: expected FOO=MISSING (no wrapper yet); got:\n%s", before)
+	}
+	// The fix: reconcile cleared the stale hash, so the wrapper is used.
+	if !strings.Contains(after, "FOO=from-cwd") {
+		t.Errorf("after reconcile: expected FOO=from-cwd without a manual hash -r; got:\n%s", after)
+	}
+}
+
+// TestCwdGlob_RemovedWrapperRecoversAfterReconcile is the regression
+// test for the REMOVE case, which before the fix was worse than the add
+// case: a command hashed to a wrapper that __chpwd later removed failed
+// outright with "No such file or directory" (exit 127), because bash's
+// default checkhash is off so it execs the stale hashed path blindly.
+// Now __chpwd's wrapper-removal returns exit 10 and the hook clears the
+// hash, so the command runs cleanly (unwrapped) on the next invocation.
+func TestCwdGlob_RemovedWrapperRecoversAfterReconcile(t *testing.T) {
+	f := newCPCFixture(t)
+	mappedA := cpcConfig(cwdGlobMapping(f.projA))
+	f.writeConfig(f.shellCfgPath, mappedA)
+	key := f.writeConfig(f.agentCfgPath, mappedA)
+	defer f.startAgent(key)()
+
+	// Edit that removes projA's mapping (moves it to projB).
+	edited := filepath.Join(f.dir, "shell-after.toml")
+	f.writeConfig(edited, cpcConfig(cwdGlobMapping(f.projB)))
+
+	out, code := f.runBashAllowErr(fmt.Sprintf(`
+cd %q
+__jitenv_chpwd             # wrapper built; next line hashes $WRAP_DIR/fakecmd
+fakecmd
+echo '--- mapping-removed ---'
+cp %q %q                   # disk no longer maps projA
+touch -d "+5 seconds" %q
+__jitenv_chpwd             # removes $WRAP_DIR/fakecmd AND clears the hash (exit 10)
+fakecmd                    # hash cleared → runs unwrapped, no "not found"
+`, f.projA, edited, f.shellCfgPath, f.shellCfgPath))
+	t.Logf("output (exit %d):\n%s", code, out)
+
+	if code != 0 {
+		t.Errorf("expected a clean exit after the wrapper was removed; got exit %d:\n%s", code, out)
+	}
+	removed := sectionBetween(out, "--- mapping-removed ---", "")
+	if strings.Contains(removed, "No such file or directory") {
+		t.Errorf("mapping removed: command hit a stale hash entry; got:\n%s", removed)
+	}
+	// The fix: the command runs unwrapped (FOO=MISSING) rather than 127.
+	if !strings.Contains(removed, "FOO=MISSING") {
+		t.Errorf("mapping removed: expected the command to run unwrapped (FOO=MISSING); got:\n%s", removed)
+	}
+}
+
+// TestCwdGlob_ExternalEditStaleUntilReconcile isolates root cause (1):
+// the wrapper reconcile timing. With the bash hash factored out (hash -r
+// before each probe), an external edit that newly maps the current dir
+// is NOT picked up until __chpwd fires — modelling an edit made from
+// another terminal while this shell sits at an idle prompt. The agent
+// already knows the mapping (models a TUI edit that pinged reload), so
+// the only stale layer here is the wrapper dir.
+func TestCwdGlob_ExternalEditStaleUntilReconcile(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(cwdGlobMapping(f.projA))
+	key := f.writeConfig(f.agentCfgPath, mapped) // agent knows projA
+	defer f.startAgent(key)()
+
+	f.writeConfig(f.shellCfgPath, cpcConfig(nil)) // disk: projA unmapped
+	edited := filepath.Join(f.dir, "shell-after.toml")
+	f.writeConfig(edited, mapped) // the pending edit: projA mapped
+
+	out := f.runBash(fmt.Sprintf(`
+cd %q
+__jitenv_chpwd             # prompt fire #1: disk says unmapped → no wrapper
+echo '--- before-edit ---'
+fakecmd
+cp %q %q                   # external edit: disk now maps projA
+touch -d "+5 seconds" %q
+echo '--- edited-no-prompt ---'
+fakecmd                    # no prompt fired → wrapper still absent
+__jitenv_chpwd             # prompt fire #2: reconciles the wrapper (+ rehash)
+echo '--- after-prompt ---'
+fakecmd
+`, f.projA, edited, f.shellCfgPath, f.shellCfgPath))
+	t.Logf("output:\n%s", out)
+
+	before := sectionBetween(out, "--- before-edit ---", "--- edited-no-prompt ---")
+	noPrompt := sectionBetween(out, "--- edited-no-prompt ---", "--- after-prompt ---")
+	afterPrompt := sectionBetween(out, "--- after-prompt ---", "")
+	if !strings.Contains(before, "FOO=MISSING") {
+		t.Errorf("before edit: expected FOO=MISSING; got:\n%s", before)
+	}
+	// The reconcile-timing gap: disk maps projA, hash is clear, but no
+	// prompt fired since the edit → wrapper absent → no inject.
+	if !strings.Contains(noPrompt, "FOO=MISSING") {
+		t.Errorf("edited, no prompt fire: expected FOO=MISSING (wrapper not reconciled yet); got:\n%s", noPrompt)
+	}
+	if !strings.Contains(afterPrompt, "FOO=from-cwd") {
+		t.Errorf("after prompt fire: expected FOO=from-cwd; got:\n%s", afterPrompt)
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -68,6 +68,17 @@ __jitenv_chpwd() {
     # hide debug diagnostics + a "jitenv: command not found"
     # if the binary ever falls off $PATH mid-session.
     jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
+    # Exit 10 means a wrapper was added or removed. Clear bash's
+    # command-hash table so the change takes effect immediately: bash
+    # caches command→path lookups, so a wrapper added for a command that
+    # was already run keeps resolving to the original binary (secrets
+    # silently not injected), and a wrapper just removed leaves a dead
+    # hash entry that fails with "No such file or directory" (checkhash
+    # is off by default). `hash -r` is cheap — the next lookup re-scans
+    # $PATH. Capture $? first; the trailing assignment resets it to 0 so
+    # we don't leak a non-zero status into the user's prompt.
+    local rc=$?
+    [[ $rc -eq 10 ]] && hash -r 2>/dev/null
     __JITENV_LAST_PWD="$PWD"
 }
 # Run once at hook-load time so the wrapper dir is populated before

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -57,6 +57,14 @@ __jitenv_cfg_path() {
 __jitenv_chpwd() {
     # No 2>/dev/null on purpose; see bash.sh for the rationale.
     jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
+    # Exit 10 means a wrapper was added or removed → rebuild zsh's
+    # command hash table so the change takes effect immediately. Without
+    # it, a wrapper added for an already-run command stays masked by the
+    # cached path, and a just-removed wrapper leaves a dead hash entry.
+    # See bash.sh for the full rationale. Capture $? first; the trailing
+    # assignment resets it so we don't leak a non-zero status.
+    local rc=$?
+    [[ $rc -eq 10 ]] && rehash
     __JITENV_LAST_PWD="$PWD"
 }
 typeset -ga precmd_functions


### PR DESCRIPTION
## Summary

Editing a `cwd_glob` mapping's target while a shell was already live could silently fail to take effect — the reported "issues after modifying the path of a cwd mapping." Investigation (a new e2e matrix) surfaced **three** independent staleness layers; this PR fixes the dominant one: **bash/zsh command hashing**.

bash/zsh cache command→path lookups, so:

- A wrapper **added** for a command already run in the session stayed masked by the stale hash — the command resolved to the original binary and **secrets were never injected**.
- A wrapper **removed** by `__chpwd` left a dead hash entry, so the command failed with **"No such file or directory" (exit 127)** — bash's `checkhash` is off by default, so it execs the stale hashed path blindly.

Neither was fixed by `cd` out/in — only `hash -r` / a new shell.

## Fix

- `internal/chpwd/chpwd.go` — `reconcile` and `Run` now report whether the wrapper set actually changed (an entry was added or removed). A no-op reconcile (dir already matches) reports `false`.
- `internal/cli/chpwd_internal.go` — `jitenv __chpwd` exits **10** when the wrapper set changed, `0` otherwise. This is a documented, load-bearing exit code in the same spirit as the `is-mapped` contract.
- `internal/shell/snippets/{bash,zsh}.sh` — `__jitenv_chpwd` clears the shell command hash (`hash -r` / `rehash`) on exit 10. `$?` is captured first and the trailing `__JITENV_LAST_PWD` assignment resets it to 0, so the user's prompt status is not affected (same end-state as before).

The hash is only cleared when something actually changed, so the common per-prompt fire (no change → exit 0) leaves the hash table alone.

## Tests

New `internal/shell/cwd_path_change_e2e_test.go` — a real-binary + bash + agent-daemon e2e matrix that models the two config-staleness layers independently by pointing the daemon at its own `--config` (the agent's in-memory view) and the shell at a separate `JITENV_CONFIG` (the on-disk view):

- `TestCwdGlob_AddedWrapperTakesEffectAfterReconcile` — add case (regression for this fix).
- `TestCwdGlob_RemovedWrapperRecoversAfterReconcile` — remove case; asserts a clean exit instead of 127.
- `TestCwdGlob_ExternalEditStaleUntilReconcile` — the prompt-fire timing window (see follow-up issue).
- `TestPathMapping_ChangeTakesEffectImmediately` — correct-behavior baseline: path mappings have no staleness window (routing reads disk fresh via `is-mapped`).
- `TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent` — wrapper reconcile is config-only (works locked); injection fails closed when the agent is down.

## Test plan

- [x] `go test ./internal/chpwd/ ./internal/cli/ ./internal/shell/` — pass (full shell e2e suite incl. existing wrapper/hook tests).
- [x] `go build ./...`, `go vet`, `gofmt -l` — clean.
- [x] **Negative check**: with the `hash -r` line neutered, `TestCwdGlob_AddedWrapperTakesEffectAfterReconcile` **fails**; restored, it passes — confirming the test exercises the fix.

## Follow-ups (not in this PR)

The other two staleness layers the investigation surfaced are tracked separately — they're design decisions, not part of this fix:

- Agent in-memory config is never reloaded on a hand-edit of `config.toml` (no `jitenv reload` / no file-watch).
- The `__chpwd` reconcile timing window (an external edit at an idle prompt isn't seen until the next prompt fire).