### PR TITLE
fix(agent): auto-reload config when it changes on disk (#202)

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -167,6 +167,67 @@ func TestAgentReload(t *testing.T) {
 	}
 }
 
+// TestAgentAutoReloadsOnConfigMtimeChange covers #202: once SetConfigPath
+// is set, a data op picks up an out-of-band edit to the config (mtime
+// advanced) without an explicit reload op. The reload is mtime-gated, so
+// it fires exactly once per change — not on every fetch.
+func TestAgentAutoReloadsOnConfigMtimeChange(t *testing.T) {
+	first := &fakeResolver{env: map[string]map[string]string{"/a": {"K": "v1"}}}
+	second := &fakeResolver{env: map[string]map[string]string{"/a": {"K": "v2"}}}
+
+	cfgFile := filepath.Join(newTestAgentDir(t), "config.toml")
+	if err := os.WriteFile(cfgFile, []byte("# v1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var reloadCalls int
+	a, p := newTestAgent(t, first)
+	a.SetReload(func() (Resolver, error) {
+		reloadCalls++
+		return second, nil
+	})
+	a.SetConfigPath(cfgFile)
+
+	go a.Serve(context.Background()) //nolint:errcheck // goroutine: error surfaced via Shutdown/Listen pair
+	cli := NewClient(p.Socket)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// No edit yet → first resolver, no reload.
+	if env, _ := cli.FetchEnv(context.Background(), "/a"); env["K"] != "v1" {
+		t.Fatalf("pre-edit K=%q (want v1)", env["K"])
+	}
+	if reloadCalls != 0 {
+		t.Fatalf("pre-edit reloadCalls=%d (want 0)", reloadCalls)
+	}
+
+	// Edit the file and bump its mtime past the recorded baseline.
+	if err := os.WriteFile(cfgFile, []byte("# v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(cfgFile, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	// Next fetch auto-reloads → second resolver.
+	if env, _ := cli.FetchEnv(context.Background(), "/a"); env["K"] != "v2" {
+		t.Fatalf("post-edit K=%q (want v2 — auto-reload didn't fire)", env["K"])
+	}
+	// A further fetch with no new edit must NOT reload again (mtime-gated).
+	if env, _ := cli.FetchEnv(context.Background(), "/a"); env["K"] != "v2" {
+		t.Fatalf("steady-state K=%q (want v2)", env["K"])
+	}
+	if reloadCalls != 1 {
+		t.Fatalf("reloadCalls=%d (want exactly 1 — reload should be mtime-gated)", reloadCalls)
+	}
+}
+
 func TestAgentReloadUnsupported(t *testing.T) {
 	a, p := newTestAgent(t, nil)
 	go a.Serve(context.Background()) //nolint:errcheck // goroutine: error surfaced via Shutdown/Listen pair

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"sync"
@@ -54,8 +55,20 @@ type Agent struct {
 	mu       sync.RWMutex
 	resolver Resolver
 	// reload, if set, rebuilds a Resolver from the current config on disk.
-	// Called from the OpReload handler. Nil-safe.
+	// Called from the OpReload handler and from the on-disk-change
+	// auto-reload (maybeReload). Nil-safe.
 	reload func() (Resolver, error)
+
+	// configPath + cfgMtime drive the auto-reload-on-change path (#202).
+	// When configPath is set, data ops stat the file and reload via
+	// `reload` when its mtime has advanced past cfgMtime — so an edit
+	// made outside the TUI (a hand-edit, or another tool) is picked up
+	// without an explicit reload op. reloadMu serialises the reload so
+	// concurrent fetches don't rebuild the resolver more than once per
+	// change.
+	configPath string
+	cfgMtime   atomic.Int64
+	reloadMu   sync.Mutex
 }
 
 // Resolver is the agent-internal hook to resolve mapping + fetch env vars.
@@ -89,6 +102,72 @@ func (a *Agent) SetReload(fn func() (Resolver, error)) {
 	a.mu.Lock()
 	a.reload = fn
 	a.mu.Unlock()
+}
+
+// SetConfigPath enables auto-reload-on-change (#202): once set, the
+// agent stats path before serving data ops and transparently reloads
+// (via the SetReload callback) when its mtime has advanced — so a
+// config edited outside the TUI (a hand-edit, or any external tool) is
+// picked up without an explicit reload op or a lock/unlock cycle. The
+// current mtime is recorded now so only edits made after this call
+// trigger a reload. No-op when path is empty.
+func (a *Agent) SetConfigPath(path string) {
+	a.configPath = path
+	a.cfgMtime.Store(configMtime(path))
+}
+
+// maybeReload reloads the resolver when the on-disk config changed since
+// the last load. Cheap in the common case — a single stat whose result
+// matches the cached mtime returns immediately. On a genuine change
+// exactly one caller performs the reload (others observe the updated
+// mtime under reloadMu and skip). A failed reload leaves the previous
+// resolver in place and is retried on the next call (cfgMtime is not
+// advanced), so a transient half-written file doesn't wedge the agent on
+// a stale-but-working config.
+func (a *Agent) maybeReload() {
+	if a.configPath == "" {
+		return
+	}
+	m := configMtime(a.configPath)
+	if m == 0 || m == a.cfgMtime.Load() {
+		return
+	}
+	a.reloadMu.Lock()
+	defer a.reloadMu.Unlock()
+	if m == a.cfgMtime.Load() {
+		return // another goroutine already reloaded for this mtime
+	}
+	a.mu.RLock()
+	fn := a.reload
+	a.mu.RUnlock()
+	if fn == nil {
+		return
+	}
+	next, err := fn()
+	if err != nil {
+		slog.Warn("agent: config changed on disk but reload failed; serving previous config", "err", err)
+		return
+	}
+	a.mu.Lock()
+	a.resolver = next
+	a.mu.Unlock()
+	a.cfgMtime.Store(m)
+	slog.Info("agent: reloaded config after on-disk change")
+}
+
+// configMtime returns path's mtime in Unix nanoseconds, or 0 if it's
+// missing/unreadable. Nanosecond precision detects rewrites within the
+// same wall-clock second (config.AtomicSave is a write-then-rename, so
+// the renamed file carries a fresh mtime).
+func configMtime(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return st.ModTime().UnixNano()
 }
 
 func (a *Agent) currentResolver() Resolver {
@@ -297,6 +376,14 @@ func (a *Agent) handle(ctx context.Context, c net.Conn) {
 }
 
 func (a *Agent) dispatch(ctx context.Context, req Request) Response {
+	// Data ops must reflect the current on-disk config: pick up any
+	// out-of-band edit (hand-edit / external tool) before serving (#202).
+	// No-op unless SetConfigPath was called and the mtime actually moved.
+	switch req.Op {
+	case OpIsMapped, OpFetchEnv, OpFetchEnvCwd, OpCwdCommands:
+		a.maybeReload()
+	}
+
 	switch req.Op {
 	case OpStatus:
 		r := a.currentResolver()

--- a/internal/cli/agent_internal.go
+++ b/internal/cli/agent_internal.go
@@ -65,6 +65,9 @@ func newAgentInternalCmd() *cobra.Command {
 			}
 			ag := agent.NewAgent(paths, idle, res)
 			ag.SetReload(loadAndBuild)
+			// Pick up out-of-band edits to the config (hand-edit /
+			// external tool) without a lock/unlock cycle (#202).
+			ag.SetConfigPath(cfgArg)
 			if err := ag.Listen(); err != nil {
 				return err
 			}

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -72,6 +72,9 @@ func newUnlockCmd() *cobra.Command {
 				}
 				ag := agent.NewAgent(paths, idle, res)
 				ag.SetReload(loadAndBuild)
+				// Pick up out-of-band edits to the config without a
+				// lock/unlock cycle (#202).
+				ag.SetConfigPath(cfgPath)
 				if err := ag.Listen(); err != nil {
 					return err
 				}


### PR DESCRIPTION
## Summary

Closes #202.

A running agent only reloaded its config on an explicit reload op (TUI save / `clone`) or a `lock`/`unlock` cycle — there is no `jitenv reload` command and no file-watch. So a `config.toml` edited **by hand or by any external tool** was never seen: the agent kept serving env values from its stale in-memory config. Combined with the cwd-mapping flow, the shim could inject for a `(pwd, command)` pair the on-disk config no longer maps, or miss a freshly-added one.

This is the agent-side staleness layer found while investigating the cwd-mapping issues (the shell-command-hash layer was fixed in #201).

## Fix

The agent now records the config mtime (`SetConfigPath`) and, before serving the **data ops** (`is_mapped` / `fetch_env` / `fetch_env_cwd` / `cwd_commands`), stats the file and reloads via the existing `SetReload` callback when the mtime has advanced.

- **mtime-gated**: the common case is a single `stat` whose result matches the cached mtime → returns immediately. No re-decrypt / rebuild unless the file actually changed.
- **serialised** (`reloadMu`) with a double-check, so concurrent fetches reload at most once per change.
- **fail-safe**: a failed reload (e.g. a transient half-written file) leaves the previous resolver in place and does not advance the cached mtime, so it's retried on the next op rather than wedging the agent on a broken config.
- Wired at both daemon entry points — `__agent` (`internal/cli/agent_internal.go`) and `unlock --foreground` (`internal/cli/unlock.go`) — via the new `Agent.SetConfigPath`.

The TUI / `clone` reload ping is unchanged; it's now just a fast-path for the same outcome (the agent would pick the edit up on the next fetch anyway).

## Tests

`TestAgentAutoReloadsOnConfigMtimeChange` (`internal/agent/agent_test.go`), at the same in-process socket+client level as the existing `TestAgentReload`:

- Pre-edit fetch returns the first resolver's value; reload callback not called.
- After editing the file + bumping its mtime, the next fetch returns the new value.
- A further fetch with no new edit does **not** reload again — asserts the reload is mtime-gated (exactly one reload call).

## Test plan

- [x] `go test ./internal/agent/ ./internal/cli/` — pass.
- [x] `go build ./...`, `go vet ./internal/agent/ ./internal/cli/`, `gofmt -l` — clean.
- [x] **Negative check**: with the `maybeReload()` dispatch hook removed, `TestAgentAutoReloadsOnConfigMtimeChange` fails; restored, it passes — confirming the test exercises the fix.

## Notes

- The real-crypto reload path (`loadAndBuild`: `config.Load` → `DecryptInPlace` → `Validate` → `BuildResolver`) is the same closure already used by the explicit reload op and exercised by the daemonize/wrapper e2e at startup; this PR only changes *when* it's invoked.
- The remaining follow-up (#203, the `__chpwd` reconcile one-prompt timing window) is the lowest-severity layer and is left as-is per its issue discussion.