### PR TITLE
fix(release): sign+notarize macOS via codesign/notarytool, not quill (#13)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,12 @@ concurrency:
 
 jobs:
   goreleaser:
-    # macOS runner is required: the `notarize:` block uses Apple's
-    # `codesign` + `notarytool`, both macOS-only. The Linux deb/rpm
-    # nfpms artifacts are still produced here — nfpm runs anywhere
-    # since it doesn't shell out to dpkg/rpm. Issue #13.
+    # macOS runner is required: darwin binaries are code-signed +
+    # notarized with Apple's own `codesign` + `xcrun notarytool` (both
+    # macOS-only) in a goreleaser build post-hook — see
+    # packaging/macos/sign-notarize.sh and .goreleaser.yaml. The Linux
+    # deb/rpm nfpms artifacts are still produced here — nfpm runs
+    # anywhere since it doesn't shell out to dpkg/rpm. Issue #13.
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -35,6 +37,62 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
+      # Import the Developer ID Application cert into a throwaway
+      # keychain and decode the notary API key, then export the derived
+      # values for goreleaser's sign-notarize build hook (#13). No-ops
+      # when MACOS_SIGN_P12 is empty, so unsigned releases keep working
+      # until the secrets are configured. We do NOT use goreleaser's
+      # `notarize:` block: its bundled quill signer can't verify Apple's
+      # cert chain (Go x509 "unhandled critical extension").
+      - name: Set up macOS signing keychain
+        env:
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MACOS_SIGN_P12}" ]; then
+            echo "MACOS_SIGN_P12 unset — releasing unsigned darwin binaries."
+            exit 0
+          fi
+          keychain="$RUNNER_TEMP/jitenv-signing.keychain-db"
+          keychain_pw="$(openssl rand -base64 24)"
+          cert_p12="$RUNNER_TEMP/cert.p12"
+          notary_key="$RUNNER_TEMP/notary-key.p8"
+
+          printf '%s' "$MACOS_SIGN_P12" | base64 --decode > "$cert_p12"
+          printf '%s' "$MACOS_NOTARY_KEY" | base64 --decode > "$notary_key"
+
+          security create-keychain -p "$keychain_pw" "$keychain"
+          # Long, no auto-lock so the keychain stays usable across steps.
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_pw" "$keychain"
+          security import "$cert_p12" -k "$keychain" -P "$MACOS_SIGN_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          # Allow codesign to use the key without an interactive prompt.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$keychain_pw" "$keychain" >/dev/null
+          # Prepend our keychain to the search list so codesign finds the key.
+          security list-keychains -d user -s "$keychain" \
+            $(security list-keychains -d user | sed 's/"//g')
+
+          identity="$(security find-identity -v -p codesigning "$keychain" \
+            | awk '/Developer ID Application/ {print $2; exit}')"
+          if [ -z "$identity" ]; then
+            echo "::error::no 'Developer ID Application' identity found in the imported cert"
+            security find-identity -v -p codesigning "$keychain" || true
+            exit 1
+          fi
+          rm -f "$cert_p12"
+
+          {
+            echo "MACOS_SIGN_IDENTITY=$identity"
+            echo "MACOS_KEYCHAIN=$keychain"
+            echo "MACOS_KEYCHAIN_PW=$keychain_pw"
+            echo "MACOS_NOTARY_KEY_FILE=$notary_key"
+          } >> "$GITHUB_ENV"
+          echo "Imported signing identity $identity"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -44,12 +102,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          # macOS signing + notarization (#13). Goreleaser's
-          # `notarize:` block skips itself when MACOS_SIGN_P12 is
-          # empty, so unsigned releases keep working until the
-          # secrets are configured in repo settings.
-          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
-          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
-          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          # The sign-notarize build hook reads the keychain/identity
+          # from the step above (via $GITHUB_ENV) plus the notary key
+          # id + issuer below. The hook no-ops when MACOS_SIGN_IDENTITY
+          # is unset (secrets not configured).
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          set -uo pipefail
+          if [ -n "${MACOS_KEYCHAIN:-}" ] && [ -f "${MACOS_KEYCHAIN}" ]; then
+            security delete-keychain "$MACOS_KEYCHAIN" || true
+          fi
+          rm -f "${MACOS_NOTARY_KEY_FILE:-}" || true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,15 @@ builds:
       - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
       - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
       - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+    hooks:
+      # Sign + notarize darwin binaries with Apple's own toolchain
+      # (#13). The script no-ops on non-darwin targets and when the
+      # signing identity isn't configured, so non-macOS/local builds
+      # are unaffected. See packaging/macos/sign-notarize.sh and the
+      # note above the (intentionally absent) goreleaser notarize block.
+      post:
+        - cmd: ./packaging/macos/sign-notarize.sh "{{ .Path }}" "{{ .Os }}"
+          output: true
 
   # The interactive TUI lives in a separate binary so the main
   # jitenv binary's import graph stays free of Bubble Tea / Lip
@@ -54,6 +63,11 @@ builds:
       - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
       - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
       - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+    hooks:
+      # Same darwin sign+notarize hook as the jitenv build (#13).
+      post:
+        - cmd: ./packaging/macos/sign-notarize.sh "{{ .Path }}" "{{ .Os }}"
+          output: true
 
 archives:
   - id: jitenv
@@ -154,9 +168,11 @@ homebrew_casks:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "Brew cask update for jitenv {{ .Tag }}"
-    # No xattr-strip hook: the binaries are Apple-notarized below, so
-    # Gatekeeper accepts them out of the box. If notarization gets
-    # disabled (secrets missing on a release), users will need to run
+    # No xattr-strip hook: the binaries are code-signed + Apple-
+    # notarized by the build post-hook (see packaging/macos/sign-
+    # notarize.sh), so Gatekeeper accepts them out of the box. If
+    # notarization gets disabled (secrets missing on a release), users
+    # will need to run
     # `xattr -dr com.apple.quarantine` on jitenv + jitenv-tui once.
 
 # Chocolatey (#180) is intentionally NOT a goreleaser pipe: its
@@ -183,46 +199,18 @@ signs:
       - "${artifact}"
       - "--yes"
 
-# Apple Developer ID code-signing + notarization for the
-# darwin/amd64 + darwin/arm64 binaries (#13). The release job has
-# to run on macOS — codesign and notarytool are macOS-only.
-#
-# Required GH Actions secrets (set in repo Settings → Secrets):
-#
-#   MACOS_SIGN_P12          base64 of a Developer ID Application
-#                           certificate exported as .p12
-#   MACOS_SIGN_PASSWORD     password set when the .p12 was exported
-#   MACOS_NOTARY_KEY        base64 of an App Store Connect API key
-#                           (.p8 file)
-#   MACOS_NOTARY_KEY_ID     the API key ID (e.g. "A1B2C3D4E5")
-#   MACOS_NOTARY_ISSUER_ID  the issuer UUID from App Store Connect
-#
-# `enabled` is a templated boolean. When MACOS_SIGN_P12 is unset
-# (no Apple Developer account configured yet, or local snapshot),
-# the entire notarize block is skipped and unsigned tarballs ship
-# as before. When the secrets are set, each darwin binary is
-# code-signed, the archives are submitted to Apple, and goreleaser
-# waits for the ticket before publishing the release.
-notarize:
-  macos:
-    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
-      # Both halves of the binary split (#182): jitenv-tui ships in the
-      # cask alongside jitenv and is the re-exec target for `jitenv
-      # config`, so it must be signed + notarized too — otherwise, with
-      # the cask's xattr-strip hook removed above, Gatekeeper would
-      # block jitenv-tui on first run.
-      ids:
-        - jitenv
-        - jitenv-tui
-      sign:
-        certificate: '{{ .Env.MACOS_SIGN_P12 }}'
-        password: '{{ .Env.MACOS_SIGN_PASSWORD }}'
-      notarize:
-        issuer_id: '{{ .Env.MACOS_NOTARY_ISSUER_ID }}'
-        key_id: '{{ .Env.MACOS_NOTARY_KEY_ID }}'
-        key: '{{ .Env.MACOS_NOTARY_KEY }}'
-        wait: true
-        timeout: 20m
+# Apple Developer ID code-signing + notarization is NOT done via
+# goreleaser's `notarize:` block: that path uses the bundled `quill`
+# signer, whose Go crypto/x509 chain verification rejects Apple's
+# Developer ID certificate chain with "x509: unhandled critical
+# extension" (#13). Instead each darwin binary is signed + notarized
+# in a build post-hook (see the `hooks.post` on each build above)
+# using Apple's own `codesign` + `xcrun notarytool` on the macOS
+# runner — packaging/macos/sign-notarize.sh. The release job
+# (.github/workflows/release.yml) imports the signing identity into a
+# temp keychain before invoking goreleaser. The hook no-ops on
+# non-darwin targets and when signing isn't configured, so local
+# `goreleaser release --snapshot` still works unsigned.
 
 snapshot:
   version_template: "{{ .Version }}-snapshot-{{ .ShortCommit }}"

--- a/packaging/macos/sign-notarize.sh
+++ b/packaging/macos/sign-notarize.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Sign + notarize a single darwin binary with Apple's own toolchain
+# (codesign + xcrun notarytool), invoked from each build's
+# `hooks.post` in .goreleaser.yaml (#13).
+#
+# We do NOT use goreleaser's built-in `notarize:` block: its bundled
+# `quill` signer verifies the Developer ID cert chain with Go's
+# crypto/x509, which rejects Apple's certs ("x509: unhandled critical
+# extension"). Apple's native codesign/notarytool have no such issue.
+#
+# Usage: sign-notarize.sh <binary-path> <goos>
+#
+# No-ops (exit 0) when:
+#   - the target isn't darwin, or
+#   - MACOS_SIGN_IDENTITY is unset (signing not configured — e.g. a
+#     local `goreleaser release --snapshot` or a fork without secrets).
+#
+# Required env when signing IS configured (exported by the release
+# workflow's keychain-setup step):
+#   MACOS_SIGN_IDENTITY     codesigning identity (SHA-1 hash or CN)
+#   MACOS_KEYCHAIN          path to the temp keychain holding the cert
+#   MACOS_KEYCHAIN_PW       password to unlock that keychain
+#   MACOS_NOTARY_KEY_FILE   path to the App Store Connect API key (.p8)
+#   MACOS_NOTARY_KEY_ID     the API key ID
+#   MACOS_NOTARY_ISSUER_ID  the issuer UUID
+#
+# Bare CLI binaries (Mach-O, not .app/.pkg/.dmg) cannot be stapled, so
+# we don't staple — Gatekeeper verifies the notarization online on
+# first run. That's why the Homebrew cask no longer strips the
+# quarantine xattr.
+
+set -euo pipefail
+
+BIN="${1:?usage: sign-notarize.sh <binary-path> <goos>}"
+GOOS="${2:?usage: sign-notarize.sh <binary-path> <goos>}"
+
+if [ "$GOOS" != "darwin" ]; then
+  exit 0
+fi
+
+if [ -z "${MACOS_SIGN_IDENTITY:-}" ]; then
+  echo "sign-notarize: MACOS_SIGN_IDENTITY unset — skipping $BIN (unsigned build)"
+  exit 0
+fi
+
+: "${MACOS_KEYCHAIN:?MACOS_KEYCHAIN must be set when MACOS_SIGN_IDENTITY is}"
+: "${MACOS_NOTARY_KEY_FILE:?MACOS_NOTARY_KEY_FILE must be set}"
+: "${MACOS_NOTARY_KEY_ID:?MACOS_NOTARY_KEY_ID must be set}"
+: "${MACOS_NOTARY_ISSUER_ID:?MACOS_NOTARY_ISSUER_ID must be set}"
+
+echo "sign-notarize: codesigning $BIN"
+# Defensive unlock: GitHub runners can re-lock the keychain between
+# steps. Harmless if it's already unlocked.
+if [ -n "${MACOS_KEYCHAIN_PW:-}" ]; then
+  security unlock-keychain -p "$MACOS_KEYCHAIN_PW" "$MACOS_KEYCHAIN" >/dev/null 2>&1 || true
+fi
+
+# --options runtime (hardened runtime) and --timestamp are both
+# prerequisites for notarization; --force re-signs if needed.
+codesign --force --timestamp --options runtime \
+  --keychain "$MACOS_KEYCHAIN" \
+  --sign "$MACOS_SIGN_IDENTITY" \
+  "$BIN"
+codesign --verify --strict --verbose=2 "$BIN"
+
+echo "sign-notarize: notarizing $BIN"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+zip="$workdir/$(basename "$BIN").zip"
+# notarytool needs a zip/pkg/dmg container; ditto produces a zip
+# notarytool accepts.
+ditto -c -k "$BIN" "$zip"
+
+xcrun notarytool submit "$zip" \
+  --key "$MACOS_NOTARY_KEY_FILE" \
+  --key-id "$MACOS_NOTARY_KEY_ID" \
+  --issuer "$MACOS_NOTARY_ISSUER_ID" \
+  --wait \
+  --timeout 20m
+
+echo "sign-notarize: done $BIN"


### PR DESCRIPTION
## Why
The v0.10.0 release **aborted with zero artifacts** at goreleaser's `notarize:` step:

```
sign & notarize macOS binaries
⨯ release failed: dist/jitenv_darwin_amd64_v1/jitenv: failed to verify certificate chain: x509: unhandled critical extension
```

goreleaser's `notarize:` block uses its bundled **quill** signer, whose Go `crypto/x509` chain verification rejects Apple's Developer ID cert chain (Apple marks extensions critical that Go doesn't recognize). 2.16.0 is the newest **stable** goreleaser, so no version bump fixes quill, and the block has no skip-verify option. The release aborts before publishing → no binaries, no cask update, no Chocolatey trigger.

## Fix — Apple's native toolchain (per the chosen approach)
Replace quill with `codesign` + `xcrun notarytool` on the macОS runner:

- **`packaging/macos/sign-notarize.sh`** — signs one darwin binary (`codesign --options runtime --timestamp`) then `notarytool submit --wait`. No-ops on non-darwin targets and when `MACOS_SIGN_IDENTITY` is unset (local snapshot / forks), so unsigned builds keep working. Bare CLI binaries can't be stapled, so Gatekeeper verifies notarization **online** — which is why the cask keeps its xattr-strip hook removed.
- **`.goreleaser.yaml`** — drop the `notarize:` block; invoke the script from a `hooks.post` on **both** the `jitenv` and `jitenv-tui` builds, so each darwin binary (amd64 + arm64) is signed+notarized in-pipeline before archiving.
- **`release.yml`** — import the Developer ID cert into a throwaway keychain + decode the notary key before goreleaser runs, export the derived identity/keychain/key-path via `$GITHUB_ENV` for the hook, and clean up the keychain afterwards (`if: always()`).

No secret changes needed — reuses the `MACOS_SIGN_P12` / `MACOS_SIGN_PASSWORD` / `MACOS_NOTARY_KEY` / `MACOS_NOTARY_KEY_ID` / `MACOS_NOTARY_ISSUER_ID` you already set.

## Test plan
- [x] `goreleaser check` passes (build hooks well-formed; notarize block removed)
- [x] `actionlint` clean on `release.yml`
- [x] `goreleaser build --snapshot` shows the hook firing for all 4 darwin targets and no-opping on linux/windows; the script's no-op paths exit 0; `bash -n` clean
- [ ] **Real tag release** — the codesign/notarytool path itself runs only on the macOS runner with secrets (not exercised by PR CI)

## ⚠️ After merge — re-cut the release
v0.10.0's tag + GitHub release exist but are **empty** (the abort happened before publish). Once this merges, the empty v0.10.0 needs re-cutting — either delete the v0.10.0 tag + release and re-push the tag, or let release-please cut v0.10.1. Happy to do the tag/release cleanup on request (it's destructive + outward-facing, so leaving it to you).