### PR TITLE
fix(release): raise macOS notarization wait to 45m (#13)

### DIFF
--- a/packaging/macos/sign-notarize.sh
+++ b/packaging/macos/sign-notarize.sh
@@ -71,11 +71,19 @@ zip="$workdir/$(basename "$BIN").zip"
 # notarytool accepts.
 ditto -c -k "$BIN" "$zip"
 
+# --wait blocks until Apple finishes. Notarization time is variable —
+# usually a few minutes, but Apple's service routinely exceeds 20m
+# during backlogs (a 20m cap timed out a real v0.10.0 release with the
+# submission still "In Progress"). 45m comfortably covers slow periods
+# while staying well under the GitHub job timeout; the build hooks run
+# concurrently so wall-clock is ~the slowest single submission, not the
+# sum. A timeout here fails the release loudly rather than shipping an
+# un-notarized binary.
 xcrun notarytool submit "$zip" \
   --key "$MACOS_NOTARY_KEY_FILE" \
   --key-id "$MACOS_NOTARY_KEY_ID" \
   --issuer "$MACOS_NOTARY_ISSUER_ID" \
   --wait \
-  --timeout 20m
+  --timeout 45m
 
 echo "sign-notarize: done $BIN"


### PR DESCRIPTION
## Why
The v0.10.0 release now gets past the cert + codesign (your Developer ID cert works), but failed at the notarization wait:

```
Current status: In Progress.......... [for the full 20 min]
Timeout of 1200 second(s) was reached before processing completed.
```

No rejection — Apple simply hadn't finished within the `--timeout 20m` my script passed to `notarytool`. Notarization time is variable and routinely exceeds 20 minutes during Apple service backlogs, so that cap is too tight.

## Fix
Raise `notarytool --wait --timeout` from `20m` → `45m` in `packaging/macos/sign-notarize.sh`. Well above typical completion, well under the GitHub job timeout (6h). The four build hooks (jitenv + jitenv-tui × amd64/arm64) run concurrently, so wall-clock is ~the slowest single submission, not the sum.

## Test plan
- [x] `bash -n` clean
- [ ] Re-run the v0.10.0 release after merge — should clear notarization if Apple completes within 45m (a recurring timeout past 45m would indicate an Apple-side outage, checkable at developer.apple.com/system-status)

One-line change to the timeout value.