### PR TITLE
fix(release): decouple macOS sign/notarize + cask from the main release (#13)

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,146 @@
+name: macos-release
+
+# Post-publish macOS workflow (#13). Triggered after the main
+# release.yml has published lin/win artifacts. Runs entirely on
+# macos-latest:
+#
+#   1. Imports the Developer ID Application cert into a throwaway
+#      keychain (same pattern release.yml used before the decoupling).
+#   2. Builds darwin amd64+arm64 for jitenv + jitenv-tui via
+#      goreleaser with .goreleaser.darwin.yaml; the build post-hook
+#      sign-notarize.sh codesigns + notarizes each binary using
+#      Apple's native codesign + xcrun notarytool.
+#   3. Uploads the darwin tarballs + their cosign-signed
+#      SHA256SUMS-darwin to the existing GH release (the main release
+#      ships SHA256SUMS for lin/win; the darwin checksum has its own
+#      filename so they don't clobber).
+#   4. Pushes the Homebrew cask to Galvill/homebrew-jitenv (goreleaser
+#      homebrew_casks pipe). The darwin config sets release.disable:
+#      true so goreleaser doesn't touch the GH release here.
+#
+# Skips pre-releases (the `-rc.N` tags). workflow_dispatch allows
+# manual re-runs against any tag without re-cutting the release.
+#
+# Injection hygiene: release-supplied values (the tag) flow through
+# the job-level env: block and are read as $TAG in run:, never
+# inlined as ${{ ... }} inside run:.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sign + notarize, e.g. v0.10.1"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: macos-release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: macos-latest
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Set up macOS signing keychain
+        env:
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MACOS_SIGN_P12}" ]; then
+            echo "::error::MACOS_SIGN_P12 is empty — refuse to ship un-notarized darwin binaries."
+            exit 1
+          fi
+          keychain="$RUNNER_TEMP/jitenv-signing.keychain-db"
+          keychain_pw="$(openssl rand -base64 24)"
+          cert_p12="$RUNNER_TEMP/cert.p12"
+          notary_key="$RUNNER_TEMP/notary-key.p8"
+
+          printf '%s' "$MACOS_SIGN_P12" | base64 --decode > "$cert_p12"
+          printf '%s' "$MACOS_NOTARY_KEY" | base64 --decode > "$notary_key"
+
+          security create-keychain -p "$keychain_pw" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_pw" "$keychain"
+          security import "$cert_p12" -k "$keychain" -P "$MACOS_SIGN_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$keychain_pw" "$keychain" >/dev/null
+          security list-keychains -d user -s "$keychain" \
+            $(security list-keychains -d user | sed 's/"//g')
+
+          identity="$(security find-identity -v -p codesigning "$keychain" \
+            | awk '/Developer ID Application/ {print $2; exit}')"
+          if [ -z "$identity" ]; then
+            echo "::error::no 'Developer ID Application' identity found in the imported cert"
+            security find-identity -v -p codesigning "$keychain" || true
+            exit 1
+          fi
+          rm -f "$cert_p12"
+
+          {
+            echo "MACOS_SIGN_IDENTITY=$identity"
+            echo "MACOS_KEYCHAIN=$keychain"
+            echo "MACOS_KEYCHAIN_PW=$keychain_pw"
+            echo "MACOS_NOTARY_KEY_FILE=$notary_key"
+          } >> "$GITHUB_ENV"
+          echo "Imported signing identity $identity"
+
+      - name: Run GoReleaser (darwin)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --config .goreleaser.darwin.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+
+      - name: Upload darwin artifacts to the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          gh release upload "$TAG" \
+            dist/jitenv_*_darwin_*.tar.gz \
+            "dist/jitenv_${version}_darwin_SHA256SUMS" \
+            "dist/jitenv_${version}_darwin_SHA256SUMS.sig" \
+            "dist/jitenv_${version}_darwin_SHA256SUMS.pem" \
+            --clobber
+
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          set -uo pipefail
+          if [ -n "${MACOS_KEYCHAIN:-}" ] && [ -f "${MACOS_KEYCHAIN}" ]; then
+            security delete-keychain "$MACOS_KEYCHAIN" || true
+          fi
+          rm -f "${MACOS_NOTARY_KEY_FILE:-}" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,12 @@ concurrency:
 
 jobs:
   goreleaser:
-    # macOS runner is required: darwin binaries are code-signed +
-    # notarized with Apple's own `codesign` + `xcrun notarytool` (both
-    # macOS-only) in a goreleaser build post-hook — see
-    # packaging/macos/sign-notarize.sh and .goreleaser.yaml. The Linux
-    # deb/rpm nfpms artifacts are still produced here — nfpm runs
-    # anywhere since it doesn't shell out to dpkg/rpm. Issue #13.
-    runs-on: macos-latest
+    # Linux runner: this workflow now builds Linux + Windows artifacts
+    # only. macOS code-signing + notarization + Homebrew cask publish
+    # ship asynchronously via .github/workflows/macos-release.yml (#13)
+    # so Apple's variable notarization latency can't block lin/win
+    # or the Chocolatey publish that triggers off release:published.
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,62 +36,6 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
-      # Import the Developer ID Application cert into a throwaway
-      # keychain and decode the notary API key, then export the derived
-      # values for goreleaser's sign-notarize build hook (#13). No-ops
-      # when MACOS_SIGN_P12 is empty, so unsigned releases keep working
-      # until the secrets are configured. We do NOT use goreleaser's
-      # `notarize:` block: its bundled quill signer can't verify Apple's
-      # cert chain (Go x509 "unhandled critical extension").
-      - name: Set up macOS signing keychain
-        env:
-          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
-          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
-          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${MACOS_SIGN_P12}" ]; then
-            echo "MACOS_SIGN_P12 unset — releasing unsigned darwin binaries."
-            exit 0
-          fi
-          keychain="$RUNNER_TEMP/jitenv-signing.keychain-db"
-          keychain_pw="$(openssl rand -base64 24)"
-          cert_p12="$RUNNER_TEMP/cert.p12"
-          notary_key="$RUNNER_TEMP/notary-key.p8"
-
-          printf '%s' "$MACOS_SIGN_P12" | base64 --decode > "$cert_p12"
-          printf '%s' "$MACOS_NOTARY_KEY" | base64 --decode > "$notary_key"
-
-          security create-keychain -p "$keychain_pw" "$keychain"
-          # Long, no auto-lock so the keychain stays usable across steps.
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$keychain_pw" "$keychain"
-          security import "$cert_p12" -k "$keychain" -P "$MACOS_SIGN_PASSWORD" \
-            -T /usr/bin/codesign -T /usr/bin/security
-          # Allow codesign to use the key without an interactive prompt.
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$keychain_pw" "$keychain" >/dev/null
-          # Prepend our keychain to the search list so codesign finds the key.
-          security list-keychains -d user -s "$keychain" \
-            $(security list-keychains -d user | sed 's/"//g')
-
-          identity="$(security find-identity -v -p codesigning "$keychain" \
-            | awk '/Developer ID Application/ {print $2; exit}')"
-          if [ -z "$identity" ]; then
-            echo "::error::no 'Developer ID Application' identity found in the imported cert"
-            security find-identity -v -p codesigning "$keychain" || true
-            exit 1
-          fi
-          rm -f "$cert_p12"
-
-          {
-            echo "MACOS_SIGN_IDENTITY=$identity"
-            echo "MACOS_KEYCHAIN=$keychain"
-            echo "MACOS_KEYCHAIN_PW=$keychain_pw"
-            echo "MACOS_NOTARY_KEY_FILE=$notary_key"
-          } >> "$GITHUB_ENV"
-          echo "Imported signing identity $identity"
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -101,19 +44,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          # The sign-notarize build hook reads the keychain/identity
-          # from the step above (via $GITHUB_ENV) plus the notary key
-          # id + issuer below. The hook no-ops when MACOS_SIGN_IDENTITY
-          # is unset (secrets not configured).
-          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
-          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
-
-      - name: Clean up signing keychain
-        if: always()
-        run: |
-          set -uo pipefail
-          if [ -n "${MACOS_KEYCHAIN:-}" ] && [ -f "${MACOS_KEYCHAIN}" ]; then
-            security delete-keychain "$MACOS_KEYCHAIN" || true
-          fi
-          rm -f "${MACOS_NOTARY_KEY_FILE:-}" || true

--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -1,0 +1,140 @@
+version: 2
+
+# macOS-only goreleaser config (#13). Used by
+# .github/workflows/macos-release.yml on macos-latest to build, sign,
+# notarize, archive, and publish the darwin tarballs + Homebrew cask
+# AFTER the main release (.goreleaser.yaml, ubuntu) has shipped
+# lin/win. release.disable is true here: this config doesn't create or
+# touch the GitHub release — the workflow uploads the darwin tarballs +
+# their SHA256SUMS-darwin to the existing release via `gh release
+# upload`. Goreleaser still pushes the Homebrew cask (cask publish is
+# independent of the release pipe).
+
+project_name: jitenv
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: jitenv
+    main: ./cmd/jitenv
+    binary: jitenv
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
+      - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+    hooks:
+      # Sign + notarize each darwin binary using Apple's native
+      # codesign + xcrun notarytool. The script no-ops when the
+      # signing identity isn't configured, so a local
+      # `goreleaser release --config .goreleaser.darwin.yaml --snapshot`
+      # still works unsigned for testing.
+      post:
+        - cmd: ./packaging/macos/sign-notarize.sh "{{ .Path }}" "{{ .Os }}"
+          output: true
+
+  - id: jitenv-tui
+    main: ./cmd/jitenv-tui
+    binary: jitenv-tui
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
+      - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+    hooks:
+      post:
+        - cmd: ./packaging/macos/sign-notarize.sh "{{ .Path }}" "{{ .Os }}"
+          output: true
+
+# Archive shape matches the main release's archives exactly (same
+# name_template, same bundled files) so users see a coherent
+# darwin/linux/windows triplet on the release page.
+archives:
+  - id: jitenv
+    formats: [tar.gz]
+    ids:
+      - jitenv
+      - jitenv-tui
+    name_template: "jitenv_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+      - src: internal/shell/snippets/bash.sh
+        dst: snippets/bash.sh
+      - src: internal/shell/snippets/zsh.sh
+        dst: snippets/zsh.sh
+      - src: internal/shell/snippets/powershell.ps1
+        dst: snippets/powershell.ps1
+
+# Distinct checksum filename so this doesn't clobber the main
+# release's SHA256SUMS (which covers lin/win).
+checksum:
+  name_template: "jitenv_{{ .Version }}_darwin_SHA256SUMS"
+
+signs:
+  - id: cosign-checksum
+    cmd: cosign
+    artifacts: checksum
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+
+# Homebrew tap: cask references the darwin tarballs this config
+# produces. Cask publishing is part of goreleaser's publish stage and
+# is independent of `release.disable`, so the cask still gets pushed.
+homebrew_casks:
+  - name: jitenv
+    repository:
+      owner: Galvill
+      name: homebrew-jitenv
+      branch: main
+      token: '{{ index .Env "HOMEBREW_TAP_GITHUB_TOKEN" }}'
+    directory: Casks
+    homepage: https://github.com/Galvill/jitenv
+    description: Just-in-time env-var injection from pluggable secret sources, scoped to per-command process trees
+    skip_upload: auto
+    binaries:
+      - jitenv
+      - jitenv-tui
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew cask update for jitenv {{ .Tag }}"
+    # No xattr-strip hook: the binaries are code-signed + Apple-
+    # notarized by the build post-hook above, so Gatekeeper accepts
+    # them out of the box.
+
+snapshot:
+  version_template: "{{ .Version }}-snapshot-{{ .ShortCommit }}"
+
+# Disable goreleaser's GH release pipe — the release was already
+# created by the main workflow on the same tag. macos-release.yml
+# uploads the darwin tarballs + SHA256SUMS-darwin + cosign sigs to it
+# via `gh release upload --clobber`.
+release:
+  disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,12 @@ before:
   hooks:
     - go mod download
 
+# Main release builds Linux + Windows only. Darwin binaries (signed
+# + notarized) and the Homebrew cask are produced by the separate
+# .github/workflows/macos-release.yml workflow on macos-latest after
+# this release publishes, so Apple's variable notarization latency
+# never blocks lin/win artifacts (or the Chocolatey publish that
+# triggers off release:published). See .goreleaser.darwin.yaml.
 builds:
   - id: jitenv
     main: ./cmd/jitenv
@@ -14,7 +20,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
       - windows
     goarch:
       - amd64
@@ -26,15 +31,6 @@ builds:
       - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
       - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
       - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
-    hooks:
-      # Sign + notarize darwin binaries with Apple's own toolchain
-      # (#13). The script no-ops on non-darwin targets and when the
-      # signing identity isn't configured, so non-macOS/local builds
-      # are unaffected. See packaging/macos/sign-notarize.sh and the
-      # note above the (intentionally absent) goreleaser notarize block.
-      post:
-        - cmd: ./packaging/macos/sign-notarize.sh "{{ .Path }}" "{{ .Os }}"
-          output: true
 
   # The interactive TUI lives in a separate binary so the main
   # jitenv binary's import graph stays free of Bubble Tea / Lip
@@ -51,7 +47,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
       - windows
     goarch:
       - amd64
@@ -63,11 +58,6 @@ builds:
       - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
       - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
       - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
-    hooks:
-      # Same darwin sign+notarize hook as the jitenv build (#13).
-      post:
-        - cmd: ./packaging/macos/sign-notarize.sh "{{ .Path }}" "{{ .Os }}"
-          output: true
 
 archives:
   - id: jitenv
@@ -126,54 +116,13 @@ nfpms:
       postinstall: packaging/postinstall.sh
       preremove: packaging/preremove.sh
 
-# Homebrew tap (#13): goreleaser auto-generates a cask from the
-# macOS tarball artifacts and pushes it to a separate tap repo
-# (`Galvill/homebrew-jitenv`). End users then install with:
-#
-#     brew install Galvill/jitenv/jitenv
-#
-# Cask (not formula) because Homebrew now recommends casks for any
-# pre-built binary distribution and goreleaser is phasing out the
-# `brews:` block.
-#
-# Cross-repo pushes need a PAT scoped to the tap repo; the default
-# GITHUB_TOKEN can only write to the current repo. `index .Env "..."`
-# returns "" when the secret is absent, so `goreleaser release
-# --snapshot` keeps working locally — combined with `skip_upload:
-# auto` it just generates the cask in dist/ without trying to push.
-#
-# Without notarization the cask sets `no_quarantine: true` so the
-# Gatekeeper hard-block doesn't fire on install. Users still see the
-# "downloaded from the internet" warning the first time they invoke
-# jitenv via Spotlight/Finder; running from the terminal is fine.
-homebrew_casks:
-  - name: jitenv
-    repository:
-      owner: Galvill
-      name: homebrew-jitenv
-      branch: main
-      token: '{{ index .Env "HOMEBREW_TAP_GITHUB_TOKEN" }}'
-    directory: Casks
-    homepage: https://github.com/Galvill/jitenv
-    description: Just-in-time env-var injection from pluggable secret sources, scoped to per-command process trees
-    skip_upload: auto
-    # Ship both halves of the binary split (#182 bug B): jitenv runs
-    # everything except the TUI; jitenv-tui is the re-exec target for
-    # `jitenv config`. The cask links both into the Homebrew prefix
-    # bin/ so `which jitenv-tui` resolves.
-    binaries:
-      - jitenv
-      - jitenv-tui
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-    commit_msg_template: "Brew cask update for jitenv {{ .Tag }}"
-    # No xattr-strip hook: the binaries are code-signed + Apple-
-    # notarized by the build post-hook (see packaging/macos/sign-
-    # notarize.sh), so Gatekeeper accepts them out of the box. If
-    # notarization gets disabled (secrets missing on a release), users
-    # will need to run
-    # `xattr -dr com.apple.quarantine` on jitenv + jitenv-tui once.
+# Homebrew cask + darwin binaries (#13) are NOT in this config: they
+# ship via .github/workflows/macos-release.yml using
+# .goreleaser.darwin.yaml on macos-latest after the main release
+# publishes, so Apple's variable notarization latency can't block the
+# lin/win artifacts or the Chocolatey publish that triggers off
+# release:published. The darwin tarballs + their cosign-signed
+# SHA256SUMS-darwin land on the same GitHub release asynchronously.
 
 # Chocolatey (#180) is intentionally NOT a goreleaser pipe: its
 # packer shells out to the `choco` CLI, which only exists on Windows,
@@ -199,18 +148,14 @@ signs:
       - "${artifact}"
       - "--yes"
 
-# Apple Developer ID code-signing + notarization is NOT done via
-# goreleaser's `notarize:` block: that path uses the bundled `quill`
-# signer, whose Go crypto/x509 chain verification rejects Apple's
-# Developer ID certificate chain with "x509: unhandled critical
-# extension" (#13). Instead each darwin binary is signed + notarized
-# in a build post-hook (see the `hooks.post` on each build above)
-# using Apple's own `codesign` + `xcrun notarytool` on the macOS
-# runner — packaging/macos/sign-notarize.sh. The release job
-# (.github/workflows/release.yml) imports the signing identity into a
-# temp keychain before invoking goreleaser. The hook no-ops on
-# non-darwin targets and when signing isn't configured, so local
-# `goreleaser release --snapshot` still works unsigned.
+# macOS code-signing + notarization runs entirely in
+# .github/workflows/macos-release.yml against .goreleaser.darwin.yaml
+# (#13). It triggers on `release: published`, builds + signs +
+# notarizes the darwin binaries using Apple's native codesign + xcrun
+# notarytool (packaging/macos/sign-notarize.sh), uploads the darwin
+# tarballs + their own SHA256SUMS-darwin to this release, and pushes
+# the Homebrew cask. Decoupled so Apple's variable notarization
+# latency never blocks the lin/win artifacts shipped here.
 
 snapshot:
   version_template: "{{ .Version }}-snapshot-{{ .ShortCommit }}"
@@ -224,9 +169,13 @@ release:
   header: |
     ## jitenv {{ .Tag }}
 
-    Linux, macOS, and Windows artifacts for `amd64` and `arm64`.
+    Linux and Windows artifacts for `amd64` and `arm64`. The macOS
+    tarballs + Homebrew cask are signed + notarized + published
+    asynchronously by a separate workflow (typically within ~30 min)
+    and land on this same release with an `SHA256SUMS-darwin` of
+    their own.
 
-    macOS users can install via Homebrew:
+    macOS users can install via Homebrew (once the cask is pushed):
 
     ```sh
     brew install Galvill/jitenv/jitenv
@@ -244,7 +193,8 @@ release:
     tracking issue. Verify integrity:
 
     ```sh
-    sha256sum -c SHA256SUMS
+    sha256sum -c SHA256SUMS         # linux + windows
+    sha256sum -c SHA256SUMS-darwin  # macOS, once published
 
     cosign verify-blob \
       --certificate-identity-regexp "^https://github.com/Galvill/jitenv/" \

--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ brew install Galvill/jitenv/jitenv
 Distributed as a Homebrew **cask** that downloads the goreleaser
 tarball for your arch. macOS binaries are Developer ID code-signed
 and notarized, so Gatekeeper accepts them without a quarantine
-override. After install, activate the shell hook **once** as your
-normal user:
+override. The cask and the darwin tarballs ship from a separate
+post-publish workflow (`macos-release.yml`) so the GitHub release
+itself doesn't block on Apple notarization; the cask typically lands
+within ~30 minutes of a new release. After install, activate the
+shell hook **once** as your normal user:
 
 ```sh
 jitenv hook install


### PR DESCRIPTION
## Why
v0.10.0 and v0.10.1 both shipped **zero artifacts** because Apple's notarization wait blocked the entire goreleaser run on the macOS runner. v0.10.1 ran for **71 minutes** (build: ~2 min, the rest was four sequential per-binary notarizations) before timing out, even with #211's 45m per-binary cap. Per-binary serial waits compound during Apple backlogs, so any single submission stuck behind Apple's queue blocks lin/win artifacts AND the Chocolatey publish that triggers off `release:published`.

## Architecture
Two goreleaser configs + two workflows:

```
   v* tag pushed
        │
        ▼
  release.yml (ubuntu-latest, ~5 min)
        │ .goreleaser.yaml — lin/win only
        │ archives + deb/rpm + cosign-signed SHA256SUMS
        ▼
  GitHub release published with lin/win artifacts
        │
        ├─► chocolatey.yml  (windows-latest, unchanged)
        │
        └─► macos-release.yml  (macos-latest, async)
                .goreleaser.darwin.yaml
                build → codesign → notarytool --wait → archive
                gh release upload --clobber  (darwin tarballs +
                                              SHA256SUMS-darwin + sigs)
                homebrew_casks pipe pushes the cask
```

A notarization timeout now fails ONLY the post-publish macOS workflow. lin/win/choco are already published; `workflow_dispatch` re-runs macOS against any tag without re-cutting the release.

## Changes
- **`.goreleaser.yaml`** — drop `darwin` from `builds.goos` for both jitenv and jitenv-tui, remove the sign-notarize build hooks, remove the `homebrew_casks:` block. Release header updated to note darwin/cask ship async.
- **`.github/workflows/release.yml`** — `runs-on: ubuntu-latest` (revert from macos-latest), drop the keychain setup + cleanup steps, drop all `MACOS_*` env. Back to the fast linux release path.
- **`.goreleaser.darwin.yaml`** *(new)* — darwin-only builds with the sign-notarize `hooks.post`, distinct `jitenv_<v>_darwin_SHA256SUMS` checksum, cosign sign, `homebrew_casks:` block (referencing the darwin tarballs), `release.disable: true`.
- **`.github/workflows/macos-release.yml`** *(new)* — `macos-latest`, on `release: published` (skips prereleases) + `workflow_dispatch`. Imports the Developer ID cert into a throwaway keychain (same logic release.yml had pre-decoupling), runs goreleaser with `--config .goreleaser.darwin.yaml`, uploads darwin tarballs + SHA256SUMS-darwin + sigs to the existing release via `gh release upload --clobber`. The homebrew_casks pipe pushes the cask. Same injection-hygiene pattern (tag through `env.TAG`).
- **`README.md`** — Homebrew section notes the cask lands async post-release (typically ~30 min).

Reuses every existing secret unchanged: `MACOS_SIGN_P12` / `MACOS_SIGN_PASSWORD` / `MACOS_NOTARY_KEY` / `MACOS_NOTARY_KEY_ID` / `MACOS_NOTARY_ISSUER_ID` / `HOMEBREW_TAP_GITHUB_TOKEN`. Includes #211's 45m timeout (already on main).

## Test plan
- [x] `actionlint` clean on all four workflows (release, macos-release, chocolatey, release-rc, e2e, ci)
- [x] `goreleaser check` passes for both `.goreleaser.yaml` and `.goreleaser.darwin.yaml`
- [x] `goreleaser release --snapshot` on the main config builds **lin/win only**, archives produced, no darwin
- [x] `goreleaser release --snapshot` on the darwin config builds **darwin only**, the sign-notarize hook fires for each binary and correctly no-ops without `MACOS_SIGN_IDENTITY` (unsigned local builds work)
- [ ] Real tag release: confirm main release publishes immediately, then macos-release.yml uploads the darwin tarballs + pushes the cask

## After merge — re-cut
v0.10.0 and v0.10.1 tags exist but neither has a GitHub release (both runs aborted pre-publish). Cleanest follow-up: delete both tags + cut a fresh `v0.10.x` (probably `v0.10.2` so release-please stays sane, or re-cut `v0.10.1` at the new HEAD). Happy to drive that after merge.