### PR TITLE
fix(chocolatey): poll release assets via API instead of trusting SHA256SUMS 200 (#180)

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -66,26 +66,48 @@ jobs:
           $url = "$base/$zip"
 
           # goreleaser creates the release as non-draft, so `published`
-          # can fire while assets are still uploading. Retry the
-          # SHA256SUMS fetch (it's uploaded after the archives, so its
-          # presence implies the zip is up too) with backoff before
-          # giving up.
-          $sums = $null
-          foreach ($attempt in 1..10) {
+          # fires the moment the release is created — while assets are
+          # still uploading. v0.10.2 hit this: SHA256SUMS returned 200
+          # at the URL but the windows-amd64 entry hadn't landed in it
+          # yet (upload race / CDN), and the resolve step bailed with
+          # "checksum for ... not found in SHA256SUMS".
+          #
+          # Poll the release's asset LIST via the GitHub API (which is
+          # authoritative — it lists assets only once fully uploaded)
+          # and only proceed when BOTH SHA256SUMS and the windows zip
+          # are present. Then fetch SHA256SUMS once and grep it.
+          $apiUrl = "https://api.github.com/repos/Galvill/jitenv/releases/tags/$tag"
+          $ready = $false
+          foreach ($attempt in 1..15) {
             try {
-              $sums = (Invoke-WebRequest -Uri "$base/SHA256SUMS" -UseBasicParsing).Content
-              break
+              $assetsResp = Invoke-WebRequest -Uri $apiUrl -UseBasicParsing -Headers @{ 'Accept' = 'application/vnd.github+json' }
+              $names = (($assetsResp.Content | ConvertFrom-Json).assets | ForEach-Object { $_.name })
+              if (($names -contains 'SHA256SUMS') -and ($names -contains $zip)) {
+                $ready = $true
+                break
+              }
+              $missing = (@('SHA256SUMS', $zip) | Where-Object { $names -notcontains $_ }) -join ', '
+              Write-Host "Release assets not yet complete (attempt $attempt) — missing: $missing"
             } catch {
-              Write-Host "SHA256SUMS not ready (attempt $attempt): $($_.Exception.Message)"
-              Start-Sleep -Seconds (5 * $attempt)
+              Write-Host "Asset list fetch failed (attempt $attempt): $($_.Exception.Message)"
             }
+            Start-Sleep -Seconds ([Math]::Min(5 * $attempt, 30))
           }
-          if (-not $sums) { throw "SHA256SUMS asset never became available for $tag" }
+          if (-not $ready) {
+            throw "Release $tag never exposed both SHA256SUMS and $zip in its asset list"
+          }
 
+          $sums = (Invoke-WebRequest -Uri "$base/SHA256SUMS" -UseBasicParsing).Content
           $line = ($sums -split "`n") |
             Where-Object { $_ -match [regex]::Escape($zip) } |
             Select-Object -First 1
-          if (-not $line) { throw "checksum for $zip not found in SHA256SUMS" }
+          if (-not $line) {
+            # Asset list said the zip exists; if SHA256SUMS now lacks it,
+            # surface the file contents to make the next debug fast.
+            Write-Host "SHA256SUMS content:"
+            Write-Host $sums
+            throw "checksum for $zip not found in SHA256SUMS (asset listed but not in checksum file)"
+          }
           $checksum = ($line -split '\s+')[0]
           if ($checksum -notmatch '^[0-9a-fA-F]{64}$') {
             throw "parsed checksum '$checksum' is not a SHA256 hex digest"


### PR DESCRIPTION
## What broke
The v0.10.2 chocolatey publish failed at the **resolve step** with:

```
SHA256SUMS not ready (attempt 1..6): 404 Not Found
[attempt 7 succeeded — got a 200]
checksum for jitenv_0.10.2_windows_amd64.zip not found in SHA256SUMS
```

SHA256SUMS at that URL is **now** complete and contains the windows entry. So between attempt 7 returning 200 and my regex grep, the file's *content* didn't yet reflect the full upload — i.e. the release was non-draft and `release: published` had fired while goreleaser was still mid-upload, and the SHA256SUMS the asset URL served was a transient/CDN-cached partial version.

## Fix
Replace the "retry until SHA256SUMS URL returns 200" loop with **"poll the release's asset list via the GitHub API until both `SHA256SUMS` AND `jitenv_<v>_windows_amd64.zip` are listed"** — the API only lists assets once they're fully uploaded, so it's authoritative for "is the release done uploading?". Once both are present we fetch SHA256SUMS once and grep it.

Defensive: if SHA256SUMS *still* lacks the zip entry after the API said it's listed, dump the file contents to the log so the next debug is one read away.

Same retry-budget shape (15 attempts, sleeps capped at 30s ≈ ~5 min worst case) — comfortably covers goreleaser's sequential asset upload.

## Test plan
- [x] `actionlint` clean
- [x] `yaml` valid
- [ ] Next stable release: chocolatey.yml proceeds past resolve and packs/pushes (or pacs+uploads artifact if `CHOCOLATEY_API_KEY` isn't set)

Doesn't change `release.yml`, `macos-release.yml`, or any goreleaser config.