### PR TITLE
fix(release): raise macOS notarization wait to 120m (#13)

### DIFF
--- a/packaging/macos/sign-notarize.sh
+++ b/packaging/macos/sign-notarize.sh
@@ -71,19 +71,21 @@ zip="$workdir/$(basename "$BIN").zip"
 # notarytool accepts.
 ditto -c -k "$BIN" "$zip"
 
-# --wait blocks until Apple finishes. Notarization time is variable —
-# usually a few minutes, but Apple's service routinely exceeds 20m
-# during backlogs (a 20m cap timed out a real v0.10.0 release with the
-# submission still "In Progress"). 45m comfortably covers slow periods
-# while staying well under the GitHub job timeout; the build hooks run
-# concurrently so wall-clock is ~the slowest single submission, not the
-# sum. A timeout here fails the release loudly rather than shipping an
-# un-notarized binary.
+# --wait blocks until Apple finishes. Notarization time is highly
+# variable — the smaller jitenv-tui binary completes in ~25 min while
+# the larger jitenv binary has been observed still "In Progress" past
+# 45m (v0.10.2 timed out both jitenv targets at the previous cap).
+# 120m gives plenty of headroom; goreleaser runs the hooks with bounded
+# concurrency, so worst-case wall-clock is ~2 rounds × 120m = 4h,
+# inside the 6h default GitHub job timeout. Since macos-release.yml is
+# decoupled from the main release (#212), a long mac run no longer
+# blocks lin/win/choco. A real timeout here fails the cask publish
+# loudly rather than shipping an un-notarized binary.
 xcrun notarytool submit "$zip" \
   --key "$MACOS_NOTARY_KEY_FILE" \
   --key-id "$MACOS_NOTARY_KEY_ID" \
   --issuer "$MACOS_NOTARY_ISSUER_ID" \
   --wait \
-  --timeout 45m
+  --timeout 120m
 
 echo "sign-notarize: done $BIN"


### PR DESCRIPTION
## v0.10.2 mac log made the variance clear
First fully-decoupled mac run, four parallel notarizations:

| Binary | Outcome | Time |
|---|---|---|
| `jitenv-tui` darwin amd64 | **Accepted** ✓ | ~27 min |
| `jitenv` darwin amd64 | **Timed out** ✗ | 45 min (still "In Progress") |
| `jitenv` darwin arm64 | **Timed out** ✗ | 45 min (still "In Progress") |
| `jitenv-tui` darwin arm64 | **Accepted** ✓ | ~27 min (started after #1 finished) |

The smaller `jitenv-tui` binary completes well inside 30 min; the larger `jitenv` binary (agent + crypto + IPC + sources) has been observed still `In Progress` past 45m. Apple's notarization scanner takes meaningfully longer on it.

## Fix
Bump `notarytool --wait --timeout` from **45m → 120m** in `packaging/macos/sign-notarize.sh`. Comfortably covers the slower binary even on slow service days. goreleaser runs build hooks with bounded concurrency (~3 at a time on macos-latest), so worst-case wall-clock is ~2 rounds × 120m = 4h — inside the 6h default GitHub job timeout. Because `macos-release.yml` is decoupled from the main release (#212), a long mac run no longer blocks lin/win/choco artifacts.

## Test plan
- [x] `bash -n` clean
- [ ] Re-run `macos-release.yml` on `v0.10.2` via `workflow_dispatch` after merge — should clear all four binaries within the new cap

After merge, easiest verification is a manual `workflow_dispatch` of `macos-release.yml` on tag `v0.10.2` (it'll rebuild + re-sign + re-notarize + upload darwin tarballs + push the cask, no need to re-cut the release).