### PR TITLE
feat(release): make macOS notarization timeout overridable via repo variable (#13)

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -122,6 +122,11 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          # Repo variable (Settings -> Variables -> Actions), NOT a
+          # secret — overridable per-run without a code change so we
+          # can retry with a longer wait when Apple's queue is slow.
+          # sign-notarize.sh defaults to 120m if this is unset.
+          MACOS_NOTARY_TIMEOUT: ${{ vars.MACOS_NOTARY_TIMEOUT }}
 
       - name: Upload darwin artifacts to the GitHub release
         env:

--- a/packaging/macos/sign-notarize.sh
+++ b/packaging/macos/sign-notarize.sh
@@ -24,6 +24,13 @@
 #   MACOS_NOTARY_KEY_ID     the API key ID
 #   MACOS_NOTARY_ISSUER_ID  the issuer UUID
 #
+# Optional:
+#   MACOS_NOTARY_TIMEOUT    notarytool --timeout value (e.g. "60m",
+#                           "3h"). Default "120m". Wired to the repo
+#                           variable of the same name by
+#                           macos-release.yml so the cap can be
+#                           bumped per-run without a code change.
+#
 # Bare CLI binaries (Mach-O, not .app/.pkg/.dmg) cannot be stapled, so
 # we don't staple — Gatekeeper verifies the notarization online on
 # first run. That's why the Homebrew cask no longer strips the
@@ -74,18 +81,23 @@ ditto -c -k "$BIN" "$zip"
 # --wait blocks until Apple finishes. Notarization time is highly
 # variable — the smaller jitenv-tui binary completes in ~25 min while
 # the larger jitenv binary has been observed still "In Progress" past
-# 45m (v0.10.2 timed out both jitenv targets at the previous cap).
-# 120m gives plenty of headroom; goreleaser runs the hooks with bounded
-# concurrency, so worst-case wall-clock is ~2 rounds × 120m = 4h,
-# inside the 6h default GitHub job timeout. Since macos-release.yml is
+# 45m. The cap is overridable at runtime via the MACOS_NOTARY_TIMEOUT
+# env var (set as a repo variable on macos-release.yml — see the
+# workflow), defaulting to 120m so it just works without configuration.
+# Bumping the var lets you retry a release with a longer wait without
+# a code change. Goreleaser runs the hooks with bounded concurrency,
+# so worst-case wall-clock is ~2 rounds × this value; pick something
+# inside GitHub's default 6h job timeout. Since macos-release.yml is
 # decoupled from the main release (#212), a long mac run no longer
 # blocks lin/win/choco. A real timeout here fails the cask publish
 # loudly rather than shipping an un-notarized binary.
+notary_timeout="${MACOS_NOTARY_TIMEOUT:-120m}"
+echo "sign-notarize: notarytool --timeout $notary_timeout"
 xcrun notarytool submit "$zip" \
   --key "$MACOS_NOTARY_KEY_FILE" \
   --key-id "$MACOS_NOTARY_KEY_ID" \
   --issuer "$MACOS_NOTARY_ISSUER_ID" \
   --wait \
-  --timeout 120m
+  --timeout "$notary_timeout"
 
 echo "sign-notarize: done $BIN"


### PR DESCRIPTION
## Why
`notarytool --timeout` was hardcoded at 120m, so retrying a stuck release with a longer wait meant another code change + PR + merge. With Apple's notarization latency being so variable, you want to bump the cap from the GitHub UI and just re-dispatch.

## What
Read the cap from a new env var `MACOS_NOTARY_TIMEOUT`, defaulting to `120m` when unset, wired to a GitHub **repo variable** (NOT a secret — `Settings → Secrets and variables → Actions → Variables` tab) into `macos-release.yml`'s goreleaser step env. `sign-notarize.sh` reads it.

- **`packaging/macos/sign-notarize.sh`** — `--timeout "${MACOS_NOTARY_TIMEOUT:-120m}"`; the script also logs which value is being used. Documented in the script's env-vars comment block.
- **`.github/workflows/macos-release.yml`** — adds `MACOS_NOTARY_TIMEOUT: ${{ vars.MACOS_NOTARY_TIMEOUT }}` to the Run-GoReleaser env. Unset variable → empty string → script's `120m` default kicks in.

## To retry with a different cap after merge
1. Repo → Settings → Secrets and variables → Actions → **Variables** tab → New repository variable → name `MACOS_NOTARY_TIMEOUT`, value e.g. `3h`.
2. Actions → `macos-release` → Run workflow → pick a tag (e.g. `v0.10.2`).

No commit, no PR, no re-tag.

## Test plan
- [x] `bash -n` clean on the script
- [x] `actionlint` clean on the workflow
- [x] Default branch verified locally — script prints `120m` when `MACOS_NOTARY_TIMEOUT` unset, `3h` when set
- [x] Real `workflow_dispatch` run after merge (with a `vars.MACOS_NOTARY_TIMEOUT` set in repo settings) — confirm the value flows through to `notarytool --timeout`

## Compatible with the inflight diagnostic
Doesn't change anything about the four pending submissions you're checking via `xcrun notarytool info` locally — that diagnosis stands. Once we know whether those `jitenv` submissions eventually went Accepted (would have needed a bigger cap) or Invalid (real binary issue), this PR is the right knob for the former.