### PR TITLE
fix(release): set explicit cask url_template for the darwin config (#13)

### DIFF
--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -118,6 +118,16 @@ homebrew_casks:
     homepage: https://github.com/Galvill/jitenv
     description: Just-in-time env-var injection from pluggable secret sources, scoped to per-command process trees
     skip_upload: auto
+    # Explicit tarball URL — goreleaser normally derives this from the
+    # `release:` block, but we set `release.disable: true` above (the
+    # mac workflow uploads assets manually to the GH release that
+    # release.yml already created), and goreleaser refuses to render
+    # the cask without a fallback URL: "release is disabled, cannot
+    # use default url_template". Same shape as the auto-derived URL
+    # the main config used to emit, so the cask download URL is
+    # unchanged for end users.
+    url:
+      template: "https://github.com/Galvill/jitenv/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     binaries:
       - jitenv
       - jitenv-tui


### PR DESCRIPTION
## Why
v0.11.0's `macos-release.yml` ran for ~55 min and **notarized all four darwin binaries successfully** — the 120m / 5d timeout was nowhere near being touched. The actual failure was at the very next step:

```
release failed after 54m50s    error=release is disabled, cannot use default url_template
```

`.goreleaser.darwin.yaml` sets `release.disable: true` so goreleaser doesn't touch the GH release (the workflow uploads darwin tarballs to it manually). But the `homebrew_casks:` pipe derives the cask's tarball download URL from the release config by default, and refuses to render when the release pipe is disabled.

## Fix
Explicit `url.template` in the cask block — same shape the default would have produced:

```yaml
url:
  template: "https://github.com/Galvill/jitenv/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
```

End-user cask URLs are **unchanged**.

## Test plan
- [x] `goreleaser check --config .goreleaser.darwin.yaml` passes
- [x] `goreleaser release --snapshot --clean --skip=sign,publish --config .goreleaser.darwin.yaml` writes `dist/homebrew/Casks/jitenv.rb` with both arch `url`/`sha256` lines correctly populated
- [ ] Re-run `macos-release.yml` on `v0.11.0` via `workflow_dispatch` after merge — should now publish the darwin tarballs + push the cask cleanly

## After merge
The `v0.11.0` tag/release already exist (the main release published lin/win + chocolatey ran). Only the darwin tarballs + cask are missing. I'll trigger `macos-release.yml` against `v0.11.0` via `workflow_dispatch` once this lands — no re-cut needed. With Apple's slowness the day of, the run will likely take ~50–60 min again, but it'll finish properly.