### PR TITLE
fix(hook): keep wrap dir at the front of PATH across later prepends (#224)

### DIFF
--- a/internal/shell/hook_path_shim_first_test.go
+++ b/internal/shell/hook_path_shim_first_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-// TestHookKeepsWrapDirFirstAfterLaterPrepend regresses #223: Ubuntu's
+// TestHookKeepsWrapDirFirstAfterLaterPrepend regresses #224: Ubuntu's
 // stock ~/.profile sources ~/.bashrc (which loads the hook → wrap dir
 // prepended) and THEN prepends ~/.local/bin to PATH. The result is
 // wrap dir at position 2 with .local/bin at position 1, so any real

--- a/internal/shell/hook_path_shim_first_test.go
+++ b/internal/shell/hook_path_shim_first_test.go
@@ -1,0 +1,91 @@
+//go:build !windows
+
+package shell_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestHookKeepsWrapDirFirstAfterLaterPrepend regresses #223: Ubuntu's
+// stock ~/.profile sources ~/.bashrc (which loads the hook → wrap dir
+// prepended) and THEN prepends ~/.local/bin to PATH. The result is
+// wrap dir at position 2 with .local/bin at position 1, so any real
+// binary in .local/bin (terraform, kubectl, ...) silently masks the
+// wrapper symlink and secrets never get injected.
+//
+// The hook ensures the wrap dir stays first on every PROMPT_COMMAND
+// fire via __jitenv_ensure_path. This test simulates one prompt cycle
+// after a later prepend and asserts PATH order is restored.
+func TestHookKeepsWrapDirFirstAfterLaterPrepend(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	binDir := strings.TrimSuffix(bin, "/jitenv")
+
+	// Sequence:
+	//   1. Source the hook → wrap dir prepended.
+	//   2. Mimic Ubuntu .profile: PATH="$HOME/.local/bin:$PATH".
+	//   3. Run __jitenv_chpwd (PROMPT_COMMAND fires it before every
+	//      prompt) → wrap dir must end up first again.
+	script := strings.Join([]string{
+		`eval "$(jitenv hook bash)"`,
+		`PATH="$HOME/.local/bin:$PATH"`,
+		`__jitenv_chpwd`,
+		`printf 'FIRST=%s\n' "${PATH%%:*}"`,
+		`printf 'WRAP=%s\n' "$__JITENV_WRAP_DIR"`,
+	}, "; ")
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = []string{
+		"PATH=" + binDir + ":/usr/bin:/bin",
+		"HOME=" + t.TempDir(),
+		"XDG_RUNTIME_DIR=" + t.TempDir(),
+		"TMPDIR=/tmp",
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash -c: %v\noutput=%s", err, out)
+	}
+
+	var first, wrap string
+	for _, ln := range strings.Split(string(out), "\n") {
+		switch {
+		case strings.HasPrefix(ln, "FIRST="):
+			first = strings.TrimPrefix(ln, "FIRST=")
+		case strings.HasPrefix(ln, "WRAP="):
+			wrap = strings.TrimPrefix(ln, "WRAP=")
+		}
+	}
+	if wrap == "" {
+		t.Fatalf("hook didn't set __JITENV_WRAP_DIR\nfull output: %s", out)
+	}
+	if first != wrap {
+		t.Fatalf("after a later PATH prepend, the wrap dir is not first:\n"+
+			"  first PATH entry = %q\n"+
+			"  wrap dir         = %q\n"+
+			"full output: %s", first, wrap, out)
+	}
+
+	// Sanity: the wrap dir should appear EXACTLY once — the
+	// ensure_path function should de-dupe rather than accumulate.
+	pathCountScript := strings.Join([]string{
+		`eval "$(jitenv hook bash)"`,
+		`PATH="$HOME/.local/bin:$PATH"`,
+		`__jitenv_chpwd`,
+		`__jitenv_chpwd`,
+		`__jitenv_chpwd`,
+		`printf 'COUNT=%s\n' "$(awk -v RS=: -v wrap="$__JITENV_WRAP_DIR" '$0==wrap{c++} END{print c+0}' <<<"$PATH")"`,
+	}, "; ")
+	cmd2 := exec.Command("bash", "-c", pathCountScript)
+	cmd2.Env = cmd.Env
+	out2, err := cmd2.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dedup check: %v\noutput=%s", err, out2)
+	}
+	if !strings.Contains(string(out2), "COUNT=1\n") {
+		t.Errorf("wrap dir should appear exactly once after multiple chpwd calls; output:\n%s", out2)
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -43,7 +43,7 @@ export __JITENV_SHELL_PID=$$
 # wrapper symlink with a real binary of the same name. Concrete
 # repro: Ubuntu's stock ~/.profile sources ~/.bashrc (running the
 # hook → shim dir prepended) and THEN prepends ~/.local/bin (issue
-# #223). A real `~/.local/bin/terraform` would otherwise win over our
+# #224). A real `~/.local/bin/terraform` would otherwise win over our
 # symlinked wrapper and secrets would silently not get injected.
 __jitenv_ensure_path() {
     case ":$PATH:" in
@@ -78,7 +78,7 @@ __jitenv_cfg_path() {
 __jitenv_chpwd() {
     # Keep the wrap dir at the front of PATH even if a downstream
     # startup file (e.g. ~/.profile's `~/.local/bin` prepend) shoved
-    # it back (#223).
+    # it back (#224).
     __jitenv_ensure_path
     # No 2>/dev/null on purpose: the chpwd subcommand is silent
     # in normal operation (it only writes to stderr when

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -37,10 +37,24 @@ export __JITENV_SHELL_PID=$$
 # ownership check (security #117). A subshell with umask 077 makes
 # every intermediate land at 0700.
 (umask 077 && mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null)
-case ":$PATH:" in
-    *":$__JITENV_WRAP_DIR:"*) : ;;
-    *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;
-esac
+
+# Ensure the wrap dir sits at the FRONT of PATH. Re-run from
+# __jitenv_chpwd below so any later PATH prepend can't silently mask a
+# wrapper symlink with a real binary of the same name. Concrete
+# repro: Ubuntu's stock ~/.profile sources ~/.bashrc (running the
+# hook → shim dir prepended) and THEN prepends ~/.local/bin (issue
+# #223). A real `~/.local/bin/terraform` would otherwise win over our
+# symlinked wrapper and secrets would silently not get injected.
+__jitenv_ensure_path() {
+    case ":$PATH:" in
+        ":$__JITENV_WRAP_DIR:"*) return 0 ;;
+    esac
+    local p=":$PATH:"
+    p="${p//:$__JITENV_WRAP_DIR:/:}"
+    p="${p#:}"; p="${p%:}"
+    export PATH="$__JITENV_WRAP_DIR:$p"
+}
+__jitenv_ensure_path
 
 # Tiny per-shell $JITENV_CONFIG override so users can re-point one
 # shell at a different config without re-sourcing the hook. The
@@ -62,6 +76,10 @@ __jitenv_cfg_path() {
 # do. Keeping the state in Go means a fresh `eval "$(jitenv hook bash)"`
 # doesn't cause a spurious reconcile.
 __jitenv_chpwd() {
+    # Keep the wrap dir at the front of PATH even if a downstream
+    # startup file (e.g. ~/.profile's `~/.local/bin` prepend) shoved
+    # it back (#223).
+    __jitenv_ensure_path
     # No 2>/dev/null on purpose: the chpwd subcommand is silent
     # in normal operation (it only writes to stderr when
     # JITENV_HOOK_DEBUG is set). Swallowing stderr here would

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -34,7 +34,7 @@ export __JITENV_SHELL_PID=$$
 # Ensure the wrap dir sits at the FRONT of PATH. Re-run from
 # __jitenv_chpwd below so any later PATH prepend can't silently mask a
 # wrapper symlink with a real binary of the same name. See bash.sh
-# (#223) for the concrete Ubuntu-stock-~/.profile repro.
+# (#224) for the concrete Ubuntu-stock-~/.profile repro.
 __jitenv_ensure_path() {
     case ":$PATH:" in
         ":$__JITENV_WRAP_DIR:"*) return 0 ;;
@@ -67,7 +67,7 @@ __jitenv_cfg_path() {
 # hook doesn't cause a spurious reconcile.
 __jitenv_chpwd() {
     # Keep the wrap dir at the front of PATH even if a downstream
-    # startup file (e.g. ~/.zprofile prepends) shoved it back (#223).
+    # startup file (e.g. ~/.zprofile prepends) shoved it back (#224).
     __jitenv_ensure_path
     # No 2>/dev/null on purpose; see bash.sh for the rationale.
     jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -30,10 +30,21 @@ export __JITENV_SHELL_PID=$$
 # ownership check (security #117). A subshell with umask 077 makes
 # every intermediate land at 0700.
 (umask 077 && mkdir -p "$__JITENV_WRAP_DIR" 2>/dev/null)
-case ":$PATH:" in
-    *":$__JITENV_WRAP_DIR:"*) : ;;
-    *) export PATH="$__JITENV_WRAP_DIR:$PATH" ;;
-esac
+
+# Ensure the wrap dir sits at the FRONT of PATH. Re-run from
+# __jitenv_chpwd below so any later PATH prepend can't silently mask a
+# wrapper symlink with a real binary of the same name. See bash.sh
+# (#223) for the concrete Ubuntu-stock-~/.profile repro.
+__jitenv_ensure_path() {
+    case ":$PATH:" in
+        ":$__JITENV_WRAP_DIR:"*) return 0 ;;
+    esac
+    local p=":$PATH:"
+    p="${p//:$__JITENV_WRAP_DIR:/:}"
+    p="${p#:}"; p="${p%:}"
+    export PATH="$__JITENV_WRAP_DIR:$p"
+}
+__jitenv_ensure_path
 
 # Tiny per-shell $JITENV_CONFIG override so users can re-point one
 # shell at a different config without re-sourcing the hook. The
@@ -55,6 +66,9 @@ __jitenv_cfg_path() {
 # common case. Keeping the state in Go means a fresh re-source of the
 # hook doesn't cause a spurious reconcile.
 __jitenv_chpwd() {
+    # Keep the wrap dir at the front of PATH even if a downstream
+    # startup file (e.g. ~/.zprofile prepends) shoved it back (#223).
+    __jitenv_ensure_path
     # No 2>/dev/null on purpose; see bash.sh for the rationale.
     jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
     # Exit 10 means a wrapper was added or removed → rebuild zsh's


### PR DESCRIPTION
Closes #224

## Summary
A mapping for `terraform` showed the real binary winning over the wrapper symlink:

\`\`\`
$ which terraform
/home/gv/.local/bin/terraform                      # WRONG — should be the shim
$ which npm
/run/user/1000/jitenv/shells/<pid>/bin/npm          # OK
\`\`\`

The wrap dir DOES contain a `terraform` → `jitenv` symlink. The problem is PATH order: on stock Ubuntu, `~/.profile` sources `~/.bashrc` (running the hook → shim prepended) and THEN prepends `~/.local/bin`. Net result: `.local/bin:shim:rest`. Any binary present in both wins from `.local/bin`. npm/docker/go aren't in `.local/bin`, so the shim still wins for those — only commands that exist in both are affected.

## Fix
- Extract the PATH-ensure step into `__jitenv_ensure_path`. Returns early when the wrap dir is already first; otherwise removes every existing occurrence and re-prepends.
- Call it from `__jitenv_chpwd` (PROMPT_COMMAND on bash, precmd on zsh) so the order is restored before the next command runs.
- Same change in both `bash.sh` and `zsh.sh`.

## Test plan
- New regression test `TestHookKeepsWrapDirFirstAfterLaterPrepend` simulates the Ubuntu chain: source the hook, prepend `~/.local/bin`, fire `__jitenv_chpwd`, assert wrap dir is back at position 1. Also asserts no duplicate accumulation after three chpwd calls.
- Manual end-to-end repro with a real `terraform` binary in `~/.local/bin` confirms `which terraform` now resolves to the shim.
- `go test ./internal/shell/...` — the one pre-existing failure (`TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent`) reproduces on `main` and is unrelated to this change.
- `make fmt vet` — clean.

## Out of scope
`shell.loginFileSourcesBashrc` doesn't recognize the quoted `. "$HOME/.bashrc"` form Ubuntu's stock `.profile` uses, so the installer appends a redundant guarded `. ~/.bashrc` line at the bottom of `.profile`. That line is a no-op (hook guard short-circuits the re-source) so it doesn't cause this bug — noted in the issue body as a follow-up.