### PR TITLE
fix(chocolatey): read SHA256SUMS as text, not a byte[] (#227)

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Resolve version, archive URL, and checksum
         id: meta
         shell: pwsh
+        env:
+          # Used by `gh release download` below — GitHub Actions
+          # doesn't auto-inject GH_TOKEN into pwsh steps the way it
+          # does for bash via $GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $tag = $env:TAG
           if (-not $tag) { throw "no release tag available" }
@@ -97,7 +102,25 @@ jobs:
             throw "Release $tag never exposed both SHA256SUMS and $zip in its asset list"
           }
 
-          $sums = (Invoke-WebRequest -Uri "$base/SHA256SUMS" -UseBasicParsing).Content
+          # Don't use Invoke-WebRequest for the asset download (#227):
+          # GitHub serves release assets with
+          # `Content-Type: application/octet-stream`, and pwsh's
+          # `.Content` for that comes back as `byte[]`. Subsequent
+          # `-split "\n"` then stringifies the array as a stream of
+          # space-separated decimal byte values — no newlines in
+          # sight — so the grep for the zip's checksum line never
+          # matches and the script throws a misleading "asset listed
+          # but not in checksum file" error.
+          # `gh release download` writes raw asset bytes to a file we
+          # then read as utf8 text, sidestepping the content-type
+          # heuristic entirely.
+          $sumsFile = Join-Path $env:RUNNER_TEMP "SHA256SUMS"
+          if (Test-Path $sumsFile) { Remove-Item $sumsFile }
+          gh release download $tag --repo Galvill/jitenv --pattern SHA256SUMS --output $sumsFile
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path $sumsFile)) {
+            throw "gh release download SHA256SUMS failed (exit $LASTEXITCODE)"
+          }
+          $sums = Get-Content -Raw -Encoding utf8 $sumsFile
           $line = ($sums -split "`n") |
             Where-Object { $_ -match [regex]::Escape($zip) } |
             Select-Object -First 1


### PR DESCRIPTION
Closes #227

## Summary
The chocolatey workflow has failed on every non-prerelease tag (v0.10.0 → v0.12.0) at the same step with the same message, always after the asset-list poll converges:

```
checksum for jitenv_<version>_windows_amd64.zip not found in SHA256SUMS (asset listed but not in checksum file)
```

Root cause is not the CDN race the workflow comment blames — that race is already defended by the poll loop. The bug is in the line right after the poll:

```powershell
$sums = (Invoke-WebRequest -Uri "$base/SHA256SUMS" -UseBasicParsing).Content
```

GitHub serves release-asset downloads with `Content-Type: application/octet-stream`. PowerShell's `Invoke-WebRequest` returns `.Content` as `byte[]` for non-text content types. The subsequent `-split "`n"` stringifies the array as `"55 52 53 48 …"` (space-separated decimal byte values) — no newlines, no zip filename, no checksum match.

## Fix
Replace the IWR call with `gh release download --pattern SHA256SUMS --output <file>` + `Get-Content -Raw -Encoding utf8`. Writing raw asset bytes to disk and reading them back as text avoids the content-type heuristic. `gh` is already on every runner image. Step env gets `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` since pwsh steps don't pick up the auto-injected token bash gets.

## Test plan
- After merge, trigger via `workflow_dispatch` against v0.12.0 — the workflow supports this via the `inputs.tag` branch — to verify the chocolatey-nupkg artifact is produced.
- All four PR CI checks (build/test/lint, e2e, macos, windows) should remain green since this only touches a release-time workflow.

## Out of scope
The `Note when key absent` step at chocolatey.yml:174-178 will continue to warn-and-stop because `CHOCOLATEY_API_KEY` isn't configured — separate follow-up.