### PR TITLE
feat(tui): add file browser for picking mapping targets (#223)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-jose/go-jose/v4 v4.1.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/internal/tui/file_picker_screen.go
+++ b/internal/tui/file_picker_screen.go
@@ -1,0 +1,184 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/filepicker"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// filePickerScreen is the file-browser popup launched from the mapping
+// target input (#223). The user navigates the filesystem with the
+// standard hjkl/arrow keys, hits enter to commit the highlighted item,
+// or esc to cancel.
+//
+// On commit the screen emits a tea.Sequence(popMsg{}, pathPickedMsg{})
+// — popMsg first so the picker is off the stack by the time the
+// pathPickedMsg reaches inputScreen.Update, which uses it to fill the
+// textinput field.
+//
+// The picker is mode-aware: pickFile lets the user select files
+// (directories navigate-in only), pickDir lets the user select
+// directories (files are visible but not selectable). The mapping
+// kind drives which mode is requested:
+//   - path  → pickFile
+//   - glob  → pickDir (the user picks a directory; doublestar tail is
+//     appended in the input field if they want a recursive match)
+//   - cwd   → pickDir
+type pickerMode int
+
+const (
+	pickFile pickerMode = iota
+	pickDir
+)
+
+// pathPickedMsg is emitted by filePickerScreen when the user selects
+// a path. The receiving screen (inputScreen) uses it to populate its
+// textinput. A nil/empty path is treated as cancel and shouldn't be
+// emitted — callers must guard.
+type pathPickedMsg struct{ path string }
+
+type filePickerScreen struct {
+	root   *rootModel
+	fp     filepicker.Model
+	mode   pickerMode
+	prompt string
+}
+
+func newFilePickerScreen(r *rootModel, mode pickerMode, startDir string) *filePickerScreen {
+	fp := filepicker.New()
+	fp.AutoHeight = false
+	fp.SetHeight(15)
+	fp.CurrentDirectory = startDir
+	fp.ShowHidden = false
+	switch mode {
+	case pickDir:
+		fp.FileAllowed = false
+		fp.DirAllowed = true
+	default:
+		fp.FileAllowed = true
+		fp.DirAllowed = false
+	}
+	// Free esc for "cancel picker" at the screen level. The default
+	// Back binding includes esc; without this override esc would
+	// just walk up one directory rather than closing the popup,
+	// which is the UX users expect.
+	fp.KeyMap.Back = key.NewBinding(key.WithKeys("h", "left", "backspace"))
+
+	prompt := "Navigate with arrow keys / hjkl, enter to pick, esc to cancel. Press . to toggle hidden files."
+	if mode == pickDir {
+		prompt = "Navigate into a directory to pick it. Arrow keys / hjkl, enter to pick, esc to cancel. Press . to toggle hidden files."
+	}
+	return &filePickerScreen{root: r, fp: fp, mode: mode, prompt: prompt}
+}
+
+func (s *filePickerScreen) Title() string {
+	if s.mode == pickDir {
+		return "pick a directory"
+	}
+	return "pick a file"
+}
+
+func (s *filePickerScreen) Status() string { return defaultFormStatus }
+
+func (s *filePickerScreen) Init() tea.Cmd { return s.fp.Init() }
+
+func (s *filePickerScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		switch k.String() {
+		case "esc":
+			return s, emit(popMsg{})
+		case ".":
+			s.fp.ShowHidden = !s.fp.ShowHidden
+			return s, s.fp.Init()
+		}
+	}
+	var cmd tea.Cmd
+	s.fp, cmd = s.fp.Update(msg)
+	if didSelect, path := s.fp.DidSelectFile(msg); didSelect {
+		return s, tea.Sequence(emit(popMsg{}), emit(pathPickedMsg{path: path}))
+	}
+	return s, cmd
+}
+
+func (s *filePickerScreen) View() string {
+	var b strings.Builder
+	if s.prompt != "" {
+		b.WriteString(dimText(s.prompt) + "\n\n")
+	}
+	b.WriteString(s.fp.View())
+	return b.String()
+}
+
+// pickerStartDir derives a sensible starting directory for the
+// picker from the current text-input value. Tilde-relative paths are
+// expanded so the picker has an absolute path to chdir into. When the
+// derived path doesn't exist (or is empty), it falls back to $HOME.
+//
+// For glob/cwd inputs, the static prefix before any glob metacharacter
+// is used — e.g. "~/work/**/*.sh" → "~/work" → "/home/me/work".
+func pickerStartDir(currentVal string) string {
+	v := strings.TrimSpace(currentVal)
+	v = staticPrefix(v)
+	if v == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return "."
+	}
+	if strings.HasPrefix(v, "~") {
+		if home, err := os.UserHomeDir(); err == nil {
+			v = home + strings.TrimPrefix(v, "~")
+		}
+	}
+	// If v points at a file, start in its parent directory.
+	if info, err := os.Stat(v); err == nil {
+		if info.IsDir() {
+			return v
+		}
+		return filepath.Dir(v)
+	}
+	// v doesn't exist — walk up until we find a real dir, so the
+	// picker doesn't choke on a half-typed path.
+	for {
+		parent := filepath.Dir(v)
+		if parent == v {
+			break
+		}
+		if info, err := os.Stat(parent); err == nil && info.IsDir() {
+			return parent
+		}
+		v = parent
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return home
+	}
+	return "."
+}
+
+// staticPrefix returns the portion of pattern before the first glob
+// metacharacter. Mirrors how doublestar treats a pattern when looking
+// for its root directory.
+func staticPrefix(pattern string) string {
+	cut := len(pattern)
+	for i, r := range pattern {
+		switch r {
+		case '*', '?', '[':
+			cut = i
+		}
+		if cut < len(pattern) {
+			break
+		}
+	}
+	if cut == len(pattern) {
+		return pattern
+	}
+	prefix := pattern[:cut]
+	if idx := strings.LastIndex(prefix, "/"); idx >= 0 {
+		return prefix[:idx]
+	}
+	return ""
+}

--- a/internal/tui/file_picker_screen.go
+++ b/internal/tui/file_picker_screen.go
@@ -177,7 +177,11 @@ func staticPrefix(pattern string) string {
 		return pattern
 	}
 	prefix := pattern[:cut]
-	if idx := strings.LastIndex(prefix, "/"); idx >= 0 {
+	// Accept either path separator: jitenv normalises mapping
+	// patterns to `/` but a Windows user may paste a native path
+	// like C:\Users\…\**\*.sh straight from explorer, and the test
+	// fixture uses filepath.Join which produces `\` on windows.
+	if idx := strings.LastIndexAny(prefix, "/\\"); idx >= 0 {
 		return prefix[:idx]
 	}
 	return ""

--- a/internal/tui/file_picker_screen_test.go
+++ b/internal/tui/file_picker_screen_test.go
@@ -1,0 +1,164 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// findFilePicker is the picker-screen analogue of findInputScreen —
+// returns the most recently pushed filePickerScreen out of a drained
+// message stream.
+func findFilePicker(msgs []tea.Msg) *filePickerScreen {
+	for _, m := range msgs {
+		if pm, ok := m.(pushMsg); ok {
+			if fp, ok := pm.s.(*filePickerScreen); ok {
+				return fp
+			}
+		}
+	}
+	return nil
+}
+
+func TestInputScreen_BrowseButtonPushesPicker(t *testing.T) {
+	r := &rootModel{}
+	var capturedCurrent string
+	is := newInputScreen(r, inputOpts{
+		Title:   "edit path",
+		Initial: "/some/initial",
+		Browse: func(current string) tea.Cmd {
+			capturedCurrent = current
+			return emit(pushMsg{s: newFilePickerScreen(r, pickFile, "/")})
+		},
+	}, nil)
+
+	// Buttons should now be [Browse, Apply, Back] in that order.
+	wantLabels := []string{"Browse", "Apply", "Back"}
+	gotLabels := make([]string, len(is.buttons))
+	for i, b := range is.buttons {
+		gotLabels[i] = b.label
+	}
+	if !reflect.DeepEqual(gotLabels, wantLabels) {
+		t.Fatalf("button labels: got %v, want %v", gotLabels, wantLabels)
+	}
+
+	// Tab to focus Browse, then Enter on it.
+	_, _ = is.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if is.btnFocus != 0 {
+		t.Fatalf("expected first tab to land on Browse (idx 0); got %d", is.btnFocus)
+	}
+	_, cmd := is.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	msgs := drainCmd(cmd)
+	if fp := findFilePicker(msgs); fp == nil {
+		t.Fatalf("Enter on Browse should have pushed a filePickerScreen; msgs=%+v", msgs)
+	}
+	if capturedCurrent != "/some/initial" {
+		t.Errorf("browse callback should receive current input value; got %q", capturedCurrent)
+	}
+}
+
+func TestInputScreen_CtrlOLaunchesPicker(t *testing.T) {
+	r := &rootModel{}
+	called := false
+	is := newInputScreen(r, inputOpts{
+		Initial: "/a",
+		Browse: func(current string) tea.Cmd {
+			called = true
+			return emit(pushMsg{s: newFilePickerScreen(r, pickFile, "/")})
+		},
+	}, nil)
+
+	_, cmd := is.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	if !called {
+		t.Fatalf("ctrl+o should invoke the Browse callback")
+	}
+	if findFilePicker(drainCmd(cmd)) == nil {
+		t.Errorf("ctrl+o should produce a filePickerScreen push")
+	}
+}
+
+func TestInputScreen_PathPickedMsgFillsField(t *testing.T) {
+	r := &rootModel{}
+	is := newInputScreen(r, inputOpts{
+		Initial: "old/value",
+		Browse:  func(_ string) tea.Cmd { return nil },
+	}, nil)
+
+	// Simulate the message the picker emits on commit.
+	_, _ = is.Update(pathPickedMsg{path: "/picked/path.sh"})
+	if got := is.input.Value(); got != "/picked/path.sh" {
+		t.Errorf("textinput value after pathPickedMsg: got %q, want %q", got, "/picked/path.sh")
+	}
+}
+
+func TestInputScreen_PathPickedEmptyIsCancel(t *testing.T) {
+	r := &rootModel{}
+	is := newInputScreen(r, inputOpts{Initial: "keep-me"}, nil)
+	_, _ = is.Update(pathPickedMsg{path: ""})
+	if got := is.input.Value(); got != "keep-me" {
+		t.Errorf("empty pathPickedMsg should not overwrite; got %q", got)
+	}
+}
+
+func TestInputScreen_NoBrowseFunc_NoBrowseButton(t *testing.T) {
+	r := &rootModel{}
+	is := newInputScreen(r, inputOpts{Initial: "x"}, nil)
+	for _, b := range is.buttons {
+		if b.label == "Browse" {
+			t.Errorf("Browse button should not be present when inputOpts.Browse is nil")
+		}
+	}
+}
+
+func TestFilePicker_EscPops(t *testing.T) {
+	fp := newFilePickerScreen(&rootModel{}, pickFile, ".")
+	_, cmd := fp.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	msgs := drainCmd(cmd)
+	for _, m := range msgs {
+		if _, ok := m.(popMsg); ok {
+			return
+		}
+	}
+	t.Errorf("esc should produce a popMsg; got %+v", msgs)
+}
+
+func TestPickerStartDir_AbsoluteFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "x.sh")
+	if err := os.WriteFile(file, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := pickerStartDir(file); got != dir {
+		t.Errorf("file path should start the picker in its parent dir; got %q, want %q", got, dir)
+	}
+}
+
+func TestPickerStartDir_DirReturnsItself(t *testing.T) {
+	dir := t.TempDir()
+	if got := pickerStartDir(dir); got != dir {
+		t.Errorf("dir path should be the start dir as-is; got %q, want %q", got, dir)
+	}
+}
+
+func TestPickerStartDir_GlobUsesStaticPrefix(t *testing.T) {
+	// Use the tempdir directly so the static prefix lands on a real
+	// directory and the function doesn't fall back to $HOME.
+	dir := t.TempDir()
+	pattern := filepath.Join(dir, "**", "*.sh")
+	if got := pickerStartDir(pattern); got != dir {
+		t.Errorf("glob's static prefix should be the start dir; got %q, want %q", got, dir)
+	}
+}
+
+func TestPickerStartDir_EmptyFallsBackToHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	if got := pickerStartDir(""); got != home {
+		t.Errorf("empty value should fall back to home; got %q, want %q", got, home)
+	}
+}

--- a/internal/tui/input_screen.go
+++ b/internal/tui/input_screen.go
@@ -20,6 +20,7 @@ type inputScreen struct {
 	masked    bool
 	allowBlnk bool
 	onCommit  func(string) tea.Cmd
+	browse    func(current string) tea.Cmd
 	err       string
 
 	btnFocus int // -1 = input focused; else button idx
@@ -36,6 +37,12 @@ type inputOpts struct {
 	AllowBlank  bool // when false, empty values produce an error
 	SaveLabel   string
 	CancelLabel string
+	// Browse, when non-nil, adds a `[ Browse ]` button (and a ctrl+o
+	// binding) to the screen. The callback receives the current
+	// textinput value and returns a tea.Cmd that should push a
+	// filePickerScreen — the picker emits a pathPickedMsg on commit
+	// which the inputScreen catches and uses to fill the field.
+	Browse func(current string) tea.Cmd
 }
 
 func newInputScreen(r *rootModel, opts inputOpts, onCommit func(string) tea.Cmd) *inputScreen {
@@ -64,6 +71,11 @@ func newInputScreen(r *rootModel, opts inputOpts, onCommit func(string) tea.Cmd)
 	if opts.Masked {
 		btns = append([]button{newButton("Reveal")}, btns...)
 	}
+	if opts.Browse != nil {
+		// Place Browse right before the save button so the focus
+		// order reads naturally left-to-right: [..., Browse, Apply, Back].
+		btns = append([]button{newButton("Browse")}, btns...)
+	}
 
 	return &inputScreen{
 		root:      r,
@@ -73,6 +85,7 @@ func newInputScreen(r *rootModel, opts inputOpts, onCommit func(string) tea.Cmd)
 		masked:    opts.Masked,
 		allowBlnk: opts.AllowBlank,
 		onCommit:  onCommit,
+		browse:    opts.Browse,
 		btnFocus:  -1,
 		buttons:   btns,
 	}
@@ -83,10 +96,25 @@ func (s *inputScreen) Status() string { return defaultFormStatus }
 func (s *inputScreen) Init() tea.Cmd  { return nil }
 
 func (s *inputScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	// pathPickedMsg comes from filePickerScreen via tea.Sequence
+	// after the picker pops itself, so it always reaches this screen
+	// after the picker is off the stack (#223).
+	if m, ok := msg.(pathPickedMsg); ok {
+		if m.path != "" {
+			s.input.SetValue(m.path)
+			s.input.CursorEnd()
+			s.err = ""
+		}
+		return s, nil
+	}
 	if k, ok := msg.(tea.KeyMsg); ok {
 		switch k.String() {
 		case "esc":
 			return s, emit(popMsg{})
+		case "ctrl+o":
+			if s.browse != nil {
+				return s, s.browse(s.input.Value())
+			}
 		case "tab":
 			if s.btnFocus < 0 {
 				s.btnFocus = 0
@@ -156,6 +184,11 @@ func (s *inputScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				return s, nil
 			case "Back", "Cancel":
 				return s, emit(popMsg{})
+			case "Browse":
+				if s.browse != nil {
+					return s, s.browse(s.input.Value())
+				}
+				return s, nil
 			default:
 				return s, s.commit()
 			}

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -495,9 +495,22 @@ func (s *mappingFormScreen) openTargetInput() tea.Cmd {
 		}
 		return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}))
 	}
+	// Picker mode follows the mapping kind: file pick for path,
+	// directory pick for glob/cwd. The picker is launched via the
+	// inputOpts.Browse callback (button or ctrl+o); the input field
+	// stays primary so typing a not-yet-existing path still works
+	// (#223).
+	pickerKind := pickFile
+	if kind == "glob" || kind == "cwd" {
+		pickerKind = pickDir
+	}
+	browse := func(current string) tea.Cmd {
+		return emit(pushMsg{s: newFilePickerScreen(s.root, pickerKind, pickerStartDir(current))})
+	}
 	return emit(pushMsg{s: newInputScreen(s.root, inputOpts{
 		Title: title, Prompt: prompt, Placeholder: ph, Initial: init,
 		SaveLabel: "Apply", CancelLabel: "Back",
+		Browse: browse,
 	}, commit)})
 }
 


### PR DESCRIPTION
Closes #223

## Summary
The mapping target row was typed-only: no completion, no file-existence hint, no way to pick from a directory listing. This adds an opt-in `[ Browse ]` button (and `ctrl+o` keybinding) on the target input screen that opens a file/directory picker.

## Design
- New `filePickerScreen` wraps `bubbles/filepicker` (already a transitive dep — only needed to add `dustin/go-humanize` to go.sum).
- The picker runs as a normal screen-stack entry: push to open, pop on commit or esc.
- On commit it emits `tea.Sequence(popMsg, pathPickedMsg{path})` so the picker is off the stack by the time `inputScreen.Update` catches the message and fills its textinput.
- Mode follows the mapping kind:
  - `path` → `pickFile` (files selectable, dirs navigate-in only)
  - `glob` / `cwd` → `pickDir` (directories selectable, files visible-only)
- `pickerStartDir` walks up from the current input value to a real directory (so half-typed paths don't crash the picker), uses the static prefix for globs (`~/work/**/*.sh` → `~/work`), and falls back to `$HOME` when empty.

## UX
- Typing a not-yet-existing path still works exactly as before — the picker is purely additive.
- `[ Browse ]` button sits left of `[ Apply ] [ Back ]`; `ctrl+o` works from any focus.
- `.` toggles hidden files (the codebase calls out the dotfile case in the issue).
- `esc` cancels the picker and pops back to the input with the value unchanged.

## Test plan
- New `internal/tui/file_picker_screen_test.go`: 10 tests covering button launch, ctrl+o launch, pathPickedMsg fills the field, empty path = no-op, no Browse button when callback is nil, esc pops, and the four pickerStartDir branches (file, dir, glob static prefix, empty → home).
- `go test ./internal/tui/...` — pass.
- `make fmt vet` — clean.
- One pre-existing flake (`TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent`) reproduces on main and is unrelated.

## Out of scope per the issue
- Fuzzy-find / fzf-style filtering.
- Browse affordance on other inputs (var keys, source params) — only the mapping target was in scope.