### PR TITLE
fix(finalize): pass --repo explicitly to gh release upload

### DIFF
--- a/.github/workflows/macos-release-finalize.yml
+++ b/.github/workflows/macos-release-finalize.yml
@@ -94,8 +94,13 @@ jobs:
         run: |
           set -euo pipefail
           version="${TAG#v}"
+          # cd into FINALIZE_WORK so the tarball glob expands locally,
+          # but the `cd` puts us outside the repo, so `gh` can't
+          # auto-detect which repository to upload to from the .git
+          # parent walk. Pass --repo explicitly.
           cd "$FINALIZE_WORK"
           gh release upload "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             jitenv_*_darwin_*.tar.gz \
             "jitenv_${version}_darwin_SHA256SUMS" \
             "jitenv_${version}_darwin_SHA256SUMS.sig" \


### PR DESCRIPTION
## Failure
The first real run of `macos-release-finalize.yml` (v0.13.0, run 26825683742) succeeded through cosign + download but failed at **Upload darwin artifacts to the GitHub release** with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

## Root cause
The Upload step does `cd "$FINALIZE_WORK"` so the tarball glob (`jitenv_*_darwin_*.tar.gz`) expands locally. But `$FINALIZE_WORK` is `/home/runner/work/_temp/finalize/` — no `.git` parent. `gh release upload` falls back to git autodetection to pick the repo and bails before the upload starts.

## Fix
Pass `--repo "$GITHUB_REPOSITORY"` so the upload is unambiguous regardless of cwd. Same shape as #220's explicit cask URL template — `gh`'s autodetection isn't reliable outside the checked-out tree.

## State of v0.13.0
The pending artifact (`darwin-notarize-pending-v0.13.0`) is still alive: the `Delete pending artifact` step has `if: success()`, so the failed upload didn't consume it. After this merges the next 15-min poll cycle will redispatch finalize automatically.