### PR TITLE
feat(agentwarn): inline unlock from the agent-down countdown (#232)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The bash/zsh snippets switch on the exit code of `jitenv is-mapped`:
 - **1** → not mapped, run normally.
 - **2** → config unreadable. Run normally — no env injection, no warning. Treated like an unmapped path; only `JITENV_HOOK_DEBUG=1` reveals it.
 
-`jitenv is-mapped` reads the config directly and never contacts the agent, so exit 2 always means a missing/malformed `config.toml`, never an agent-down condition. The agent-down UX (red countdown, "Press Enter to skip, Ctrl+C to abort") lives in `internal/agentwarn/agentwarn.go` and only fires inside `jitenv run` / the cwd_glob shim — i.e. *after* `is-mapped` returned 0.
+`jitenv is-mapped` reads the config directly and never contacts the agent, so exit 2 always means a missing/malformed `config.toml`, never an agent-down condition. The agent-down UX (red countdown, "Press [u] to unlock and inject, [Enter] to continue without env, [Ctrl+C] to abort") lives in `internal/agentwarn/agentwarn.go` and only fires inside `jitenv run` / the cwd_glob shim — i.e. *after* `is-mapped` returned 0. `WarnAndWait` returns an `Action` (`ActionContinue` / `ActionAbort` / `ActionUnlock`); on `ActionUnlock` the caller drives `internal/unlock.Spawn` (passphrase prompt → background agent) and re-fetches env so the mapped command IS injected. `internal/unlock` exists as its own package to sidestep the import cycle (`internal/cli` already imports `internal/run` and `internal/shim`, so those cannot import `internal/cli`). The prompt is TTY-only and switches stdin to raw mode for the countdown so single keystrokes register without Enter.
 
 See `internal/cli/ismapped.go` for the exit-code contract and `bash.sh` for the dispatch.
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/creack/pty v1.1.24
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/hashicorp/vault/api/auth/approle v0.12.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEX
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/agentwarn/agentwarn.go
+++ b/internal/agentwarn/agentwarn.go
@@ -3,6 +3,8 @@
 //
 // During the countdown the user can:
 //
+//	u        → caller drops the countdown and runs the unlock flow,
+//	           then re-fetches env so the mapped command IS injected.
 //	wait     → caller proceeds with the parent environment.
 //	Enter    → caller proceeds immediately, no further wait.
 //	Ctrl+C   → caller aborts; nothing runs.
@@ -21,16 +23,36 @@ import (
 	"golang.org/x/term"
 )
 
-// WarnAndWait paints the warning + countdown to stderr and returns
-// true when the user aborted via Ctrl+C (caller should not exec).
-// Returns false on Enter or timeout (caller should exec, possibly
-// without injected env vars).
+// stdinIsTTY reports whether stdin is an interactive terminal. It's a
+// package var so tests can force the interactive path while feeding a
+// pipe (real PTY allocation needs a dependency the repo doesn't carry;
+// the keystroke-dispatch logic this gate guards is what's under test).
+var stdinIsTTY = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+
+// Action is the outcome of the agent-down countdown.
+type Action int
+
+const (
+	// ActionContinue: run the command without injected env (the user
+	// pressed Enter / any non-`u` key, or the countdown timed out).
+	ActionContinue Action = iota
+	// ActionAbort: the user pressed Ctrl+C; the caller must not exec.
+	ActionAbort
+	// ActionUnlock: the user pressed `u`; the caller should run the
+	// unlock flow and, on success, re-fetch env before exec.
+	ActionUnlock
+)
+
+// WarnAndWait paints the warning + countdown to stderr and reports the
+// user's choice as an Action.
 //
-// Skipped entirely when stdin is not a TTY: no human can press
-// Enter, so the countdown serves no purpose and only adds latency
-// to scripted / piped invocations. The warning line is still
-// printed once so the failure mode is visible in logs.
-func WarnAndWait(target string) bool {
+// Skipped entirely when stdin is not a TTY: no human can answer the
+// prompt, so the countdown serves no purpose and only adds latency to
+// scripted / piped invocations — it returns ActionContinue after
+// printing the warning line once so the failure mode stays visible in
+// logs. The inline-unlock option is likewise only offered on a TTY
+// (issue #232 out-of-scope note).
+func WarnAndWait(target string) Action {
 	const red = "\033[1;31m"
 	const reset = "\033[0m"
 
@@ -41,33 +63,55 @@ func WarnAndWait(target string) bool {
 		}
 	}
 
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
+	if !stdinIsTTY() {
 		fmt.Fprintf(os.Stderr,
 			"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
 			red, target, reset)
-		return false
+		return ActionContinue
 	}
 
 	fmt.Fprintf(os.Stderr,
 		"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
 		red, target, reset)
 	fmt.Fprintf(os.Stderr,
-		"%sWill run the command anyway in %ds. Press Enter to skip, Ctrl+C to abort.%s\n",
-		red, total, reset)
+		"%sPress [u] to unlock and inject, [Enter] to continue without env, [Ctrl+C] to abort.%s\n",
+		red, reset)
 
 	if total == 0 {
-		return false
+		return ActionContinue
 	}
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
 
-	// Drain stdin in a goroutine; signal on the first newline. We
-	// don't tear it down at return time: the caller is about to
-	// syscall.Exec, which replaces the process image and reaps the
-	// goroutine for free.
-	enterCh := make(chan struct{}, 1)
+	// Put stdin into raw mode for the countdown so a single keypress
+	// (`u`, Enter, Ctrl+C) is delivered immediately instead of being
+	// line-buffered until the user also hits Enter — the prompt offers
+	// single-key options, so cooked mode would make `u` feel broken.
+	// Restored before return so the subsequent passphrase prompt (which
+	// drives its own raw mode on /dev/tty) and the eventual exec inherit
+	// a sane terminal. In raw mode Ctrl+C arrives as the 0x03 byte
+	// rather than SIGINT, so the reader treats it as abort; the
+	// signal.Notify above remains a fallback for the non-raw path
+	// (e.g. when MakeRaw fails).
+	var restore func()
+	if oldState, err := term.MakeRaw(int(os.Stdin.Fd())); err == nil {
+		fd := int(os.Stdin.Fd())
+		restore = func() { _ = term.Restore(fd, oldState) }
+		defer restore()
+	}
+
+	// Drain stdin in a goroutine; report the first decisive keystroke.
+	// `u`/`U` → unlock, newline → continue, Ctrl+C (0x03) → abort. We
+	// don't tear it down at return time: on the continue/abort paths
+	// the caller is about to syscall.Exec (which replaces the process
+	// image and reaps the goroutine for free), and on the unlock path
+	// WarnAndWait returns before the passphrase prompt opens — the
+	// single outstanding Read has already consumed the keystroke, so it
+	// can't steal a byte from the subsequent term.ReadPassword on the
+	// same TTY.
+	keyCh := make(chan Action, 1)
 	go func() {
 		buf := make([]byte, 1)
 		for {
@@ -75,31 +119,58 @@ func WarnAndWait(target string) bool {
 			if err != nil || n == 0 {
 				return
 			}
-			if buf[0] == '\n' || buf[0] == '\r' {
+			switch buf[0] {
+			case 'u', 'U':
 				select {
-				case enterCh <- struct{}{}:
+				case keyCh <- ActionUnlock:
+				default:
+				}
+				return
+			case 0x03: // Ctrl+C in raw mode (no SIGINT is raised)
+				select {
+				case keyCh <- ActionAbort:
+				default:
+				}
+				return
+			case '\n', '\r':
+				select {
+				case keyCh <- ActionContinue:
 				default:
 				}
 				return
 			}
+			// Any other key: keep reading until a decisive keystroke,
+			// the countdown elapses, or stdin closes.
 		}
 	}()
 
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
 
+	// finish restores the terminal (so the trailing newline / any later
+	// prompt render on a cooked TTY) before returning the chosen action.
+	finish := func(act Action) Action {
+		if restore != nil {
+			restore()
+			restore = nil // the deferred call becomes a no-op
+		}
+		if act == ActionAbort {
+			fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
+		} else {
+			fmt.Fprintln(os.Stderr)
+		}
+		return act
+	}
+
 	for i := total; i > 0; i-- {
 		fmt.Fprintf(os.Stderr, "\r%s  %2ds remaining %s", red, i, reset)
 		select {
 		case <-sigCh:
-			fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
-			return true
-		case <-enterCh:
-			fmt.Fprintln(os.Stderr)
-			return false
+			return finish(ActionAbort)
+		case act := <-keyCh:
+			return finish(act)
 		case <-tick.C:
 		}
 	}
-	fmt.Fprintln(os.Stderr)
-	return false
+	return finish(ActionContinue)
 }

--- a/internal/agentwarn/agentwarn_test.go
+++ b/internal/agentwarn/agentwarn_test.go
@@ -27,13 +27,89 @@ func TestWarnAndWait_NonTTYReturnsImmediately(t *testing.T) {
 	t.Cleanup(func() { os.Stdin = prev })
 
 	start := time.Now()
-	aborted := WarnAndWait("/some/script.sh")
+	act := WarnAndWait("/some/script.sh")
 	elapsed := time.Since(start)
 
-	if aborted {
-		t.Fatal("expected aborted=false on the non-TTY skip path")
+	if act != ActionContinue {
+		t.Fatalf("expected ActionContinue on the non-TTY skip path, got %v", act)
 	}
 	if elapsed > time.Second {
 		t.Fatalf("non-TTY skip should be instant; took %s", elapsed)
 	}
+}
+
+// withStdin swaps os.Stdin for r and forces the interactive-TTY path
+// for the duration of the test, restoring both on cleanup. Real PTY
+// allocation would need a dependency the repo doesn't carry; forcing
+// stdinIsTTY lets us exercise the keystroke-dispatch loop with a pipe.
+func withStdin(t *testing.T, r *os.File) {
+	t.Helper()
+	prevStdin := os.Stdin
+	prevTTY := stdinIsTTY
+	os.Stdin = r
+	stdinIsTTY = func() bool { return true }
+	t.Cleanup(func() {
+		os.Stdin = prevStdin
+		stdinIsTTY = prevTTY
+	})
+}
+
+// TestWarnAndWait_UnlockKey: typing `u` returns ActionUnlock so the
+// caller can route into the inline-unlock flow (issue #232).
+func TestWarnAndWait_UnlockKey(t *testing.T) {
+	t.Setenv("JITENV_HOOK_DELAY", "10")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	withStdin(t, r)
+
+	if _, err := w.WriteString("u\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	done := make(chan Action, 1)
+	go func() { done <- WarnAndWait("/some/script.sh") }()
+
+	select {
+	case act := <-done:
+		if act != ActionUnlock {
+			t.Fatalf("expected ActionUnlock, got %v", act)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WarnAndWait did not return on `u` keystroke before the countdown elapsed")
+	}
+	w.Close()
+}
+
+// TestWarnAndWait_EnterKey: the newline keeps the legacy
+// "continue without env" behavior.
+func TestWarnAndWait_EnterKey(t *testing.T) {
+	t.Setenv("JITENV_HOOK_DELAY", "10")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	withStdin(t, r)
+
+	if _, err := w.WriteString("\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	done := make(chan Action, 1)
+	go func() { done <- WarnAndWait("/some/script.sh") }()
+
+	select {
+	case act := <-done:
+		if act != ActionContinue {
+			t.Fatalf("expected ActionContinue, got %v", act)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("WarnAndWait did not return on Enter before the countdown elapsed")
+	}
+	w.Close()
 }

--- a/internal/run/inline_unlock_e2e_test.go
+++ b/internal/run/inline_unlock_e2e_test.go
@@ -1,0 +1,166 @@
+//go:build !windows
+
+package run_test
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/creack/pty"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// TestRunInlineUnlock is the issue #232 e2e: a mapped command is run
+// while the agent is locked (no agent running). The agent-down
+// countdown is painted on a PTY; the test types `u`, then the
+// passphrase, which drives the inline unlock flow. The freshly
+// unlocked agent then answers the re-fetch and the script runs WITH
+// its injected env vars.
+//
+// PTY rationale: agentwarn.WarnAndWait only offers the prompt on a
+// TTY, and crypto.PromptPassphrase reads from /dev/tty (the PTY, once
+// it's the child's controlling terminal). Driving both through one
+// PTY mirrors the real interactive flow.
+func TestRunInlineUnlock(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	if err := os.WriteFile(scriptPath,
+		[]byte("#!/bin/sh\nprintf 'A=%s\\n' \"$A\"\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-inline-unlock")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// Disable the pre-run notice so the only injected-env signal we
+	// assert on is the script's own output.
+	off := false
+	cfg.Agent.PreRunNotice = &off
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"a": "from-agent"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: scriptPath, Vars: []config.VarRef{
+			{Name: "A", Source: "n", Ref: "a"},
+		}},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	// Empty runtime dir → no agent socket → run.go hits the agent-down
+	// countdown, which is where the inline-unlock prompt lives.
+	runtimeDir := shortRuntimeDir(t)
+
+	// TERM=dumb stops termenv (linked into the binary via the shared
+	// version-notice path) from emitting an OSC 11 + cursor-position
+	// query at startup and then blocking ~2s for a response the test
+	// PTY never sends. The agent-down warning and passphrase prompt use
+	// raw escapes / term.ReadPassword directly, so the flow is intact.
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_CONFIG="+cfgPath,
+		"JITENV_HOOK_DELAY=10",
+		"TERM=dumb",
+	)
+
+	cmd := exec.Command(bin, "run", scriptPath)
+	cmd.Env = subprocEnv
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty start: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = cmd.Process.Kill() }()
+
+	// Collect everything the child writes to the PTY for diagnostics.
+	var mu = make(chan string, 1)
+	mu <- ""
+	go func() {
+		buf := make([]byte, 4096)
+		acc := ""
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				acc += string(buf[:n])
+				<-mu
+				mu <- acc
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	readAll := func() string { s := <-mu; mu <- s; return s }
+
+	waitFor := func(substr string, d time.Duration) bool {
+		deadline := time.Now().Add(d)
+		for time.Now().Before(deadline) {
+			if strings.Contains(readAll(), substr) {
+				return true
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return false
+	}
+
+	if !waitFor("Press [u] to unlock", 5*time.Second) {
+		t.Fatalf("never saw the inline-unlock prompt;\noutput=%s", readAll())
+	}
+
+	// Type `u` to drop the countdown and enter the unlock flow.
+	if _, err := ptmx.Write([]byte("u")); err != nil {
+		t.Fatalf("write u: %v", err)
+	}
+
+	if !waitFor("unlock passphrase", 5*time.Second) {
+		t.Fatalf("never saw the passphrase prompt after `u`;\noutput=%s", readAll())
+	}
+
+	// Type the passphrase + newline.
+	if _, err := ptmx.Write(append(pw, '\n')); err != nil {
+		t.Fatalf("write passphrase: %v", err)
+	}
+
+	// The script should run with the injected env from the now-unlocked
+	// agent.
+	if !waitFor("A=from-agent", 10*time.Second) {
+		t.Fatalf("script did not run with injected env after inline unlock;\noutput=%s", readAll())
+	}
+
+	// Drain remaining output and let the process exit. Ignore the wait
+	// error: the PTY close races the child's exit on some kernels.
+	go func() { _, _ = io.Copy(io.Discard, ptmx) }()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("child did not exit;\noutput=%s", readAll())
+	}
+
+	if strings.Contains(readAll(), "running without injected env") {
+		t.Fatalf("inline unlock fell back to no-env path;\noutput=%s", readAll())
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gv/jitenv/internal/agent"
 	"github.com/gv/jitenv/internal/agentwarn"
 	"github.com/gv/jitenv/internal/runnotice"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 // injectedMarker mirrors the one in internal/shim: a one-shot env
@@ -43,12 +44,14 @@ const (
 // replaces the current process with file+args+merged-env.
 //
 // When the agent is unreachable (locked, never started, …), the
-// command isn't refused: the user gets the same "agent is not
-// loaded — Press Enter to skip, Ctrl+C to abort" countdown the
-// shim uses, and after the wait the script runs with the parent
-// env. This is what the bash hook used to paint inline; moving it
-// here means `jitenv run`'s behaviour is consistent whether it was
-// invoked by the hook, by hand, or by another tool.
+// command isn't refused: the user gets the same agent-down countdown
+// the shim uses ("Press [u] to unlock and inject, [Enter] to continue
+// without env, [Ctrl+C] to abort"). Pressing `u` runs the inline
+// unlock flow and re-fetches env so the command IS injected; Enter /
+// timeout runs the script with the parent env. This is what the bash
+// hook used to paint inline; moving it here means `jitenv run`'s
+// behaviour is consistent whether it was invoked by the hook, by hand,
+// or by another tool.
 func Run(ctx context.Context, file string, args []string) error {
 	abs, err := filepath.Abs(file)
 	if err != nil {
@@ -164,20 +167,47 @@ var cryptoRandRead = rand.Read
 // zero vars; false = agent was down and the user dismissed the
 // warning).
 func fetchOrWarn(ctx context.Context, socket, abs string) (map[string]string, bool, error) {
-	if _, err := os.Stat(socket); err != nil {
-		if agentwarn.WarnAndWait(abs) {
-			return nil, false, errors.New("aborted")
+	// First attempt: dial the agent if its socket is present.
+	if _, err := os.Stat(socket); err == nil {
+		cli := agent.NewClient(socket)
+		dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		extra, err := cli.FetchEnv(dctx, abs)
+		cancel()
+		if err == nil {
+			return extra, true, nil
 		}
+	}
+
+	// Agent down (socket missing or unresponsive). Show the countdown.
+	switch agentwarn.WarnAndWait(abs) {
+	case agentwarn.ActionAbort:
+		return nil, false, errors.New("aborted")
+	case agentwarn.ActionUnlock:
+		return fetchAfterUnlock(ctx, abs)
+	default: // ActionContinue
 		return nil, false, nil
 	}
-	cli := agent.NewClient(socket)
+}
+
+// fetchAfterUnlock runs the interactive unlock flow on the same TTY,
+// then re-fetches env from the now-unlocked agent so the mapped
+// command DOES get its vars (issue #232). On any failure — wrong
+// passphrase, Ctrl+C in the prompt, daemon spawn failure, or a fetch
+// error against the freshly unlocked agent — it prints one stderr line
+// and falls back to the existing "run without env" path rather than
+// aborting the command.
+func fetchAfterUnlock(ctx context.Context, abs string) (map[string]string, bool, error) {
+	res, err := unlock.Spawn("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jitenv: unlock failed (%v) — running without injected env.\n", err)
+		return nil, false, nil
+	}
+	cli := agent.NewClient(res.Socket)
 	dctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	extra, err := cli.FetchEnv(dctx, abs)
 	if err != nil {
-		if agentwarn.WarnAndWait(abs) {
-			return nil, false, errors.New("aborted")
-		}
+		fmt.Fprintf(os.Stderr, "jitenv: agent unreachable after unlock (%v) — running without injected env.\n", err)
 		return nil, false, nil
 	}
 	return extra, true, nil

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gv/jitenv/internal/agent"
 	"github.com/gv/jitenv/internal/agentwarn"
 	"github.com/gv/jitenv/internal/runnotice"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 // errAgentDown is returned by fetchEnv when the agent socket is
@@ -145,11 +146,24 @@ func run(invokedAs string, args []string) error {
 	alreadyWarned := os.Getenv(warnedMarker) == "1"
 	if shouldInject() && !alreadyWarned {
 		extra, fetchErr := fetchEnv(invokedAs)
+		// On agent-down, the countdown may offer an inline unlock. If
+		// the user picks it and the unlock + re-fetch succeed, fold the
+		// result back into the normal "fetch succeeded" path below by
+		// clearing fetchErr.
+		if errors.Is(fetchErr, errAgentDown) {
+			switch agentwarn.WarnAndWait(invokedAs) {
+			case agentwarn.ActionAbort:
+				return errors.New("aborted")
+			case agentwarn.ActionUnlock:
+				if unlocked, err := fetchAfterUnlock(invokedAs); err == nil {
+					extra, fetchErr = unlocked, nil
+				}
+				// On unlock failure fetchErr stays errAgentDown and we
+				// fall through to the warn-and-continue handling below.
+			}
+		}
 		switch {
 		case errors.Is(fetchErr, errAgentDown):
-			if agentwarn.WarnAndWait(invokedAs) {
-				return errors.New("aborted")
-			}
 			// User chose to continue without env. Propagate the marker
 			// so chained shim entries (e.g. npm → node via shebang)
 			// don't re-prompt.
@@ -491,6 +505,34 @@ func fetchEnv(cmd string) (map[string]string, error) {
 	out, err := cli.FetchEnvCwd(ctx, pwd, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", errAgentDown, err)
+	}
+	return out, nil
+}
+
+// fetchAfterUnlock runs the interactive unlock flow on the same TTY,
+// then re-fetches env from the now-unlocked agent so the wrapped
+// command DOES get its vars (issue #232). On any failure — wrong
+// passphrase, Ctrl+C in the prompt, daemon spawn failure, or a fetch
+// error against the freshly unlocked agent — it prints one stderr line
+// and returns an error so the caller falls back to the existing
+// "run without env" path rather than aborting the command.
+func fetchAfterUnlock(cmd string) (map[string]string, error) {
+	res, err := unlock.Spawn("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jitenv: unlock failed (%v) — running without injected env.\n", err)
+		return nil, err
+	}
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	cli := agent.NewClient(res.Socket)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := cli.FetchEnvCwd(ctx, pwd, cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jitenv: agent unreachable after unlock (%v) — running without injected env.\n", err)
+		return nil, err
 	}
 	return out, nil
 }

--- a/internal/unlock/unlock.go
+++ b/internal/unlock/unlock.go
@@ -1,0 +1,97 @@
+// Package unlock holds the reusable "prompt passphrase → derive key →
+// spawn background agent" flow. It lives in its own package so both
+// the `jitenv unlock` command (internal/cli) and the inline-unlock
+// prompt fired from the agent-down countdown (internal/run,
+// internal/shim) can drive it without an import cycle — internal/cli
+// already imports internal/run and internal/shim, so those two cannot
+// import internal/cli.
+//
+// Only the background-daemon path is reused. The `--foreground` dev
+// mode (which runs the agent in-process) stays in internal/cli.
+package unlock
+
+import (
+	"time"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// Result reports what happened after a Spawn attempt. Socket is the
+// agent socket / pipe the caller can dial once unlock succeeds.
+type Result struct {
+	Socket string
+}
+
+// Spawn prompts for the passphrase on the controlling terminal,
+// derives the master key, and spawns the background agent for the
+// config at cfgPath (config.Resolve is applied, so "" picks up the
+// usual JITENV_CONFIG / XDG defaults). The master key is mlock'd and
+// zeroed before return following the project's key-handling
+// convention.
+//
+// On success the agent is listening and Result.Socket points at it.
+// Any error (wrong passphrase, Ctrl+C in the passphrase prompt, daemon
+// spawn failure) is returned for the caller to surface.
+func Spawn(cfgPath string) (Result, error) {
+	resolved, err := config.Resolve(cfgPath)
+	if err != nil {
+		return Result{}, err
+	}
+	cfg, err := config.Load(resolved)
+	if err != nil {
+		return Result{}, err
+	}
+	pw, err := crypto.PromptPassphrase("jitenv unlock passphrase: ", false)
+	if err != nil {
+		return Result{}, err
+	}
+	defer zeroBytes(pw)
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		return Result{}, err
+	}
+	defer zeroBytes(key)
+	defer lockKey(key)()
+
+	paths, err := agent.DefaultPaths()
+	if err != nil {
+		return Result{}, err
+	}
+	idle := ParseIdle(cfg.Agent.IdleTimeout)
+	if err := agent.SpawnDaemon(paths, resolved, idle, key); err != nil {
+		return Result{}, err
+	}
+	return Result{Socket: paths.Socket}, nil
+}
+
+// ParseIdle mirrors the agent idle-timeout parsing used by the unlock
+// command: empty / invalid / negative falls back to 30 minutes.
+func ParseIdle(s string) time.Duration {
+	if s == "" {
+		return 30 * time.Minute
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 0 {
+		return 30 * time.Minute
+	}
+	return d
+}
+
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// lockKey pins the master-key buffer into RAM so it won't be paged to
+// swap (security #127). On failure it degrades gracefully and returns
+// a no-op cleanup. Callers defer the returned closure next to defer
+// zeroBytes(key).
+func lockKey(key []byte) func() {
+	if err := crypto.LockBytes(key); err != nil {
+		return func() {}
+	}
+	return func() { _ = crypto.UnlockBytes(key) }
+}


### PR DESCRIPTION
## What

When a mapped command runs while the agent is locked or not running, the agent-down countdown now offers an inline unlock:

```
jitenv agent is not loaded — env vars for "…" will NOT be set.
Press [u] to unlock and inject, [Enter] to continue without env, [Ctrl+C] to abort.  10s
```

- **u** → drops the countdown, runs the unlock flow (passphrase prompt on the same TTY), then re-fetches `fetch_env` from the now-unlocked agent so the mapped command DOES get its env vars. On failure (wrong passphrase, Ctrl+C in the prompt, daemon spawn failure) it falls back to run-without-env with a one-line stderr note.
- **Enter / any other key** → unchanged continue-without-env behavior.
- **Ctrl+C** → unchanged abort.

The 10s timer still defaults to run-anyway so scripted/CI flows degrade gracefully; the option is purely additive for interactive users.

## How

- `agentwarn.WarnAndWait` now returns an `Action` (`ActionContinue` / `ActionAbort` / `ActionUnlock`) instead of a bool. During the countdown stdin is switched to raw mode so single keystrokes register without Enter; in raw mode Ctrl+C arrives as the `0x03` byte and is read as abort (the `signal.Notify` path stays as a fallback when `MakeRaw` fails, e.g. the pipe-based unit tests). The terminal is restored before the function returns so the subsequent passphrase prompt / exec inherit a sane TTY.
- New `internal/unlock` package holds the reusable "prompt passphrase → derive key → spawn background agent" flow. It lives in its own package to avoid an import cycle: `internal/cli` already imports `internal/run` and `internal/shim`, so those can't import `internal/cli`. `internal/unlock` only depends on `config` / `agent` / `crypto` and follows the project's zero-on-defer + mlock key-handling convention.
- `internal/run/run.go` and `internal/shim/shim.go` route `ActionUnlock` into `unlock.Spawn` + a re-fetch; on success the shim folds the result into its existing inject branch (stamping the session-nonce marker), so chained interpreters still short-circuit correctly.

## Tests

- `internal/agentwarn/agentwarn_test.go`: `u` → `ActionUnlock`, `Enter` → `ActionContinue`, plus the existing non-TTY short-circuit (updated to the new return type).
- `internal/run/inline_unlock_e2e_test.go`: PTY-driven e2e — locked agent, type `u` + passphrase, assert the mapped command runs with the injected env. Adds `github.com/creack/pty` as a test dependency.

`go test ./...` and `golangci-lint run ./...` pass. (`internal/shell.TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent` fails on a clean `main` in this environment too — pre-existing, filed as #238, unrelated to this change.)

Closes #232