### PR TITLE
feat(config): encrypt all vars[*] fields so config.toml stops leaking the secret topology

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -102,7 +102,11 @@ func newConfigValidateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := c.Validate(); err != nil {
+			// Structure-only: this runs without the master key, so var
+			// fields are still sealed envelopes (#235). The source-name
+			// cross-reference (ValidatePost) needs decrypted content and
+			// only runs in the unlock/agent/clone paths.
+			if err := c.ValidateStructure(); err != nil {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "ok")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,8 +160,29 @@ func isValidCommandName(s string) bool {
 	return true
 }
 
-// Validate performs structural checks not covered by TOML parsing.
+// Validate performs all structural checks not covered by TOML parsing.
+// It assumes the config is decrypted: ValidatePost cross-references
+// var.source against the defined sources, which only resolves once the
+// envelopes sealed by EncryptInPlace (#235) have been opened. Callers
+// that operate on the encrypted on-disk form (e.g. `jitenv config
+// validate`, which must run without the master key) should call
+// ValidateStructure instead.
 func (c *Config) Validate() error {
+	if err := c.ValidateStructure(); err != nil {
+		return err
+	}
+	return c.ValidatePost()
+}
+
+// ValidateStructure checks shape only — every check here is safe to run
+// on the encrypted form because it tests field presence (non-empty) and
+// the never-encrypted path/glob/cwd_glob/commands fields, never the
+// decrypted content of a sealed var field. After #235, var.name/source/
+// ref/key/value are envelope strings when loaded-but-not-decrypted; an
+// envelope is still non-empty, so the "exactly one of path/glob/cwd",
+// "value exclusive with source/ref/key/extra", "name required" rules
+// all hold without the key.
+func (c *Config) ValidateStructure() error {
 	if c.Version != Version {
 		return fmt.Errorf("unsupported config version %d (want %d)", c.Version, Version)
 	}
@@ -226,6 +247,22 @@ func (c *Config) Validate() error {
 			}
 			if v.Name == "" && v.Key != "" {
 				return fmt.Errorf("mapping[%d].vars[%d]: name is required when key is set", i, j)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidatePost performs the checks that require decrypted content —
+// today just resolving each var.source to a defined source. It MUST run
+// only after DecryptInPlace; on the encrypted form var.source is an
+// envelope string that would never match a source-map key, so this
+// would spuriously reject every valid config (#235).
+func (c *Config) ValidatePost() error {
+	for i, m := range c.Mappings {
+		for j, v := range m.Vars {
+			if v.Value != "" {
+				continue
 			}
 			if _, ok := c.Sources[v.Source]; !ok {
 				return fmt.Errorf("mapping[%d].vars[%d]: source %q is not defined", i, j, v.Source)

--- a/internal/config/decrypt.go
+++ b/internal/config/decrypt.go
@@ -36,5 +36,44 @@ func DecryptInPlace(c *Config, key []byte) error {
 			kv[k] = pt
 		}
 	}
+	// vars[*] scalar + extra fields (#235). Symmetric with the encrypt
+	// walker; plaintext fields (legacy configs not yet re-saved) pass
+	// through untouched.
+	for i := range c.Mappings {
+		m := &c.Mappings[i]
+		for j := range m.Vars {
+			v := &m.Vars[j]
+			fields := []struct {
+				field string
+				ptr   *string
+			}{
+				{"name", &v.Name},
+				{"source", &v.Source},
+				{"ref", &v.Ref},
+				{"key", &v.Key},
+				{"value", &v.Value},
+			}
+			for _, f := range fields {
+				if !crypto.IsEnvelope(*f.ptr) {
+					continue
+				}
+				pt, err := crypto.DecryptField(key, *f.ptr, VarFieldAAD(i, j, f.field))
+				if err != nil {
+					return fmt.Errorf("decrypt mapping[%d].vars[%d].%s: %w", i, j, f.field, err)
+				}
+				*f.ptr = pt
+			}
+			for k, ev := range v.Extra {
+				if !crypto.IsEnvelope(ev) {
+					continue
+				}
+				pt, err := crypto.DecryptField(key, ev, VarExtraAAD(i, j, k))
+				if err != nil {
+					return fmt.Errorf("decrypt mapping[%d].vars[%d].extra.%s: %w", i, j, k, err)
+				}
+				v.Extra[k] = pt
+			}
+		}
+	}
 	return nil
 }

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -35,6 +35,22 @@ func SecretAAD(bag, key string) string {
 	return crypto.AAD("secret", bag, key)
 }
 
+// VarFieldAAD builds the AAD context for a scalar string field of
+// mappings[mappingIdx].vars[varIdx] (e.g. "name", "source", "ref",
+// "key", "value"). Binding the slot indices means an attacker who can
+// write the config can't transplant a sealed value across var slots
+// (security #110 / #235).
+func VarFieldAAD(mappingIdx, varIdx int, field string) string {
+	return crypto.AAD("var", fmt.Sprintf("%d", mappingIdx), fmt.Sprintf("%d", varIdx), field)
+}
+
+// VarExtraAAD builds the AAD context for a value stored under
+// mappings[mappingIdx].vars[varIdx].extra.<key>. Each extra map value
+// is sealed independently and bound to its slot + key.
+func VarExtraAAD(mappingIdx, varIdx int, key string) string {
+	return crypto.AAD("var", fmt.Sprintf("%d", mappingIdx), fmt.Sprintf("%d", varIdx), "extra", key)
+}
+
 // InitNew creates a brand-new encrypted config at path. The file is written
 // atomically with 0600.
 func InitNew(path string, passphrase []byte) error {

--- a/internal/config/encrypt.go
+++ b/internal/config/encrypt.go
@@ -54,5 +54,47 @@ func EncryptInPlace(c *Config, key []byte) error {
 			kv[k] = env
 		}
 	}
+	// vars[*] scalar + extra fields. Sealing these stops config.toml
+	// from leaking the secret topology (env var names, which source/
+	// ref/key each var pulls from, per-var lookup params, and literal
+	// values) to a passive reader (#235). An empty field stays empty:
+	// in particular an empty Name keeps the "expand the whole bag"
+	// semantics intact (a VarRef with no Name).
+	for i := range c.Mappings {
+		m := &c.Mappings[i]
+		for j := range m.Vars {
+			v := &m.Vars[j]
+			fields := []struct {
+				field string
+				ptr   *string
+			}{
+				{"name", &v.Name},
+				{"source", &v.Source},
+				{"ref", &v.Ref},
+				{"key", &v.Key},
+				{"value", &v.Value},
+			}
+			for _, f := range fields {
+				if *f.ptr == "" || crypto.IsEnvelope(*f.ptr) {
+					continue
+				}
+				env, err := crypto.EncryptField(key, *f.ptr, VarFieldAAD(i, j, f.field))
+				if err != nil {
+					return fmt.Errorf("mapping[%d].vars[%d].%s: %w", i, j, f.field, err)
+				}
+				*f.ptr = env
+			}
+			for k, ev := range v.Extra {
+				if ev == "" || crypto.IsEnvelope(ev) {
+					continue
+				}
+				env, err := crypto.EncryptField(key, ev, VarExtraAAD(i, j, k))
+				if err != nil {
+					return fmt.Errorf("mapping[%d].vars[%d].extra.%s: %w", i, j, k, err)
+				}
+				v.Extra[k] = env
+			}
+		}
+	}
 	return nil
 }

--- a/internal/config/encrypt_test.go
+++ b/internal/config/encrypt_test.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// newTestKey spins up a real encrypted config and derives its key so
+// the AAD wiring matches production exactly.
+func newTestKey(t *testing.T) []byte {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	t.Cleanup(func() { zero(key) })
+	return key
+}
+
+func varsConfig() *Config {
+	return &Config{
+		Version: Version,
+		Sources: map[string]SourceConfig{
+			"vault": {Type: "local"},
+		},
+		Secrets: map[string]map[string]string{
+			"stripe": {"STRIPE_SK": "sk-Y"},
+		},
+		Mappings: []Mapping{
+			{
+				Path: "/abs/run.sh",
+				Vars: []VarRef{
+					// Full source-backed var with every scalar + extra.
+					{
+						Name:   "DATABASE_URL",
+						Source: "vault",
+						Ref:    "stripe",
+						Key:    "STRIPE_SK",
+						Extra:  map[string]string{"version": "AWSCURRENT", "stage": "prod"},
+					},
+					// Expand-all VarRef: empty Name must stay empty.
+					{Source: "vault", Ref: "stripe"},
+					// Literal-value var.
+					{Name: "GIT_ASKPASS", Value: "/usr/local/bin/shim"},
+				},
+			},
+		},
+	}
+}
+
+// TestEncryptInPlace_VarsRoundTrip seals every var-field flavour, then
+// decrypts and asserts each field round-trips and empty fields stay
+// empty (#235).
+func TestEncryptInPlace_VarsRoundTrip(t *testing.T) {
+	key := newTestKey(t)
+	c := varsConfig()
+
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	v0 := c.Mappings[0].Vars[0]
+	for label, got := range map[string]string{
+		"name":          v0.Name,
+		"source":        v0.Source,
+		"ref":           v0.Ref,
+		"key":           v0.Key,
+		"extra.version": v0.Extra["version"],
+		"extra.stage":   v0.Extra["stage"],
+	} {
+		if !crypto.IsEnvelope(got) {
+			t.Errorf("vars[0].%s not sealed: %q", label, got)
+		}
+	}
+	if !crypto.IsEnvelope(c.Mappings[0].Vars[2].Value) {
+		t.Errorf("vars[2].value not sealed: %q", c.Mappings[0].Vars[2].Value)
+	}
+	// Expand-all var: empty Name must NOT have been turned into an envelope.
+	if c.Mappings[0].Vars[1].Name != "" {
+		t.Errorf("empty Name should stay empty, got %q", c.Mappings[0].Vars[1].Name)
+	}
+	if !crypto.IsEnvelope(c.Mappings[0].Vars[1].Source) {
+		t.Errorf("vars[1].source not sealed: %q", c.Mappings[0].Vars[1].Source)
+	}
+
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	want := varsConfig()
+	for i := range want.Mappings[0].Vars {
+		gv := c.Mappings[0].Vars[i]
+		wv := want.Mappings[0].Vars[i]
+		if gv.Name != wv.Name || gv.Source != wv.Source || gv.Ref != wv.Ref ||
+			gv.Key != wv.Key || gv.Value != wv.Value {
+			t.Errorf("vars[%d] mismatch:\n got=%#v\nwant=%#v", i, gv, wv)
+		}
+		for k, w := range wv.Extra {
+			if gv.Extra[k] != w {
+				t.Errorf("vars[%d].extra.%s = %q, want %q", i, k, gv.Extra[k], w)
+			}
+		}
+	}
+}
+
+// TestEncryptInPlace_VarsIdempotent verifies a re-encrypt does not
+// rotate nonces on already-sealed fields (acceptance: round-trip TUI
+// edit must not rotate envelopes).
+func TestEncryptInPlace_VarsIdempotent(t *testing.T) {
+	key := newTestKey(t)
+	c := varsConfig()
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	first := c.Mappings[0].Vars[0].Name
+	firstExtra := c.Mappings[0].Vars[0].Extra["version"]
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("re-encrypt: %v", err)
+	}
+	if c.Mappings[0].Vars[0].Name != first {
+		t.Errorf("re-encrypt rotated name envelope")
+	}
+	if c.Mappings[0].Vars[0].Extra["version"] != firstExtra {
+		t.Errorf("re-encrypt rotated extra envelope")
+	}
+}
+
+// TestDecryptInPlace_RejectsTransplantedVarEnvelope is the #235 AAD
+// regression: a var-field envelope sealed at one slot must fail to
+// decrypt when moved to another slot.
+func TestDecryptInPlace_RejectsTransplantedVarEnvelope(t *testing.T) {
+	key := newTestKey(t)
+
+	// Seal a name bound to mapping[0].vars[0].name, then transplant it
+	// into mapping[0].vars[1].name.
+	env, err := crypto.EncryptField(key, "DATABASE_URL", VarFieldAAD(0, 0, "name"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	c := &Config{
+		Version: Version,
+		Sources: map[string]SourceConfig{"vault": {Type: "local"}},
+		Mappings: []Mapping{{
+			Path: "/abs/run.sh",
+			Vars: []VarRef{
+				{Source: "vault", Ref: "a"},
+				{Name: env, Source: "vault", Ref: "b"}, // env transplanted to slot 1
+			},
+		}},
+	}
+	if err := DecryptInPlace(c, key); err == nil {
+		t.Fatal("DecryptInPlace must reject a var envelope transplanted to a different slot")
+	}
+
+	// Same envelope in its bound slot still decrypts.
+	c.Mappings[0].Vars = []VarRef{{Name: env, Source: "vault", Ref: "a"}}
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("DecryptInPlace must accept envelope in its bound slot: %v", err)
+	}
+	if got := c.Mappings[0].Vars[0].Name; got != "DATABASE_URL" {
+		t.Fatalf("decrypted name: %q", got)
+	}
+}
+
+// TestValidateSplit_StructureVsPost asserts an encrypted config passes
+// ValidateStructure but fails ValidatePost (var.source is an envelope,
+// not a real source name), while the decrypted form passes both.
+func TestValidateSplit_StructureVsPost(t *testing.T) {
+	key := newTestKey(t)
+	c := varsConfig()
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := c.ValidateStructure(); err != nil {
+		t.Fatalf("ValidateStructure on encrypted form should pass: %v", err)
+	}
+	if err := c.ValidatePost(); err == nil {
+		t.Fatal("ValidatePost on encrypted form should fail (source is an envelope)")
+	}
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate on decrypted form should pass: %v", err)
+	}
+}

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -280,6 +280,111 @@ func TestRunLocalBag(t *testing.T) {
 	}
 }
 
+// TestRunEncryptedVars is the #235 end-to-end regression: a config
+// whose vars[*] fields (name/source/ref/key + extra, and a literal
+// value var) are all sealed with EncryptInPlace — exactly as the TUI
+// save path writes them — must still unlock, decrypt, and inject env
+// into the mapped command. Proves the agent's DecryptInPlace +
+// ValidatePost path round-trips sealed var topology end-to-end.
+func TestRunEncryptedVars(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf 'DB=%s\\n' \"$DATABASE_URL\"\nprintf 'LIT=%s\\n' \"$LITERAL\"\n"), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-encvars")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"db-secret": "postgres://sealed"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: scriptPath, Vars: []config.VarRef{
+			{Name: "DATABASE_URL", Source: "n", Ref: "db-secret"},
+			{Name: "LITERAL", Value: "literal-sealed"},
+		}},
+	}
+	// Seal everything (source params + all vars[*] fields) exactly as
+	// the TUI save path does, then write it through the real save.
+	if err := config.EncryptInPlace(cfg, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := config.AtomicSave(cfgPath, cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Sanity: on-disk form must not leak the var names or literal value.
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	// Note: "db-secret" is a noop source-param KEY (source-map keys are
+	// out of scope for #235) and the var Ref envelope decrypts to it, so
+	// it legitimately appears as a param key — don't assert on it here.
+	for _, leak := range []string{"DATABASE_URL", "postgres://sealed", "literal-sealed", "LITERAL"} {
+		if strings.Contains(string(raw), leak) {
+			t.Fatalf("config.toml leaks %q in plaintext:\n%s", leak, raw)
+		}
+	}
+
+	runtimeDir := shortRuntimeDir(t)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	daemon.Stdout = os.Stdout
+	daemon.Stderr = os.Stderr
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon start: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	deadline := time.Now().Add(3 * time.Second)
+	cli := agent.NewClient(paths.Socket)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_CONFIG="+cfgPath,
+	)
+	cmd := exec.Command(bin, "run", scriptPath)
+	cmd.Env = subprocEnv
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	if !strings.Contains(got, "DB=postgres://sealed") || !strings.Contains(got, "LIT=literal-sealed") {
+		t.Fatalf("unexpected script output:\n%s", got)
+	}
+}
+
 // TestRunPreRunNotice exercises the [agent].pre_run_notice toggle. It
 // runs `jitenv run` with stderr captured (i.e. not a TTY) so the
 // expected output is the plain-text branch — proving the wiring,

--- a/internal/tui/commands_list_screen_test.go
+++ b/internal/tui/commands_list_screen_test.go
@@ -413,13 +413,15 @@ func TestCommandsList_TomlRoundTrip(t *testing.T) {
 		t.Fatalf("after edit+delete: %v", got)
 	}
 
-	// Save + validate + reload, mirroring saveCmd.
+	// Save + validate + reload, mirroring saveCmd: validate the
+	// plaintext form (ValidatePost resolves var.source) BEFORE
+	// EncryptInPlace seals those fields (#235).
 	out := cloneForSave(c)
-	if err := encryptForSave(out, key); err != nil {
-		t.Fatalf("encrypt: %v", err)
-	}
 	if err := out.Validate(); err != nil {
 		t.Fatalf("validate: %v", err)
+	}
+	if err := encryptForSave(out, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
 	}
 	if err := config.AtomicSave(path, out); err != nil {
 		t.Fatalf("save: %v", err)

--- a/internal/tui/save.go
+++ b/internal/tui/save.go
@@ -17,11 +17,14 @@ func saveCmd(r *rootModel) tea.Cmd {
 	return tea.Sequence(
 		func() tea.Msg {
 			out := cloneForSave(r.cfg)
-			if err := encryptForSave(out, r.key); err != nil {
-				return errorMsg(fmt.Sprintf("encrypt: %v", err))
-			}
+			// Validate the still-plaintext form: ValidatePost resolves
+			// var.source against the source map, which only works before
+			// EncryptInPlace seals var.source into an envelope (#235).
 			if err := out.Validate(); err != nil {
 				return errorMsg(fmt.Sprintf("validate: %v", err))
+			}
+			if err := encryptForSave(out, r.key); err != nil {
+				return errorMsg(fmt.Sprintf("encrypt: %v", err))
 			}
 			if err := config.AtomicSave(r.cfgPath, out); err != nil {
 				return errorMsg(fmt.Sprintf("save: %v", err))
@@ -62,6 +65,19 @@ func cloneForSave(c *config.Config) *config.Config {
 			if c.Mappings[i].Vars != nil {
 				cp := make([]config.VarRef, len(c.Mappings[i].Vars))
 				copy(cp, c.Mappings[i].Vars)
+				// Deep-copy each var's Extra map: EncryptInPlace seals
+				// extra values in place (#235), and a shallow struct copy
+				// would otherwise share the map with the live config and
+				// poison it with envelopes on save.
+				for j := range cp {
+					if cp[j].Extra != nil {
+						em := make(map[string]string, len(cp[j].Extra))
+						for k, v := range cp[j].Extra {
+							em[k] = v
+						}
+						cp[j].Extra = em
+					}
+				}
 				nm[i].Vars = cp
 			}
 		}


### PR DESCRIPTION
## Summary

Today `internal/config/encrypt.go` only seals `[sources.<name>.params]` values and `[secrets.<bag>]` values. Everything in `[[mappings]]` was plaintext TOML, so a passive-read attacker (cat of config.toml, screenshare, dotfiles repo, backup, screenshot) could see the full secret topology: env var names, which source/entry/key each secret comes from, per-var lookup params, and literal values.

This implements **Mitigation A (vars[*] only)** from #235: every string-typed field in `vars[*]` is now sealed with the same per-field `enc:v2:` envelope + AAD model already used for source params and secrets.

`path` / `glob` / `cwd_glob` / `commands` remain plaintext (read by `is-mapped` / `__chpwd` without the agent — that's Mitigation B, out of scope here). Source-map keys, bag-map keys, and `_meta.*` are also out of scope.

## What changed

- **AAD helpers** (`internal/config/edit.go`): `VarFieldAAD(mappingIdx, varIdx, field)` and `VarExtraAAD(mappingIdx, varIdx, key)`, binding each value to its slot indices so a config-write attacker can't transplant a sealed value across slots (security #110 property).
- **Walker** (`encrypt.go` / `decrypt.go`): a third loop over `c.Mappings` seals/opens `name`, `source`, `ref`, `key`, `value`, and each `extra[k]`. Empty fields stay empty — the "empty Name = expand whole bag" semantics are preserved. Already-sealed fields are skipped (no nonce rotation on round-trip save); legacy `enc:v1` and plaintext-var configs upgrade on next save.
- **Validate split** (`config.go`): `ValidateStructure()` (shape-only, safe on the encrypted form) + `ValidatePost()` (resolves `var.source` to a defined source, needs decrypt). `Validate()` runs both. `jitenv config validate` keeps the no-unlock UX via `ValidateStructure`; unlock/agent/clone already run post-decrypt. TUI save now validates *before* encrypting.
- **TUI** (`save.go`): `cloneForSave` deep-copies each var's `Extra` map so in-place sealing can't poison the live in-memory config.

## Tests

- `encrypt_test.go`: vars round-trip (every field flavour), idempotent re-encrypt (no nonce rotation), AAD transplant rejection, Validate structure-vs-post split.
- `run_e2e_test.go`: full unlock → run-mapped-command regression with a vars-encrypted config; asserts the on-disk form leaks no var names/values yet env injection still works end-to-end.

## Notes

- `go test ./...`, `go vet ./...`, and `golangci-lint run` pass on the affected packages.
- One pre-existing failure in `internal/shell` (`TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent`) reproduces identically on a clean `main` checkout in this sandbox (agent socket never comes up — environment/timing, not this change).

Closes #235