### PR TITLE
feat(shell): PATH-resolved bare-name hook + fix flaky cwd_glob e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,12 @@ the check entirely — there is no upgrade story for snapshots.
 - All three mapping kinds (`path`, `glob`, `cwd_glob`) work on every
   supported shell. Implementation differs per shell:
   - bash: `extdebug` + `DEBUG` trap intercepts absolute / `./`-relative
-    paths; `cwd_glob` is driven by wrapper symlinks in a per-shell PATH
-    entry, reconciled on every prompt.
-  - zsh: an `accept-line` zle widget does the same path interception;
-    `cwd_glob` again uses wrapper symlinks reconciled per prompt.
+    paths and bare names resolved through `$PATH` (`type -P`); `cwd_glob`
+    is driven by wrapper symlinks in a per-shell PATH entry, reconciled
+    on every prompt.
+  - zsh: an `accept-line` zle widget does the same path interception
+    (bare names via `whence -p`); `cwd_glob` again uses wrapper symlinks
+    reconciled per prompt.
   - PowerShell 7+: a PSReadLine `Enter` chord handler intercepts paths;
     `cwd_glob` uses `.ps1` wrappers in a per-shell PATH entry,
     reconciled by the `prompt` override. PSReadLine is the default
@@ -225,9 +227,11 @@ the check entirely — there is no upgrade story for snapshots.
     no-ops and `cwd_glob` still works.
 - Windows release binaries are not Authenticode-signed; SmartScreen
   may warn on first run.
-- The shell hook only intercepts commands whose first token is an
-  absolute or `./`-relative path — not bare PATH lookups (those are
-  routed via `cwd_glob` wrappers instead).
+- The shell hook intercepts commands whose first token is an absolute
+  or `./`-relative path, or a bare name that resolves through `$PATH` to
+  a real file — so a `path`/`glob` mapping fires whether you type the
+  full path or just the command name. Builtins, aliases, functions, and
+  typos (which don't resolve to a file) are left alone.
 - Single agent per user; multiple terminals share one unlocked instance.
 - TUI requires a TTY; for scripted setup use `jitenv config init` then
   re-run interactively.

--- a/docs/shell-hook.md
+++ b/docs/shell-hook.md
@@ -32,15 +32,22 @@ the line is already present.
 
 ## Trigger semantics
 
-The hook only intercepts commands whose first token resolves to an
-**absolute** or **`./` / `../`-relative** filesystem path. Bare PATH
-lookups (`deploy.sh`, `npm`, `python`) are ignored. This is
-intentional: it keeps the hook fast (one stat per command, not a
-PATH walk) and predictable.
+The hook intercepts a command when its first token resolves to a real
+file, whether that token is:
 
-To map a binary you'd otherwise invoke by PATH name, either run it
-explicitly through `jitenv run`, or shadow it with a wrapper script
-at a known path that's covered by a mapping.
+- an **absolute** path (`/usr/local/bin/terraform`),
+- a **`./` / `../`-relative** path (`./scripts/deploy.sh`), or
+- a **bare name resolved through `$PATH`** (`terraform`, `deploy.sh`) —
+  the hook does a single `type -P` / `whence -p` lookup and matches the
+  mapping against the resolved absolute path.
+
+Bare names that don't resolve to a real executable file — shell
+builtins, aliases, functions, and typos — are ignored, so the common
+case (no mapping) stays cheap: one `type -P` and at most one
+`jitenv is-mapped` per command, never a manual PATH walk.
+
+So a `path = "/usr/local/bin/terraform"` (or a matching `glob`) mapping
+now fires whether you type the full path or just `terraform`.
 
 ## The exit-code contract
 
@@ -119,9 +126,12 @@ shell shortens it to 2 seconds.
 
 ### "Why does the hook ignore `deploy.sh` when I'm in `./scripts/`?"
 
-Because the first token is a bare name; the hook only matches
-absolute or `./`-relative paths. Either run `./deploy.sh` or set up
-a glob mapping that covers the resolved path. See
+A bare `deploy.sh` only triggers the hook if it resolves through
+`$PATH` to a real file. A script in the current directory is *not* on
+`$PATH` (jitenv never adds `.` to PATH), so `deploy.sh` doesn't resolve
+and is ignored — run `./deploy.sh`, or set up a glob mapping that
+covers the resolved path. A binary that *is* on `$PATH` (e.g.
+`terraform`) is matched by its resolved absolute path. See
 [concepts.md](concepts.md#path-vs-glob).
 
 ### "I edited config.toml but the agent shows old values"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,9 +26,11 @@ Try in this order:
    `~/.bash_login`, or `~/.profile` sources it. The status output
    tells you whether the chain is wired up. Re-running
    `jitenv hook install` adds the guarded source line.
-3. Is the command's first token an absolute or `./`-relative path?
-   Bare PATH lookups (`deploy.sh`, `npm`) are intentionally not
-   intercepted. See [shell-hook.md](shell-hook.md#trigger-semantics).
+3. Does the command's first token resolve to a real file — an absolute
+   path, a `./`-relative path, or a bare name found on `$PATH`? Names
+   that don't resolve (builtins, aliases, functions, typos, and scripts
+   in the current dir that aren't on `$PATH`) are not intercepted. See
+   [shell-hook.md](shell-hook.md#trigger-semantics).
 4. Is the file a symlink? Mappings match the resolved canonical path,
    not the symlink. `ls -L` to confirm what jitenv sees.
 5. `JITENV_HOOK_DEBUG=1` and re-run. The hook logs each branch it

--- a/internal/shell/cwd_path_change_e2e_test.go
+++ b/internal/shell/cwd_path_change_e2e_test.go
@@ -78,6 +78,20 @@ func newCPCFixture(t *testing.T) *cpcFixture {
 	bin := buildBinary(t)
 	dir := t.TempDir()
 
+	// The agent runtime dir holds an AF_UNIX socket whose absolute path
+	// (<runtimeDir>/jitenv/agent.sock) must fit in sun_path — 108 bytes
+	// on Linux, 104 on macOS. t.TempDir() embeds the (long) test name,
+	// so for a test like TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent
+	// the socket path overflows and bind/connect fails with EINVAL
+	// ("invalid argument"), leaving the agent permanently unreachable.
+	// Anchor the runtime dir at a short, test-name-independent temp path
+	// instead so the socket path stays well under the limit (#238).
+	runtimeDir, err := os.MkdirTemp("", "jrt-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runtimeDir) })
+
 	f := &cpcFixture{
 		t:            t,
 		bin:          bin,
@@ -86,7 +100,7 @@ func newCPCFixture(t *testing.T) *cpcFixture {
 		projA:        filepath.Join(dir, "projA"),
 		projB:        filepath.Join(dir, "projB"),
 		fakeBin:      filepath.Join(dir, "bin"),
-		runtimeDir:   filepath.Join(dir, "runtime"),
+		runtimeDir:   runtimeDir,
 		agentCfgPath: filepath.Join(dir, "agent.toml"),
 		shellCfgPath: filepath.Join(dir, "shell.toml"),
 	}
@@ -168,13 +182,30 @@ func (f *cpcFixture) startAgent(key []byte) func() {
 
 	f.t.Setenv("XDG_RUNTIME_DIR", f.runtimeDir)
 	paths, _ := agent.DefaultPaths()
+	// Block until the agent socket is actually accepting connections
+	// (status round-trips) rather than sleeping a fixed interval, so the
+	// first shim invocation after startAgent can never lose a startup
+	// race. If it never comes up, fail loudly with the agent log instead
+	// of silently proceeding into a misleading "agent down" assertion.
 	cli := agent.NewClient(paths.Socket)
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for {
 		if _, err := cli.Status(context.Background()); err == nil {
 			break
+		} else {
+			lastErr = err
 		}
-		time.Sleep(50 * time.Millisecond)
+		if time.Now().After(deadline) {
+			logTail := "<no agent log>"
+			if lg, e := os.ReadFile(paths.LogFile); e == nil {
+				logTail = string(lg)
+			}
+			_ = daemon.Process.Kill()
+			f.t.Fatalf("agent never became reachable on %s: %v\nagent log:\n%s",
+				paths.Socket, lastErr, logTail)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 	return func() { _ = daemon.Process.Kill() }
 }

--- a/internal/shell/cwd_path_change_e2e_test.go
+++ b/internal/shell/cwd_path_change_e2e_test.go
@@ -248,6 +248,55 @@ eval "$(%s/jitenv hook bash)"
 	return "", -1
 }
 
+// runZsh drives the zsh hook's bare-name PATH branch. The zsh hook lives
+// in a `zle` widget bound to accept-line, which only fires inside the
+// interactive line editor — it never runs under `zsh -c`. Rather than
+// pull in a pty dependency just for this, the harness sources the hook,
+// sets BUFFER, and calls __jitenv_accept_line directly: the widget does
+// its real `whence -p` resolution + is-mapped routing and rewrites BUFFER
+// to `jitenv run <resolved>` exactly as it would interactively. The
+// trailing `zle .accept-line` errors harmlessly outside the editor (no
+// set -e), so we eval the rewritten BUFFER by hand to actually run the
+// command — the same hand-driven approach the bash tests use for
+// __jitenv_chpwd, which PROMPT_COMMAND doesn't fire under `bash -c`.
+//
+// setup runs after the hook is sourced but before the widget fires (e.g.
+// `cd <dir> && __jitenv_chpwd` to build a cwd_glob wrapper); buffer is
+// the single command line fed through the widget as its first token.
+// JITENV_CONFIG points at shellCfg.
+func (f *cpcFixture) runZsh(setup, buffer string) string {
+	f.t.Helper()
+	if _, err := exec.LookPath("zsh"); err != nil {
+		f.t.Skip("zsh not available")
+	}
+	// Source the hook, run setup, set BUFFER, run the widget (rewrites
+	// BUFFER for a mapped command; the final `zle .accept-line` fails
+	// outside the line editor, which we ignore), then eval whatever
+	// BUFFER ended up as.
+	full := fmt.Sprintf(
+		`PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(%s/jitenv hook zsh)"
+%s
+BUFFER=%q
+__jitenv_accept_line 2>/dev/null || true
+eval "$BUFFER"`, f.binDir, f.fakeBin, f.shellCfgPath, f.binDir, setup, buffer)
+	cmd := exec.Command("zsh", "-c", full)
+	cmd.Env = append(os.Environ(),
+		"XDG_RUNTIME_DIR="+f.runtimeDir,
+		"JITENV_HOOK_DELAY=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			f.t.Fatalf("zsh exited %d\noutput=%s", ee.ExitCode(), out)
+		}
+		f.t.Fatalf("zsh run failed to start: %v\noutput=%s", err, out)
+	}
+	return string(out)
+}
+
 func cwdGlobMapping(dir string) []config.Mapping {
 	return []config.Mapping{{
 		CwdGlob:  dir,
@@ -557,5 +606,57 @@ fakecmd                    # bare name → resolves to the wrapper, not double-d
 	// would run the command twice → two FOO= lines.
 	if n := strings.Count(section, "FOO="); n != 1 {
 		t.Errorf("expected exactly one FOO= line (no double dispatch); got %d:\n%s", n, section)
+	}
+}
+
+// TestPathMapping_BareNameInvocationInjects_Zsh is the zsh twin of
+// TestPathMapping_BareNameInvocationInjects (#237). GitHub's
+// ubuntu-latest CI image (where `go test -race ./...` runs the
+// !windows-tagged shell e2e suites) ships zsh, so this branch is
+// exercised in CI; it skips cleanly where zsh is absent. It drives the
+// real `whence -p` bare-name branch of the zsh accept-line widget — see
+// runZsh for why the widget is invoked directly rather than through an
+// interactive line editor.
+func TestPathMapping_BareNameInvocationInjects_Zsh(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(f.pathMappingFor())
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	// fakeBin is on PATH (see runZsh), so `fakecmd` is a bare name that
+	// resolves through $PATH (via `whence -p`) to the mapped absolute
+	// file and must route through `jitenv run`.
+	out := f.runZsh("", "fakecmd")
+	t.Logf("output:\n%s", out)
+	if !strings.Contains(out, "FOO=from-cwd") {
+		t.Errorf("zsh bare-name PATH invocation: expected FOO=from-cwd; got:\n%s", out)
+	}
+}
+
+// TestCwdGlob_BareNameNotDoubleDispatched_Zsh is the zsh twin of the
+// double-dispatch guard (#237): once the cwd_glob wrapper is built it
+// sits first on $PATH, so a bare `fakecmd` resolves (via `whence -p`) to
+// the wrapper. The zsh widget must blank `resolved` for a wrap-dir hit
+// and let the wrapper shim do the single is-mapped call — so injection
+// still works and the command runs exactly once.
+func TestCwdGlob_BareNameNotDoubleDispatched_Zsh(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(cwdGlobMapping(f.projA))
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	// cd into the mapped dir and reconcile so the wrapper exists and the
+	// wrap dir is first on PATH, then drive a bare-name `fakecmd` through
+	// the widget.
+	out := f.runZsh(fmt.Sprintf("cd %q && __jitenv_chpwd", f.projA), "fakecmd")
+	t.Logf("output:\n%s", out)
+	if !strings.Contains(out, "FOO=from-cwd") {
+		t.Errorf("zsh cwd_glob bare-name: expected FOO=from-cwd via the wrapper; got:\n%s", out)
+	}
+	// A double-dispatch would run the command twice → two FOO= lines.
+	if n := strings.Count(out, "FOO="); n != 1 {
+		t.Errorf("expected exactly one FOO= line (no double dispatch); got %d:\n%s", n, out)
 	}
 }

--- a/internal/shell/cwd_path_change_e2e_test.go
+++ b/internal/shell/cwd_path_change_e2e_test.go
@@ -468,3 +468,94 @@ fakecmd
 		t.Errorf("after prompt fire: expected FOO=from-cwd; got:\n%s", afterPrompt)
 	}
 }
+
+// pathMappingFor maps the absolute path of fakeBin/fakecmd.
+func (f *cpcFixture) pathMappingFor() []config.Mapping {
+	return []config.Mapping{{
+		Path: filepath.Join(f.fakeBin, "fakecmd"),
+		Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}},
+	}}
+}
+
+// TestPathMapping_BareNameInvocationInjects is the #237 regression: a
+// `path` mapping for an absolute file fires even when the command is
+// typed as a bare name resolved through $PATH (not just ./foo or an
+// absolute path). The hook now `type -P`s the bare name and routes the
+// resolved absolute path through `jitenv is-mapped`.
+func TestPathMapping_BareNameInvocationInjects(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(f.pathMappingFor())
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	// fakeBin is on PATH (see runBashAllowErr), so `fakecmd` is a bare
+	// name that resolves through $PATH to the mapped absolute file.
+	out := f.runBash(`
+echo '--- bare ---'
+fakecmd
+`)
+	t.Logf("output:\n%s", out)
+	if bare := sectionBetween(out, "--- bare ---", ""); !strings.Contains(bare, "FOO=from-cwd") {
+		t.Errorf("bare-name PATH invocation: expected FOO=from-cwd; got:\n%s", bare)
+	}
+}
+
+// TestPathMapping_BareNameBuiltinOrTypoRunsNormally verifies the new
+// PATH branch fails open: a shell builtin and an unresolvable typo both
+// yield an empty `type -P`, so the hook returns 0 and the command runs
+// without any jitenv involvement.
+func TestPathMapping_BareNameBuiltinOrTypoRunsNormally(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(f.pathMappingFor())
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	// `echo` is a builtin (empty type -P) and `definitely_not_a_cmd_237`
+	// does not resolve — neither should trip the mapped path.
+	out, code := f.runBashAllowErr(`
+echo '--- builtin ---'
+definitely_not_a_cmd_237 2>/dev/null
+echo '--- done ---'
+`)
+	t.Logf("output (exit %d):\n%s", code, out)
+	if strings.Contains(out, "FOO=from-cwd") {
+		t.Errorf("builtin/typo path should not inject; got:\n%s", out)
+	}
+	if !strings.Contains(out, "--- builtin ---") || !strings.Contains(out, "--- done ---") {
+		t.Errorf("expected the script to run to completion; got:\n%s", out)
+	}
+}
+
+// TestCwdGlob_BareNameNotDoubleDispatched is the critical #237
+// correctness guard: once a cwd_glob wrapper is built, the wrapper dir
+// is first on $PATH, so a bare `fakecmd` resolves to the wrapper. The
+// new PATH branch must short-circuit (resolved under $__JITENV_WRAP_DIR
+// → return 0) and let the wrapper shim do the single is-mapped call, so
+// cwd_glob behavior is byte-for-byte what it was before #237: injection
+// still works and the command is not dispatched twice.
+func TestCwdGlob_BareNameNotDoubleDispatched(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(cwdGlobMapping(f.projA))
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	out := f.runBash(fmt.Sprintf(`
+cd %q
+__jitenv_chpwd             # build the wrapper + clear the hash
+echo '--- via-wrapper ---'
+fakecmd                    # bare name → resolves to the wrapper, not double-dispatched
+`, f.projA))
+	t.Logf("output:\n%s", out)
+	section := sectionBetween(out, "--- via-wrapper ---", "")
+	if !strings.Contains(section, "FOO=from-cwd") {
+		t.Errorf("cwd_glob bare-name: expected FOO=from-cwd via the wrapper; got:\n%s", section)
+	}
+	// The wrapper emits exactly one injected line. A double-dispatch
+	// would run the command twice → two FOO= lines.
+	if n := strings.Count(section, "FOO="); n != 1 {
+		t.Errorf("expected exactly one FOO= line (no double dispatch); got %d:\n%s", n, section)
+	}
+}

--- a/internal/shell/render_test.go
+++ b/internal/shell/render_test.go
@@ -44,6 +44,32 @@ func TestRenderBakesPaths(t *testing.T) {
 	}
 }
 
+// TestRenderHasPathResolvedBranch is the render-level guard for #237:
+// both the bash and zsh hooks must resolve bare-name commands through
+// $PATH (type -P / whence -p) and must short-circuit when that resolves
+// into the cwd_glob wrapper dir so wrappers are not double-dispatched.
+func TestRenderHasPathResolvedBranch(t *testing.T) {
+	t.Setenv("JITENV_CONFIG", "")
+	cases := map[string]string{
+		"bash": "builtin type -P -- ",
+		"zsh":  "whence -p -- ",
+	}
+	for sh, lookup := range cases {
+		t.Run(sh, func(t *testing.T) {
+			out, err := Render(sh)
+			if err != nil {
+				t.Fatalf("Render(%q): %v", sh, err)
+			}
+			if !strings.Contains(out, lookup) {
+				t.Errorf("%s hook missing PATH-resolution lookup %q:\n%s", sh, lookup, out)
+			}
+			if !strings.Contains(out, `"$__JITENV_WRAP_DIR/"*`) {
+				t.Errorf("%s hook missing the cwd_glob wrapper double-dispatch guard:\n%s", sh, out)
+			}
+		})
+	}
+}
+
 // TestRenderQuotesShellMetacharacters guards against an XDG_RUNTIME_DIR
 // or config path with a single quote in it (Windows-mounted home dirs,
 // users with apostrophes in their names, etc.). The single-quote-escape

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -170,7 +170,17 @@ __jitenv_debug_trap() {
     elif [[ "$first" = ./* || "$first" = ../* ]]; then
         resolved="$(cd "$(dirname "$first")" 2>/dev/null && pwd)/$(basename "$first")"
     else
-        return 0
+        # Bare name → resolve through $PATH so `path`/`glob` mappings fire
+        # on PATH-invoked commands too, not just explicit-path ones.
+        # `type -P` only reports a real executable file (skips builtins,
+        # aliases, functions, and typos, which yield an empty result →
+        # run normally). (issue #237)
+        resolved="$(builtin type -P -- "$first" 2>/dev/null)"
+        [[ -z "$resolved" ]] && return 0
+        # If the name resolved to a cwd_glob wrapper, the wrapper shim
+        # already calls is-mapped itself — routing it through here too
+        # would double-dispatch. Let the wrapper handle it.
+        [[ "$resolved" == "$__JITENV_WRAP_DIR/"* ]] && return 0
     fi
     [[ ! -f "$resolved" ]] && return 0
 

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -125,7 +125,21 @@ __jitenv_accept_line() {
         case "$first" in
             /*)        resolved="$first" ;;
             ./*|../*)  resolved="${PWD}/${first#./}" ;;
-            *)         resolved="" ;;
+            *)
+                # Bare name → resolve through $PATH so `path`/`glob`
+                # mappings fire on PATH-invoked commands too, not just
+                # explicit-path ones. `whence -p` reports only a real
+                # executable file (skips builtins, aliases, functions,
+                # and typos, which yield an empty result → run normally).
+                # If it resolves to a cwd_glob wrapper, the wrapper shim
+                # already calls is-mapped itself, so don't double-dispatch
+                # — leave resolved empty and let the wrapper handle it.
+                # (issue #237)
+                resolved="$(whence -p -- "$first" 2>/dev/null)"
+                if [[ "$resolved" == "$__JITENV_WRAP_DIR/"* ]]; then
+                    resolved=""
+                fi
+                ;;
         esac
         if [[ -n "$resolved" && -f "$resolved" ]]; then
             __jitenv_log "candidate cmd=[$BUFFER] resolved=[$resolved]"


### PR DESCRIPTION
Implements two related issues in one branch.

## #238 — fix flaky `TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent`

**Root cause:** the test fixture anchored the agent runtime dir (and thus the AF_UNIX socket) under `t.TempDir()`, which embeds the test name. For this long-named test the socket path `<tmp>/runtime/jitenv/agent.sock` exceeded the `sun_path` limit (108 bytes on Linux), so bind/connect failed with `EINVAL` ("invalid argument") and the agent was permanently unreachable — the "unlocked" phase fell through to the agent-down path and got `FOO=MISSING`. It only reproduced on hosts where `$TMPDIR` + the test name pushed the path over the limit (e.g. WSL2 `/tmp/claude-1000/...`).

**Fix:**
- Anchor the fixture's runtime dir at a short, test-name-independent `os.MkdirTemp("", "jrt-")` path (cleaned up via `t.Cleanup`), keeping the socket path well under the limit.
- Make `startAgent` block until the agent socket actually round-trips a `status` op (instead of silently giving up after a fixed poll) and `t.Fatalf` with the agent log if it never comes up — so any future readiness problem fails loudly instead of as a misleading "agent down" assertion.

Verified stable with `-count=3`.

## #237 — fire path/glob mappings on PATH-resolved bare-name commands

The bash/zsh DEBUG-trap hook previously only routed a command through `jitenv is-mapped` when the first token started with `/`, `./`, or `../`. Bare names resolved via `$PATH` were silently skipped, so a `path = "/usr/local/bin/terraform"` mapping never fired when the user typed just `terraform`.

**Change:**
- bash: new branch resolves a bare name with `builtin type -P -- "$first"`.
- zsh: equivalent with `whence -p -- "$first"`.
- Both short-circuit (`return 0` / empty `resolved`) when the resolution lands under `$__JITENV_WRAP_DIR`, so cwd_glob wrappers are **not** double-dispatched — the wrapper shim still does the single `is-mapped` call.
- Builtins/aliases/functions/typos resolve empty → run normally (unchanged behavior).
- No Go changes: `jitenv is-mapped` already accepts any absolute path.

**Tests:**
- `TestPathMapping_BareNameInvocationInjects` — bare-name PATH invocation now injects.
- `TestPathMapping_BareNameBuiltinOrTypoRunsNormally` — builtin/typo fail open.
- `TestCwdGlob_BareNameNotDoubleDispatched` — wrapper invoked by bare name still injects exactly once (regression guard).
- `TestRenderHasPathResolvedBranch` — render-level guard that both bash and zsh snippets carry the PATH lookup and the wrapper double-dispatch guard (zsh has no runtime e2e in this suite / no zsh in CI sandbox).

**Docs:** updated `README.md`, `docs/shell-hook.md`, `docs/troubleshooting.md` — the old "explicit-path invocation only" wording is replaced with the PATH-resolved semantics.

Verification: `go test ./...`, `gofmt`, `go vet`, and `golangci-lint run` all clean.

Closes #237
Closes #238