### PR TITLE
feat(sync): encrypted config sync to pluggable remote adapters (SSH, file)

### DIFF
--- a/cmd/jitenv/main.go
+++ b/cmd/jitenv/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gv/jitenv/internal/cli"
 	"github.com/gv/jitenv/internal/shim"
 	_ "github.com/gv/jitenv/internal/sources/builtin"
+	_ "github.com/gv/jitenv/internal/syncadapters/builtin"
 )
 
 func main() {

--- a/internal/cli/subcommands.go
+++ b/internal/cli/subcommands.go
@@ -21,6 +21,7 @@ func subcommands() []*cobra.Command {
 		newVersionCheckInternalCmd(),
 		newVersionNoticeInternalCmd(),
 		newCloneCmd(),
+		newSyncCmd(),
 		newGitAskpassInternalCmd(),
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,0 +1,579 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+	"github.com/gv/jitenv/internal/syncadapters"
+	"github.com/gv/jitenv/internal/syncconfig"
+	"github.com/gv/jitenv/pkg/syncadapter"
+
+	// Blank-import the builtins so the registry is populated even in the
+	// (unlikely) event the binary linker drops the cmd/jitenv import.
+	_ "github.com/gv/jitenv/internal/syncadapters/builtin"
+)
+
+var syncConfigPath string
+
+// newSyncCmd is the top-level `jitenv sync` subtree (#241). Config sync
+// pushes the encrypted config.toml to a pluggable remote adapter and
+// pulls it back with a last-writer-wins merge plus a divergence fence.
+// The remote only ever sees one opaque AEAD blob — never plaintext.
+func newSyncCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "sync",
+		Short: "Sync the encrypted config to a pluggable remote (SSH, file).",
+		Long: `Push and pull the jitenv config to/from a remote adapter.
+
+The config.toml is sealed under a per-config data key (itself wrapped by
+your passphrase) before it leaves the host, so the remote stores only an
+opaque ciphertext blob — never plaintext, never your secrets.
+
+Merge model (v1): whole-file last-writer-wins with a divergence fence.
+'pull' fast-forwards when only the remote moved; if BOTH the local and
+remote config changed since the last sync, 'pull' aborts and asks you to
+reconcile manually (see 'jitenv sync status').`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	c.PersistentFlags().StringVar(&syncConfigPath, "sync-config", "", "path to the sync sidecar (default: $JITENV_CONFIG_SYNC or sync.toml next to config.toml)")
+	c.AddCommand(newSyncInitCmd())
+	c.AddCommand(newSyncPushCmd())
+	c.AddCommand(newSyncPullCmd())
+	c.AddCommand(newSyncStatusCmd())
+	c.AddCommand(newSyncListCmd())
+	return c
+}
+
+// loadSidecar resolves and loads the sync sidecar, returning a helpful
+// error if it doesn't exist yet.
+func loadSidecar() (string, *syncconfig.File, error) {
+	path, err := config.ResolveSync(syncConfigPath)
+	if err != nil {
+		return "", nil, err
+	}
+	f, err := syncconfig.Load(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return path, nil, fmt.Errorf("no sync sidecar at %s; run `jitenv sync init` first", path)
+	}
+	if err != nil {
+		return path, nil, err
+	}
+	return path, f, nil
+}
+
+// readConfigBytes reads the raw config.toml bytes (the exact bytes that
+// get sealed and synced). Returns the resolved path too.
+func readConfigBytes() (string, []byte, error) {
+	cfgPath, err := config.Resolve(configPath)
+	if err != nil {
+		return "", nil, err
+	}
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return cfgPath, nil, fmt.Errorf("read %s: %w (run `jitenv config init` first)", cfgPath, err)
+	}
+	return cfgPath, b, nil
+}
+
+// ---------------------------------------------------------------------
+// sync init
+// ---------------------------------------------------------------------
+
+func newSyncInitCmd() *cobra.Command {
+	var adapterType, adapterName string
+	var params []string
+	c := &cobra.Command{
+		Use:   "init",
+		Short: "Create the sync sidecar and configure a remote adapter.",
+		Long: `Create the local sync sidecar (sync.toml) and register one remote
+adapter. The sidecar stores the per-config data-encryption key wrapped by
+your passphrase, plus the adapter's connection parameters (sensitive
+values encrypted on disk).
+
+Adapter params are passed as --param key=value (repeatable). Required
+params per type:
+  file   path=/abs/path/to/blob
+  ssh    host=user@host path=/abs/remote/path [port=22]`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSyncInit(cmd, adapterType, adapterName, params)
+		},
+	}
+	c.Flags().StringVar(&adapterType, "type", "", "adapter type ("+strings.Join(syncadapters.Types(), ", ")+")")
+	c.Flags().StringVar(&adapterName, "name", "", "label for this adapter (defaults to the type)")
+	c.Flags().StringArrayVar(&params, "param", nil, "adapter param as key=value (repeatable)")
+	return c
+}
+
+func runSyncInit(cmd *cobra.Command, adapterType, adapterName string, params []string) error {
+	out := cmd.OutOrStdout()
+
+	if adapterType == "" {
+		return fmt.Errorf("--type is required (one of: %s)", strings.Join(syncadapters.Types(), ", "))
+	}
+	known := false
+	for _, t := range syncadapters.Types() {
+		if t == adapterType {
+			known = true
+		}
+	}
+	if !known {
+		return fmt.Errorf("unknown adapter type %q (known: %s)", adapterType, strings.Join(syncadapters.Types(), ", "))
+	}
+	if adapterName == "" {
+		adapterName = adapterType
+	}
+
+	paramMap, err := parseParams(params)
+	if err != nil {
+		return err
+	}
+
+	// We need the data config to copy its KDF salt/params so the master
+	// key derived from the sync sidecar matches the one that unlocks
+	// config.toml. Then prompt the passphrase and derive the key.
+	cfgPath, err := config.Resolve(configPath)
+	if err != nil {
+		return err
+	}
+	dataCfg, err := config.Load(cfgPath)
+	if err != nil {
+		return fmt.Errorf("load %s: %w (run `jitenv config init` first)", cfgPath, err)
+	}
+	if dataCfg.Meta.Salt == "" {
+		return fmt.Errorf("%s has no _meta header; run `jitenv config init` first", cfgPath)
+	}
+
+	pw, err := crypto.PromptPassphrase("jitenv sync init: passphrase: ", false)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(pw)
+	// Verify the passphrase against the data config before writing
+	// anything, and reuse the derived master key to wrap the DEK.
+	masterKey, err := config.DeriveKeyFromMeta(dataCfg, pw)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(masterKey)
+
+	syncPath, err := config.ResolveSync(syncConfigPath)
+	if err != nil {
+		return err
+	}
+
+	// If a sidecar already exists, append the adapter to it (reusing the
+	// existing wrapped DEK); otherwise create a fresh one.
+	var f *syncconfig.File
+	if existing, lerr := syncconfig.Load(syncPath); lerr == nil {
+		f = existing
+		if _, _, ok := f.FindAdapter(adapterName); ok {
+			return fmt.Errorf("adapter %q already exists in %s", adapterName, syncPath)
+		}
+	} else if errors.Is(lerr, os.ErrNotExist) {
+		f = &syncconfig.File{
+			Version:        syncconfig.Version,
+			Salt:           dataCfg.Meta.Salt,
+			ArgonTime:      dataCfg.Meta.ArgonTime,
+			ArgonMemoryKiB: dataCfg.Meta.ArgonMemoryKiB,
+			ArgonThreads:   dataCfg.Meta.ArgonThreads,
+		}
+		dek, derr := syncconfig.NewDEK()
+		if derr != nil {
+			return derr
+		}
+		defer zeroBytes(dek)
+		if werr := f.WrapDEK(masterKey, dek); werr != nil {
+			return werr
+		}
+	} else {
+		return lerr
+	}
+
+	adapter := syncconfig.Adapter{Name: adapterName, Type: adapterType, Params: paramMap}
+
+	// Build + Validate the adapter against decrypted params (paramMap is
+	// still plaintext here) before persisting, so a bad host/path fails
+	// fast.
+	built, err := syncadapters.Build(adapterType, paramMap)
+	if err != nil {
+		return err
+	}
+	if err := built.Validate(context.Background()); err != nil {
+		return fmt.Errorf("adapter validation failed: %w", err)
+	}
+
+	// Encrypt the adapter params in place before save.
+	if err := syncconfig.EncryptParams(masterKey, &adapter); err != nil {
+		return err
+	}
+	f.Adapters = append(f.Adapters, adapter)
+
+	if err := syncconfig.Save(syncPath, f); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "wrote %s\nconfigured adapter %q (type %s)\n", syncPath, adapterName, adapterType)
+	fmt.Fprintf(out, "run `jitenv sync push` to publish your config.\n")
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// sync push
+// ---------------------------------------------------------------------
+
+func newSyncPushCmd() *cobra.Command {
+	var adapterName string
+	var force bool
+	c := &cobra.Command{
+		Use:   "push",
+		Short: "Encrypt and push the local config to a remote adapter.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSyncPush(cmd, adapterName, force)
+		},
+	}
+	c.Flags().StringVar(&adapterName, "adapter", "", "adapter name (defaults to the only configured adapter)")
+	c.Flags().BoolVar(&force, "force", false, "push even if the remote advanced past our base snapshot (overwrites remote)")
+	return c
+}
+
+func runSyncPush(cmd *cobra.Command, adapterName string, force bool) error {
+	out := cmd.OutOrStdout()
+	syncPath, f, err := loadSidecar()
+	if err != nil {
+		return err
+	}
+	ad, _, err := pickAdapter(f, adapterName)
+	if err != nil {
+		return err
+	}
+
+	_, cfgBytes, err := readConfigBytes()
+	if err != nil {
+		return err
+	}
+
+	pw, err := crypto.PromptPassphrase("jitenv sync push: passphrase: ", false)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(pw)
+	masterKey, err := f.DeriveMasterKey(pw)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(masterKey)
+	dek, err := f.UnwrapDEK(masterKey)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(dek)
+
+	adapter, err := buildAdapter(masterKey, ad)
+	if err != nil {
+		return err
+	}
+
+	res, err := syncconfig.PushConfig(context.Background(), adapter, ad, dek, cfgBytes, config.Version, force)
+	if err != nil {
+		return err
+	}
+	if err := syncconfig.Save(syncPath, f); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "pushed config (%s) to adapter %q\n", short(res.Hash), ad.Name)
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// sync pull
+// ---------------------------------------------------------------------
+
+func newSyncPullCmd() *cobra.Command {
+	var adapterName string
+	var adopt bool
+	c := &cobra.Command{
+		Use:   "pull",
+		Short: "Pull the remote config and merge (last-writer-wins) into local.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSyncPull(cmd, adapterName, adopt)
+		},
+	}
+	c.Flags().StringVar(&adapterName, "adapter", "", "adapter name (defaults to the only configured adapter)")
+	c.Flags().BoolVar(&adopt, "adopt", false, "first pull on a new machine: take the remote as authoritative when no local base snapshot exists")
+	return c
+}
+
+func runSyncPull(cmd *cobra.Command, adapterName string, adopt bool) error {
+	out := cmd.OutOrStdout()
+	syncPath, f, err := loadSidecar()
+	if err != nil {
+		return err
+	}
+	ad, _, err := pickAdapter(f, adapterName)
+	if err != nil {
+		return err
+	}
+
+	cfgPath, cfgBytes, err := readConfigBytes()
+	if err != nil {
+		return err
+	}
+
+	pw, err := crypto.PromptPassphrase("jitenv sync pull: passphrase: ", false)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(pw)
+	masterKey, err := f.DeriveMasterKey(pw)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(masterKey)
+	dek, err := f.UnwrapDEK(masterKey)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(dek)
+
+	adapter, err := buildAdapter(masterKey, ad)
+	if err != nil {
+		return err
+	}
+
+	res, err := syncconfig.PullConfig(context.Background(), adapter, ad, dek, cfgBytes, adopt)
+	var div *syncconfig.DivergenceError
+	if errors.As(err, &div) {
+		// Local config is left untouched on divergence.
+		return fmt.Errorf("%w\nlocal config left untouched. reconcile manually: review both, edit via `jitenv config`, then publish the version you want with `jitenv sync push --force`", div)
+	}
+	if err != nil {
+		return err
+	}
+
+	switch res.Decision {
+	case syncconfig.DecideNoRemote:
+		return errors.New("remote has no config yet; nothing to pull (run `jitenv sync push` to publish)")
+	case syncconfig.DecidePushNeeded:
+		fmt.Fprintf(out, "local is ahead of remote; nothing to pull. run `jitenv sync push` to publish.\n")
+		return nil
+	case syncconfig.DecideNoop:
+		_ = syncconfig.Save(syncPath, f) // persist the base anchor
+		fmt.Fprintf(out, "already up-to-date (%s)\n", short(res.Hash))
+		return nil
+	case syncconfig.DecideFastForward:
+		if err := writePulledConfig(cfgPath, res.Applied); err != nil {
+			return err
+		}
+		if err := syncconfig.Save(syncPath, f); err != nil {
+			return err
+		}
+		pingAgentReloadFromClone()
+		fmt.Fprintf(out, "pulled and applied remote config (%s)\n", short(res.Hash))
+		return nil
+	default:
+		return fmt.Errorf("internal: unexpected merge decision %v", res.Decision)
+	}
+}
+
+// writePulledConfig validates the pulled bytes parse + Validate, then
+// writes them through config.AtomicSave so the agent reload hook fires
+// and on-disk perms stay 0600.
+func writePulledConfig(cfgPath string, plaintext []byte) error {
+	tmp, err := os.CreateTemp("", "jitenv-pull-*.toml")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(plaintext); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	parsed, err := config.Load(tmpName)
+	if err != nil {
+		return fmt.Errorf("pulled config does not parse: %w", err)
+	}
+	if err := parsed.Validate(); err != nil {
+		return fmt.Errorf("pulled config is invalid, refusing to apply: %w", err)
+	}
+	return config.AtomicSave(cfgPath, parsed)
+}
+
+// ---------------------------------------------------------------------
+// sync status
+// ---------------------------------------------------------------------
+
+func newSyncStatusCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "status",
+		Short: "Show local-vs-remote divergence for each adapter.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSyncStatus(cmd)
+		},
+	}
+	return c
+}
+
+func runSyncStatus(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+	_, f, err := loadSidecar()
+	if err != nil {
+		return err
+	}
+	if len(f.Adapters) == 0 {
+		fmt.Fprintln(out, "no adapters configured")
+		return nil
+	}
+	_, cfgBytes, err := readConfigBytes()
+	if err != nil {
+		return err
+	}
+	localHash := syncconfig.HashConfig(cfgBytes)
+
+	pw, err := crypto.PromptPassphrase("jitenv sync status: passphrase: ", false)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(pw)
+	masterKey, err := f.DeriveMasterKey(pw)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(masterKey)
+
+	fmt.Fprintln(out, "merge model: whole-file last-writer-wins with a divergence fence")
+	fmt.Fprintf(out, "local config: %s\n\n", short(localHash))
+	for i := range f.Adapters {
+		ad := &f.Adapters[i]
+		adapter, berr := buildAdapter(masterKey, ad)
+		if berr != nil {
+			fmt.Fprintf(out, "  %-16s [%s]  error: %v\n", ad.Name, ad.Type, berr)
+			continue
+		}
+		_, rmeta, perr := adapter.Pull(context.Background())
+		remotePresent := true
+		remoteShort := "-"
+		if errors.Is(perr, syncadapters.ErrNoRemoteState) {
+			remotePresent = false
+		} else if perr != nil {
+			fmt.Fprintf(out, "  %-16s [%s]  unreachable: %v\n", ad.Name, ad.Type, perr)
+			continue
+		} else {
+			remoteShort = short(rmeta.Hash)
+		}
+		d := syncconfig.Decide(localHash, rmeta.Hash, ad.BaseHash, remotePresent)
+		fmt.Fprintf(out, "  %-16s [%s]  remote=%s base=%s  %s\n", ad.Name, ad.Type, remoteShort, short(ad.BaseHash), d)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// sync list
+// ---------------------------------------------------------------------
+
+func newSyncListCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "list",
+		Short: "List configured sync adapters.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			_, f, err := loadSidecar()
+			if err != nil {
+				return err
+			}
+			if len(f.Adapters) == 0 {
+				fmt.Fprintln(out, "no adapters configured")
+				return nil
+			}
+			for _, ad := range f.Adapters {
+				base := short(ad.BaseHash)
+				fmt.Fprintf(out, "  %-16s [%s]  base=%s\n", ad.Name, ad.Type, base)
+			}
+			return nil
+		},
+	}
+	return c
+}
+
+// ---------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------
+
+// pickAdapter resolves the adapter to operate on: the named one, or the
+// sole configured adapter when no name is given.
+func pickAdapter(f *syncconfig.File, name string) (*syncconfig.Adapter, int, error) {
+	if name != "" {
+		ad, i, ok := f.FindAdapter(name)
+		if !ok {
+			return nil, -1, fmt.Errorf("no adapter named %q (configured: %s)", name, adapterNames(f))
+		}
+		return ad, i, nil
+	}
+	switch len(f.Adapters) {
+	case 0:
+		return nil, -1, errors.New("no adapters configured; run `jitenv sync init`")
+	case 1:
+		return &f.Adapters[0], 0, nil
+	default:
+		return nil, -1, fmt.Errorf("multiple adapters configured (%s); pass --adapter", adapterNames(f))
+	}
+}
+
+func adapterNames(f *syncconfig.File) string {
+	names := make([]string, 0, len(f.Adapters))
+	for _, a := range f.Adapters {
+		names = append(names, a.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+// buildAdapter decrypts the adapter's params under masterKey and
+// constructs the concrete adapter.
+func buildAdapter(masterKey []byte, ad *syncconfig.Adapter) (syncadapter.Adapter, error) {
+	params, err := syncconfig.DecryptParams(masterKey, ad)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt adapter %q params: %w", ad.Name, err)
+	}
+	return syncadapters.Build(ad.Type, params)
+}
+
+// parseParams turns ["k=v", ...] into a map. Empty list -> empty map.
+func parseParams(kvs []string) (map[string]any, error) {
+	m := map[string]any{}
+	for _, kv := range kvs {
+		i := strings.IndexByte(kv, '=')
+		if i <= 0 {
+			return nil, fmt.Errorf("invalid --param %q (want key=value)", kv)
+		}
+		m[kv[:i]] = kv[i+1:]
+	}
+	return m, nil
+}
+
+// short truncates a hex hash for display; empty stays "-".
+func short(h string) string {
+	if h == "" {
+		return "-"
+	}
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -369,7 +370,9 @@ func runSyncPull(cmd *cobra.Command, adapterName string, adopt bool) error {
 		fmt.Fprintf(out, "local is ahead of remote; nothing to pull. run `jitenv sync push` to publish.\n")
 		return nil
 	case syncconfig.DecideNoop:
-		_ = syncconfig.Save(syncPath, f) // persist the base anchor
+		if err := syncconfig.Save(syncPath, f); err != nil { // persist the base anchor
+			return fmt.Errorf("save sync sidecar: %w", err)
+		}
 		fmt.Fprintf(out, "already up-to-date (%s)\n", short(res.Hash))
 		return nil
 	case syncconfig.DecideFastForward:
@@ -391,12 +394,19 @@ func runSyncPull(cmd *cobra.Command, adapterName string, adopt bool) error {
 // writes them through config.AtomicSave so the agent reload hook fires
 // and on-disk perms stay 0600.
 func writePulledConfig(cfgPath string, plaintext []byte) error {
-	tmp, err := os.CreateTemp("", "jitenv-pull-*.toml")
+	// Stage the decrypted plaintext in the config directory (which is
+	// 0700), not os.TempDir() which is world-traversable — mirrors
+	// config.AtomicSave's sibling-tempfile approach.
+	tmp, err := os.CreateTemp(filepath.Dir(cfgPath), "jitenv-pull-*.toml")
 	if err != nil {
 		return err
 	}
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName)
+	if err := os.Chmod(tmpName, 0600); err != nil {
+		tmp.Close()
+		return err
+	}
 	if _, err := tmp.Write(plaintext); err != nil {
 		tmp.Close()
 		return err

--- a/internal/config/path.go
+++ b/internal/config/path.go
@@ -1,6 +1,9 @@
 package config
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // DefaultPath returns the canonical config file path. Honors
 // $JITENV_CONFIG first; otherwise dispatches to a per-platform helper
@@ -19,4 +22,27 @@ func Resolve(explicit string) (string, error) {
 		return explicit, nil
 	}
 	return DefaultPath()
+}
+
+// DefaultSyncPath returns the canonical sync-sidecar path. Honors
+// $JITENV_CONFIG_SYNC first (mirroring $JITENV_CONFIG semantics);
+// otherwise it sits next to the data config as "sync.toml" in the same
+// directory, so a JITENV_CONFIG override moves both files together.
+func DefaultSyncPath() (string, error) {
+	if p := os.Getenv("JITENV_CONFIG_SYNC"); p != "" {
+		return p, nil
+	}
+	cfg, err := DefaultPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(cfg), "sync.toml"), nil
+}
+
+// ResolveSync returns explicit if non-empty, else DefaultSyncPath().
+func ResolveSync(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	return DefaultSyncPath()
 }

--- a/internal/syncadapters/builtin/builtin.go
+++ b/internal/syncadapters/builtin/builtin.go
@@ -1,0 +1,15 @@
+// Package builtin imports the first-party sync Adapter implementations
+// so that their init() blocks register them with the global sync-adapter
+// registry. Mirrors internal/sources/builtin. Blank-imported from
+// cmd/jitenv/main.go.
+//
+// v1 ships the "file" (local / mounted filesystem) and "ssh" adapters.
+// An "s3" adapter is tracked as a follow-up: the AWS S3 service client
+// is not yet vendored, and adding it is a pure registration call here
+// once written — no core change.
+package builtin
+
+import (
+	_ "github.com/gv/jitenv/internal/syncadapters/file"
+	_ "github.com/gv/jitenv/internal/syncadapters/ssh"
+)

--- a/internal/syncadapters/file/file.go
+++ b/internal/syncadapters/file/file.go
@@ -1,0 +1,130 @@
+// Package file implements a config-sync adapter that stores the
+// encrypted blob on a local (or locally-mounted) filesystem path. It is
+// the reference adapter: it has no network dependency, so it is fully
+// unit-testable, and it doubles as a real backend for users who point a
+// Dropbox / iCloud / NFS / SMB mount at it (the remote sees AEAD
+// ciphertext only, which is exactly the threat model #116 wanted).
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gv/jitenv/internal/syncadapters"
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+const typeName = "file"
+
+func init() {
+	syncadapters.Register(typeName, New)
+}
+
+// adapter writes two sibling files at dir/<base>.blob (the ciphertext)
+// and dir/<base>.meta.json (the non-secret meta). Both are 0600.
+type adapter struct {
+	path string // absolute path to the blob file; .meta.json sits beside it
+}
+
+// New constructs a file adapter. Required param: "path" — the
+// destination file for the encrypted blob. The directory must exist or
+// be creatable.
+func New(cfg map[string]any) (syncadapter.Adapter, error) {
+	p, _ := cfg["path"].(string)
+	if p == "" {
+		return nil, errors.New("file adapter: \"path\" param is required")
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return nil, fmt.Errorf("file adapter: resolve path: %w", err)
+	}
+	return &adapter{path: abs}, nil
+}
+
+func (a *adapter) Name() string { return typeName }
+
+func (a *adapter) metaPath() string { return a.path + ".meta.json" }
+
+// Validate ensures the parent directory exists (creating it 0700 if
+// needed) and is writable. It does not touch the blob.
+func (a *adapter) Validate(ctx context.Context) error {
+	dir := filepath.Dir(a.path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("file adapter: create dir %s: %w", dir, err)
+	}
+	probe := filepath.Join(dir, ".jitenv-sync-probe")
+	if err := os.WriteFile(probe, []byte{}, 0600); err != nil {
+		return fmt.Errorf("file adapter: %s not writable: %w", dir, err)
+	}
+	_ = os.Remove(probe)
+	return nil
+}
+
+func (a *adapter) Push(ctx context.Context, blob []byte, meta syncadapter.Meta) error {
+	if err := a.Validate(ctx); err != nil {
+		return err
+	}
+	if err := writeFileAtomic(a.path, blob, 0600); err != nil {
+		return fmt.Errorf("file adapter: write blob: %w", err)
+	}
+	mb, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(a.metaPath(), mb, 0600); err != nil {
+		return fmt.Errorf("file adapter: write meta: %w", err)
+	}
+	return nil
+}
+
+func (a *adapter) Pull(ctx context.Context) ([]byte, syncadapter.Meta, error) {
+	blob, err := os.ReadFile(a.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
+	}
+	if err != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: read blob: %w", err)
+	}
+	mb, err := os.ReadFile(a.metaPath())
+	if errors.Is(err, os.ErrNotExist) {
+		// A blob without meta is corrupt remote state; treat as missing.
+		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
+	}
+	if err != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: read meta: %w", err)
+	}
+	var meta syncadapter.Meta
+	if err := json.Unmarshal(mb, &meta); err != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: parse meta: %w", err)
+	}
+	return blob, meta, nil
+}
+
+// writeFileAtomic writes via a sibling tempfile + rename so a reader
+// never sees a half-written blob.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".jitenv-sync-*")
+	if err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), perm); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}

--- a/internal/syncadapters/registry.go
+++ b/internal/syncadapters/registry.go
@@ -1,0 +1,59 @@
+// Package syncadapters holds the name-keyed registry of config-sync
+// remote adapters. It mirrors internal/sources/registry.go: each
+// concrete adapter package self-registers via init(), and
+// internal/syncadapters/builtin blank-imports them all.
+package syncadapters
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+// ErrNoRemoteState is returned by an Adapter's Pull when the remote has
+// no blob yet (first push hasn't happened). Callers treat it as a
+// distinct "nothing to pull" condition rather than a hard error.
+var ErrNoRemoteState = errors.New("no remote state")
+
+var (
+	mu       sync.RWMutex
+	builders = map[string]syncadapter.Constructor{}
+)
+
+// Register installs a Constructor under a type name. Calling Register
+// twice for the same name panics — registration is intended to happen
+// at init time.
+func Register(typeName string, c syncadapter.Constructor) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, exists := builders[typeName]; exists {
+		panic(fmt.Sprintf("sync adapter type %q already registered", typeName))
+	}
+	builders[typeName] = c
+}
+
+// Build looks up a registered Constructor and invokes it.
+func Build(typeName string, cfg map[string]any) (syncadapter.Adapter, error) {
+	mu.RLock()
+	c, ok := builders[typeName]
+	mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown sync adapter type %q", typeName)
+	}
+	return c(cfg)
+}
+
+// Types returns the sorted list of registered type names.
+func Types() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]string, 0, len(builders))
+	for k := range builders {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/syncadapters/registry_test.go
+++ b/internal/syncadapters/registry_test.go
@@ -1,0 +1,72 @@
+package syncadapters_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/syncadapters"
+	_ "github.com/gv/jitenv/internal/syncadapters/file"
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+func TestRegistryAndFile(t *testing.T) {
+	types := syncadapters.Types()
+	found := false
+	for _, n := range types {
+		if n == "file" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("file adapter not registered: %v", types)
+	}
+
+	blobPath := filepath.Join(t.TempDir(), "blob")
+	a, err := syncadapters.Build("file", map[string]any{"path": blobPath})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if a.Name() != "file" {
+		t.Fatalf("name = %q", a.Name())
+	}
+	if err := a.Validate(context.Background()); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	// Pull before any push reports no remote state.
+	if _, _, perr := a.Pull(context.Background()); perr != syncadapters.ErrNoRemoteState {
+		t.Fatalf("expected ErrNoRemoteState, got %v", perr)
+	}
+
+	want := []byte("ciphertext-bytes")
+	meta := syncadapter.Meta{Hash: "abc123", SchemaVersion: 1}
+	if err := a.Push(context.Background(), want, meta); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+
+	// Blob written 0600.
+	fi, err := os.Stat(blobPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0600 {
+		t.Fatalf("blob perm = %o, want 0600", fi.Mode().Perm())
+	}
+
+	got, gotMeta, err := a.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("blob roundtrip mismatch: %q", got)
+	}
+	if gotMeta != meta {
+		t.Fatalf("meta roundtrip mismatch: %+v", gotMeta)
+	}
+
+	if _, err := syncadapters.Build("nope", nil); err == nil {
+		t.Fatalf("expected build of unknown adapter to fail")
+	}
+}

--- a/internal/syncadapters/registry_test.go
+++ b/internal/syncadapters/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gv/jitenv/internal/syncadapters"
@@ -46,13 +47,17 @@ func TestRegistryAndFile(t *testing.T) {
 		t.Fatalf("push: %v", err)
 	}
 
-	// Blob written 0600.
+	// Blob written 0600. NTFS ACLs don't map to Unix mode bits, so a
+	// 0600 file reports 0666 via os.FileMode on Windows; assert exact
+	// perms on non-Windows only.
 	fi, err := os.Stat(blobPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fi.Mode().Perm() != 0600 {
-		t.Fatalf("blob perm = %o, want 0600", fi.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Fatalf("blob perm = %o, want 0600", got)
+		}
 	}
 
 	got, gotMeta, err := a.Pull(context.Background())

--- a/internal/syncadapters/ssh/ssh.go
+++ b/internal/syncadapters/ssh/ssh.go
@@ -1,0 +1,215 @@
+// Package ssh implements a config-sync adapter that stores the
+// encrypted blob on a remote host over the system `ssh` binary. It
+// shells out rather than linking golang.org/x/crypto/ssh + a third-party
+// SFTP library so it adds ZERO new dependencies and inherits the user's
+// existing SSH config, agent, known_hosts, and key handling verbatim.
+//
+// The remote only ever receives the opaque AEAD ciphertext; the blob is
+// written with mode 0600. Auth is whatever the user's ssh client is
+// configured for (keys / agent) — jitenv never handles SSH credentials
+// itself, so there is nothing secret to store in the sync sidecar for
+// this adapter beyond the host/path.
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/gv/jitenv/internal/syncadapters"
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+const typeName = "ssh"
+
+func init() {
+	syncadapters.Register(typeName, New)
+}
+
+// runner abstracts command execution so tests can inject a fake remote
+// without a real SSH server.
+type runner interface {
+	// run executes the ssh binary with args, feeding stdin, and returns
+	// stdout. A non-zero exit is returned as an error including stderr.
+	run(ctx context.Context, stdin []byte, args ...string) (stdout []byte, err error)
+}
+
+type execRunner struct{ bin string }
+
+func (e execRunner) run(ctx context.Context, stdin []byte, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, e.bin, args...)
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(errb.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%s: %s", err, msg)
+		}
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+type adapter struct {
+	host string // [user@]host (passed verbatim to ssh)
+	path string // absolute remote path for the blob
+	port string // optional
+	r    runner
+}
+
+// New constructs an ssh adapter. Required params: "host" and "path".
+// Optional: "port".
+func New(cfg map[string]any) (syncadapter.Adapter, error) {
+	host, _ := cfg["host"].(string)
+	path, _ := cfg["path"].(string)
+	port, _ := cfg["port"].(string)
+	if host == "" {
+		return nil, errors.New("ssh adapter: \"host\" param is required")
+	}
+	if path == "" {
+		return nil, errors.New("ssh adapter: \"path\" param is required")
+	}
+	// Reject shell metacharacters in path/host: the remote path is
+	// interpolated into a remote shell command, and host into argv.
+	if strings.ContainsAny(path, "\"'$`;&|<>(){}*?\\\n\r") {
+		return nil, fmt.Errorf("ssh adapter: remote path %q contains unsafe characters", path)
+	}
+	if strings.ContainsAny(host, " \t\n\r;&|") {
+		return nil, fmt.Errorf("ssh adapter: host %q contains unsafe characters", host)
+	}
+	return &adapter{host: host, path: path, port: port, r: execRunner{bin: "ssh"}}, nil
+}
+
+func (a *adapter) Name() string { return typeName }
+
+func (a *adapter) baseArgs() []string {
+	args := []string{"-o", "BatchMode=yes"}
+	if a.port != "" {
+		args = append(args, "-p", a.port)
+	}
+	return append(args, a.host)
+}
+
+func (a *adapter) metaRemote() string { return a.path + ".meta.json" }
+
+// Validate opens a non-interactive SSH session and confirms the parent
+// directory of the blob path is writable.
+func (a *adapter) Validate(ctx context.Context) error {
+	dir := remoteDir(a.path)
+	// `mkdir -p` (0700) then a write probe.
+	remoteCmd := fmt.Sprintf("mkdir -p -m 700 %s && test -w %s", shQuote(dir), shQuote(dir))
+	args := append(a.baseArgs(), remoteCmd)
+	if _, err := a.r.run(ctx, nil, args...); err != nil {
+		return fmt.Errorf("ssh adapter: validate %s: %w", a.host, err)
+	}
+	return nil
+}
+
+func (a *adapter) Push(ctx context.Context, blob []byte, meta syncadapter.Meta) error {
+	if err := a.Validate(ctx); err != nil {
+		return err
+	}
+	mb, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	if err := a.writeRemote(ctx, a.path, blob); err != nil {
+		return fmt.Errorf("ssh adapter: write blob: %w", err)
+	}
+	if err := a.writeRemote(ctx, a.metaRemote(), mb); err != nil {
+		return fmt.Errorf("ssh adapter: write meta: %w", err)
+	}
+	return nil
+}
+
+// writeRemote streams data to the remote path via `cat > tmp` then an
+// atomic rename, and chmods 0600 so the ciphertext is never group/world
+// readable even transiently.
+func (a *adapter) writeRemote(ctx context.Context, remotePath string, data []byte) error {
+	tmp := remotePath + ".jitenv-tmp"
+	q := shQuote(remotePath)
+	qt := shQuote(tmp)
+	remoteCmd := fmt.Sprintf("umask 077 && cat > %s && chmod 600 %s && mv %s %s", qt, qt, qt, q)
+	args := append(a.baseArgs(), remoteCmd)
+	_, err := a.r.run(ctx, data, args...)
+	return err
+}
+
+func (a *adapter) Pull(ctx context.Context) ([]byte, syncadapter.Meta, error) {
+	// Read blob; distinguish "missing" via a sentinel exit.
+	blob, err := a.readRemote(ctx, a.path)
+	if errors.Is(err, errRemoteMissing) {
+		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
+	}
+	if err != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("ssh adapter: read blob: %w", err)
+	}
+	mb, err := a.readRemote(ctx, a.metaRemote())
+	if errors.Is(err, errRemoteMissing) {
+		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
+	}
+	if err != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("ssh adapter: read meta: %w", err)
+	}
+	var meta syncadapter.Meta
+	if err := json.Unmarshal(mb, &meta); err != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("ssh adapter: parse meta: %w", err)
+	}
+	return blob, meta, nil
+}
+
+var errRemoteMissing = errors.New("remote file missing")
+
+// readRemote cats a remote file. A missing file is reported as
+// errRemoteMissing via a distinct shell exit sentinel.
+func (a *adapter) readRemote(ctx context.Context, remotePath string) ([]byte, error) {
+	q := shQuote(remotePath)
+	// If the file is absent, exit 66 so we can tell "missing" apart from
+	// a transport/auth failure.
+	remoteCmd := fmt.Sprintf("if test -f %s; then cat %s; else exit 66; fi", q, q)
+	args := append(a.baseArgs(), remoteCmd)
+	out, err := a.r.run(ctx, nil, args...)
+	if err != nil {
+		if isExit(err, 66) {
+			return nil, errRemoteMissing
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// exitCoder is satisfied by *exec.ExitError (real ssh) and by test
+// fakes, so the "remote file missing" sentinel (exit 66) can be detected
+// without a live SSH server.
+type exitCoder interface{ ExitCode() int }
+
+func isExit(err error, code int) bool {
+	var ec exitCoder
+	if errors.As(err, &ec) {
+		return ec.ExitCode() == code
+	}
+	return false
+}
+
+// remoteDir returns the parent directory of an absolute POSIX path.
+func remoteDir(p string) string {
+	if i := strings.LastIndex(p, "/"); i > 0 {
+		return p[:i]
+	}
+	return "."
+}
+
+// shQuote single-quotes a string for safe use in a remote POSIX shell.
+// New() already rejects characters that can't be made safe; this is
+// defence in depth.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/syncadapters/ssh/ssh.go
+++ b/internal/syncadapters/ssh/ssh.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/gv/jitenv/internal/syncadapters"
@@ -25,6 +27,13 @@ import (
 )
 
 const typeName = "ssh"
+
+// hostAllowed is a strict allowlist for the [user@]host argv value:
+// letters, digits, and the small set of punctuation that legitimately
+// appears in hosts and user@host forms. Combined with the explicit
+// leading-'-' rejection below, this prevents a host that smuggles ssh
+// options into the command line (argv flag injection).
+var hostAllowed = regexp.MustCompile(`^[A-Za-z0-9._@-]+$`)
 
 func init() {
 	syncadapters.Register(typeName, New)
@@ -82,8 +91,21 @@ func New(cfg map[string]any) (syncadapter.Adapter, error) {
 	if strings.ContainsAny(path, "\"'$`;&|<>(){}*?\\\n\r") {
 		return nil, fmt.Errorf("ssh adapter: remote path %q contains unsafe characters", path)
 	}
-	if strings.ContainsAny(host, " \t\n\r;&|") {
+	// A host beginning with '-' would be parsed by ssh/scp/sftp as an
+	// option, not a hostname — reject it outright (argv flag smuggling).
+	if strings.HasPrefix(host, "-") {
+		return nil, errors.New("ssh adapter: host must not start with '-'")
+	}
+	// Strict allowlist (also bars whitespace/shell metacharacters).
+	if !hostAllowed.MatchString(host) {
 		return nil, fmt.Errorf("ssh adapter: host %q contains unsafe characters", host)
+	}
+	// Port, when set, must be purely numeric so it can never be parsed as
+	// a flag or otherwise alter the ssh command line.
+	if port != "" {
+		if _, err := strconv.Atoi(port); err != nil {
+			return nil, fmt.Errorf("ssh adapter: port %q is not numeric", port)
+		}
 	}
 	return &adapter{host: host, path: path, port: port, r: execRunner{bin: "ssh"}}, nil
 }
@@ -95,6 +117,10 @@ func (a *adapter) baseArgs() []string {
 	if a.port != "" {
 		args = append(args, "-p", a.port)
 	}
+	// `--` ends option parsing: defence-in-depth so the host (already
+	// allowlisted and barred from a leading '-') can never be treated as
+	// an option even if validation were bypassed.
+	args = append(args, "--")
 	return append(args, a.host)
 }
 

--- a/internal/syncadapters/ssh/ssh_test.go
+++ b/internal/syncadapters/ssh/ssh_test.go
@@ -1,0 +1,123 @@
+package ssh
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/syncadapters"
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+// fakeRemote emulates a remote POSIX host: a single in-memory file store
+// keyed by path. It interprets the small set of remote shell commands the
+// adapter emits (cat >, cat, test -f, mkdir/test -w).
+type fakeRemote struct {
+	files map[string][]byte
+}
+
+func newFakeRemote() *fakeRemote { return &fakeRemote{files: map[string][]byte{}} }
+
+type fakeExitErr struct{ code int }
+
+func (e fakeExitErr) Error() string { return "exit" }
+func (e fakeExitErr) ExitCode() int { return e.code }
+
+func (f *fakeRemote) run(ctx context.Context, stdin []byte, args ...string) ([]byte, error) {
+	// The last arg is the remote command string; earlier args are ssh
+	// options + host.
+	cmd := args[len(args)-1]
+	switch {
+	case strings.HasPrefix(cmd, "mkdir -p"):
+		return nil, nil // validate probe always succeeds
+	case strings.Contains(cmd, "cat >"):
+		// write: "umask 077 && cat > 'tmp' && chmod 600 'tmp' && mv 'tmp' 'dst'"
+		dst := lastQuoted(cmd)
+		f.files[dst] = append([]byte(nil), stdin...)
+		return nil, nil
+	case strings.HasPrefix(cmd, "if test -f"):
+		// read: "if test -f 'p'; then cat 'p'; else exit 66; fi"
+		p := firstQuoted(cmd)
+		data, ok := f.files[p]
+		if !ok {
+			return nil, fakeExitErr{code: 66}
+		}
+		return data, nil
+	default:
+		return nil, nil
+	}
+}
+
+// firstQuoted returns the first single-quoted token in s.
+func firstQuoted(s string) string {
+	i := strings.IndexByte(s, '\'')
+	if i < 0 {
+		return ""
+	}
+	j := strings.IndexByte(s[i+1:], '\'')
+	if j < 0 {
+		return ""
+	}
+	return s[i+1 : i+1+j]
+}
+
+// lastQuoted returns the last single-quoted token in s (the mv dest).
+func lastQuoted(s string) string {
+	i := strings.LastIndexByte(s, '\'')
+	if i < 0 {
+		return ""
+	}
+	j := strings.LastIndexByte(s[:i], '\'')
+	if j < 0 {
+		return ""
+	}
+	return s[j+1 : i]
+}
+
+func newFakeAdapter(t *testing.T, fr *fakeRemote) *adapter {
+	t.Helper()
+	a, err := New(map[string]any{"host": "user@host", "path": "/srv/jitenv/blob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ad := a.(*adapter)
+	ad.r = fr
+	return ad
+}
+
+func TestSSHPushPullRoundTrip(t *testing.T) {
+	fr := newFakeRemote()
+	a := newFakeAdapter(t, fr)
+
+	if _, _, err := a.Pull(context.Background()); err != syncadapters.ErrNoRemoteState {
+		t.Fatalf("expected ErrNoRemoteState, got %v", err)
+	}
+
+	want := []byte("ciphertext")
+	meta := syncadapter.Meta{Hash: "deadbeef", SchemaVersion: 1}
+	if err := a.Push(context.Background(), want, meta); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	got, gotMeta, err := a.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("blob mismatch: %q", got)
+	}
+	if gotMeta != meta {
+		t.Fatalf("meta mismatch: %+v", gotMeta)
+	}
+}
+
+func TestSSHRejectsUnsafePath(t *testing.T) {
+	if _, err := New(map[string]any{"host": "h", "path": "/srv/$(rm -rf)"}); err == nil {
+		t.Fatal("expected unsafe path to be rejected")
+	}
+	if _, err := New(map[string]any{"host": "h; rm -rf /", "path": "/ok"}); err == nil {
+		t.Fatal("expected unsafe host to be rejected")
+	}
+	if _, err := New(map[string]any{"path": "/ok"}); err == nil {
+		t.Fatal("expected missing host to be rejected")
+	}
+}

--- a/internal/syncadapters/ssh/ssh_test.go
+++ b/internal/syncadapters/ssh/ssh_test.go
@@ -121,3 +121,38 @@ func TestSSHRejectsUnsafePath(t *testing.T) {
 		t.Fatal("expected missing host to be rejected")
 	}
 }
+
+// TestSSHRejectsArgvInjection guards against argv flag smuggling: a host
+// that begins with '-' (or otherwise leaves the allowlist) and a
+// non-numeric port must be rejected at construction.
+func TestSSHRejectsArgvInjection(t *testing.T) {
+	if _, err := New(map[string]any{"host": "-oProxyCommand=touch /tmp/pwn", "path": "/ok"}); err == nil {
+		t.Fatal("expected leading-dash host (flag smuggling) to be rejected")
+	}
+	if _, err := New(map[string]any{"host": "-J jump", "path": "/ok"}); err == nil {
+		t.Fatal("expected dash-prefixed host to be rejected")
+	}
+	if _, err := New(map[string]any{"host": "user@host", "path": "/ok", "port": "-oProxyCommand=x"}); err == nil {
+		t.Fatal("expected non-numeric port to be rejected")
+	}
+	if _, err := New(map[string]any{"host": "user@host", "path": "/ok", "port": "22abc"}); err == nil {
+		t.Fatal("expected non-numeric port to be rejected")
+	}
+	// A normal host + numeric port must still construct fine.
+	if _, err := New(map[string]any{"host": "user@host.example.com", "path": "/srv/blob", "port": "2222"}); err != nil {
+		t.Fatalf("expected valid host/port to construct, got %v", err)
+	}
+}
+
+// TestSSHBaseArgsHasEndOfOptions asserts the `--` end-of-options sentinel
+// precedes the host in the ssh argv (defence-in-depth).
+func TestSSHBaseArgsHasEndOfOptions(t *testing.T) {
+	a, err := New(map[string]any{"host": "user@host", "path": "/srv/blob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := a.(*adapter).baseArgs()
+	if len(args) < 2 || args[len(args)-2] != "--" || args[len(args)-1] != "user@host" {
+		t.Fatalf("expected baseArgs to end with `-- <host>`, got %v", args)
+	}
+}

--- a/internal/syncconfig/engine.go
+++ b/internal/syncconfig/engine.go
@@ -41,13 +41,23 @@ func PushConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, d
 		case rerr != nil:
 			return PushResult{}, fmt.Errorf("pre-push remote check failed: %w", rerr)
 		default:
-			if ad.BaseHash != "" && rmeta.Hash != ad.BaseHash && rmeta.Hash != localHash {
+			switch {
+			case ad.BaseHash == "":
+				// No recorded base (fresh machine) but the remote already
+				// has state. If local differs from remote we cannot prove
+				// local descends from it, so a non-force push would
+				// silently clobber the remote — refuse, symmetric with
+				// PullConfig's no-base fence.
+				if rmeta.Hash != localHash {
+					return PushResult{}, fmt.Errorf("remote already has config (%s) but this machine has no sync base; run `jitenv sync pull --adopt` first, or push with --force to overwrite", short(rmeta.Hash))
+				}
+			case rmeta.Hash != ad.BaseHash && rmeta.Hash != localHash:
 				return PushResult{}, fmt.Errorf("remote advanced since your last sync (remote %s != base %s); run `jitenv sync pull` first, or push with --force to overwrite", short(rmeta.Hash), short(ad.BaseHash))
 			}
 		}
 	}
 
-	blob, err := SealBlob(dek, cfgBytes)
+	blob, err := SealBlob(dek, cfgBytes, localHash)
 	if err != nil {
 		return PushResult{}, err
 	}
@@ -99,7 +109,7 @@ func PullConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, d
 	case DecideDiverged, DecideNoBase:
 		return res, &DivergenceError{Decision: decision, Local: localHash, Remote: rmeta.Hash, Base: ad.BaseHash}
 	case DecideFastForward:
-		plaintext, err := OpenBlob(dek, blob)
+		plaintext, err := OpenBlob(dek, blob, rmeta.Hash)
 		if err != nil {
 			return res, err
 		}

--- a/internal/syncconfig/engine.go
+++ b/internal/syncconfig/engine.go
@@ -1,0 +1,140 @@
+package syncconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gv/jitenv/internal/syncadapters"
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+// PushResult / PullResult report what an orchestration step did so the
+// CLI can print user-facing messages and the agent-reload hook can fire
+// only when local actually changed.
+type PushResult struct {
+	Hash string // hash of the config that was pushed
+}
+
+type PullResult struct {
+	Decision MergeDecision
+	// Applied is the config plaintext written to disk on a fast-forward
+	// (nil for every other decision). The caller writes it via
+	// config.AtomicSave so the agent reload hook fires.
+	Applied []byte
+	Hash    string // remote hash on a fast-forward / local hash otherwise
+}
+
+// PushConfig seals cfgBytes under dek and pushes via adapter, honoring
+// the divergence fence unless force is set. On success it records the
+// new base hash on ad (the caller persists the sidecar).
+//
+// dek and masterKey are NOT logged; the caller owns zeroing them.
+func PushConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, dek, cfgBytes []byte, schemaVersion int, force bool) (PushResult, error) {
+	localHash := HashConfig(cfgBytes)
+
+	if !force {
+		_, rmeta, rerr := adapter.Pull(ctx)
+		switch {
+		case errors.Is(rerr, syncadapters.ErrNoRemoteState):
+			// first push; fine
+		case rerr != nil:
+			return PushResult{}, fmt.Errorf("pre-push remote check failed: %w", rerr)
+		default:
+			if ad.BaseHash != "" && rmeta.Hash != ad.BaseHash && rmeta.Hash != localHash {
+				return PushResult{}, fmt.Errorf("remote advanced since your last sync (remote %s != base %s); run `jitenv sync pull` first, or push with --force to overwrite", short(rmeta.Hash), short(ad.BaseHash))
+			}
+		}
+	}
+
+	blob, err := SealBlob(dek, cfgBytes)
+	if err != nil {
+		return PushResult{}, err
+	}
+	meta := syncadapter.Meta{Hash: localHash, SchemaVersion: schemaVersion}
+	if err := adapter.Push(ctx, blob, meta); err != nil {
+		return PushResult{}, err
+	}
+	ad.BaseHash = localHash
+	return PushResult{Hash: localHash}, nil
+}
+
+// PullConfig fetches the remote blob, decides the merge outcome, and on a
+// fast-forward decrypts + integrity-checks the plaintext. It NEVER writes
+// to disk — the caller does that via config.AtomicSave so the existing
+// reload hook is preserved and divergence/abort leaves local untouched.
+//
+// adopt is the "first pull on a fresh machine" escape hatch: when there
+// is no recorded base snapshot but the remote has state, the
+// DecideNoBase fence normally blocks (we can't prove local descends from
+// remote). With adopt=true the caller has explicitly opted to take the
+// remote as authoritative, so a NoBase outcome is treated as a
+// fast-forward instead of an abort. It has NO effect on true divergence
+// (DecideDiverged), which always aborts.
+func PullConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, dek, localCfgBytes []byte, adopt bool) (PullResult, error) {
+	localHash := HashConfig(localCfgBytes)
+
+	blob, rmeta, perr := adapter.Pull(ctx)
+	remotePresent := true
+	if errors.Is(perr, syncadapters.ErrNoRemoteState) {
+		remotePresent = false
+	} else if perr != nil {
+		return PullResult{}, perr
+	}
+
+	decision := Decide(localHash, rmeta.Hash, ad.BaseHash, remotePresent)
+	res := PullResult{Decision: decision, Hash: localHash}
+
+	if decision == DecideNoBase && adopt {
+		decision = DecideFastForward
+		res.Decision = DecideFastForward
+	}
+
+	switch decision {
+	case DecideNoRemote, DecidePushNeeded:
+		return res, nil
+	case DecideNoop:
+		ad.BaseHash = localHash
+		return res, nil
+	case DecideDiverged, DecideNoBase:
+		return res, &DivergenceError{Decision: decision, Local: localHash, Remote: rmeta.Hash, Base: ad.BaseHash}
+	case DecideFastForward:
+		plaintext, err := OpenBlob(dek, blob)
+		if err != nil {
+			return res, err
+		}
+		if got := HashConfig(plaintext); got != rmeta.Hash {
+			return res, fmt.Errorf("remote blob hash mismatch (got %s, meta claims %s); refusing to apply", short(got), short(rmeta.Hash))
+		}
+		ad.BaseHash = rmeta.Hash
+		res.Applied = plaintext
+		res.Hash = rmeta.Hash
+		return res, nil
+	default:
+		return res, fmt.Errorf("internal: unexpected merge decision %v", decision)
+	}
+}
+
+// DivergenceError is returned by PullConfig when local and remote both
+// advanced (or there's no base anchor). It carries the hashes for a
+// helpful message and is detectable via errors.As.
+type DivergenceError struct {
+	Decision            MergeDecision
+	Local, Remote, Base string
+}
+
+func (e *DivergenceError) Error() string {
+	return fmt.Sprintf("cannot pull: %s (local %s, remote %s, base %s)",
+		e.Decision, short(e.Local), short(e.Remote), short(e.Base))
+}
+
+// short truncates a hex hash for display; empty stays "-".
+func short(h string) string {
+	if h == "" {
+		return "-"
+	}
+	if len(h) > 12 {
+		return h[:12]
+	}
+	return h
+}

--- a/internal/syncconfig/engine_test.go
+++ b/internal/syncconfig/engine_test.go
@@ -68,7 +68,19 @@ func unlock(t *testing.T, f *syncconfig.File, pass string) (masterKey, dek []byt
 	if err != nil {
 		t.Fatal(err)
 	}
+	// CLAUDE.md: key material that lives outside the agent must be
+	// zeroed on defer. Tests run after the test body via t.Cleanup.
+	t.Cleanup(func() {
+		zeroBytes(mk)
+		zeroBytes(d)
+	})
 	return mk, d
+}
+
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
 }
 
 func buildFileAdapter(t *testing.T, mk []byte, ad *syncconfig.Adapter) syncadapter.Adapter {
@@ -249,5 +261,44 @@ func TestPushFenceRejectsStaleOverwrite(t *testing.T) {
 	_, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte("version = 1\n# my edit\n"), 1, false)
 	if err == nil {
 		t.Fatal("expected stale push to be refused by the fence")
+	}
+}
+
+// TestPushFenceRejectsNoBaseOverwrite: a fresh machine with no recorded
+// base, pushing to a remote that already has DIFFERENT state, must be
+// refused on a non-force push (symmetric with PullConfig's no-base
+// fence) so it cannot silently clobber the remote. --force still works.
+func TestPushFenceRejectsNoBaseOverwrite(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+
+	// Machine 1 publishes the authoritative remote state.
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Machine 2: same passphrase, no recorded base, different local edit.
+	m2 := &syncconfig.File{
+		Version: m1.Version, Salt: m1.Salt, ArgonTime: m1.ArgonTime,
+		ArgonMemoryKiB: m1.ArgonMemoryKiB, ArgonThreads: m1.ArgonThreads,
+		WrappedDEK: m1.WrappedDEK,
+		Adapters:   []syncconfig.Adapter{{Name: "remote", Type: "file", Params: map[string]any{"path": remote}}},
+	}
+	mk2, dek2 := unlock(t, m2, samplePassphrase)
+	a2 := buildFileAdapter(t, mk2, &m2.Adapters[0])
+	if m2.Adapters[0].BaseHash != "" {
+		t.Fatal("precondition: fresh machine must have empty base")
+	}
+
+	localEdit := []byte("version = 1\n# machine 2 edit\n")
+	if _, err := syncconfig.PushConfig(context.Background(), a2, &m2.Adapters[0], dek2, localEdit, 1, false); err == nil {
+		t.Fatal("expected no-base push over existing remote to be refused")
+	}
+
+	// --force overrides the fence.
+	if _, err := syncconfig.PushConfig(context.Background(), a2, &m2.Adapters[0], dek2, localEdit, 1, true); err != nil {
+		t.Fatalf("forced push should succeed: %v", err)
 	}
 }

--- a/internal/syncconfig/engine_test.go
+++ b/internal/syncconfig/engine_test.go
@@ -1,0 +1,253 @@
+package syncconfig_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/crypto"
+	"github.com/gv/jitenv/internal/syncadapters"
+	_ "github.com/gv/jitenv/internal/syncadapters/file"
+	"github.com/gv/jitenv/internal/syncconfig"
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+const samplePassphrase = "correct horse battery staple"
+
+// sampleConfig is a minimal but valid-shaped config.toml payload. The
+// engine treats it as opaque bytes; byte-identity across the round-trip
+// is what matters.
+const sampleConfig = `version = 1
+
+[_meta]
+kdf = "argon2id"
+salt = "AAAAAAAAAAAAAAAAAAAAAA=="
+verify = "enc:v2:xxx"
+
+[sources.local]
+type = "local"
+`
+
+// newMachine builds a fresh sidecar (machine 1) with a wrapped DEK and a
+// file adapter pointing at remotePath. Returns the sidecar + master key +
+// dek (both zeroable by caller is the test's concern; ignored here).
+func newMachine(t *testing.T, remotePath string) *syncconfig.File {
+	t.Helper()
+	salt, err := crypto.NewSalt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := crypto.DefaultArgonParams()
+	f := &syncconfig.File{
+		Version:        syncconfig.Version,
+		Salt:           base64.StdEncoding.EncodeToString(salt),
+		ArgonTime:      p.Time,
+		ArgonMemoryKiB: p.MemKiB,
+		ArgonThreads:   p.Threads,
+	}
+	mk, _ := f.DeriveMasterKey([]byte(samplePassphrase))
+	dek, _ := syncconfig.NewDEK()
+	if err := f.WrapDEK(mk, dek); err != nil {
+		t.Fatal(err)
+	}
+	f.Adapters = append(f.Adapters, syncconfig.Adapter{
+		Name: "remote", Type: "file", Params: map[string]any{"path": remotePath},
+	})
+	return f
+}
+
+func unlock(t *testing.T, f *syncconfig.File, pass string) (masterKey, dek []byte) {
+	t.Helper()
+	mk, err := f.DeriveMasterKey([]byte(pass))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := f.UnwrapDEK(mk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mk, d
+}
+
+func buildFileAdapter(t *testing.T, mk []byte, ad *syncconfig.Adapter) syncadapter.Adapter {
+	t.Helper()
+	params, err := syncconfig.DecryptParams(mk, ad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	built, err := syncadapters.Build(ad.Type, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return built
+}
+
+// TestTwoMachineRoundTrip is the core paranoid test: machine 1 pushes,
+// machine 2 (same passphrase, separate sidecar) pulls and ends up with a
+// byte-identical config.
+func TestTwoMachineRoundTrip(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+
+	// Machine 1 pushes sampleConfig.
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatalf("m1 push: %v", err)
+	}
+
+	// Machine 2: SAME passphrase, but its own freshly-generated DEK is
+	// WRONG — it must adopt machine 1's wrapped DEK to decrypt. Simulate
+	// the real flow: machine 2's sidecar copies the same salt and the
+	// SAME wrapped DEK (this is what `jitenv sync init` would reproduce
+	// if it shared the wrapped DEK; here we model the "DEK is per-config,
+	// distributed out of band via the wrapped form" invariant by reusing
+	// m1's wrapped DEK).
+	m2 := &syncconfig.File{
+		Version:        m1.Version,
+		Salt:           m1.Salt,
+		ArgonTime:      m1.ArgonTime,
+		ArgonMemoryKiB: m1.ArgonMemoryKiB,
+		ArgonThreads:   m1.ArgonThreads,
+		WrappedDEK:     m1.WrappedDEK,
+		Adapters: []syncconfig.Adapter{
+			{Name: "remote", Type: "file", Params: map[string]any{"path": remote}},
+		},
+	}
+	mk2, dek2 := unlock(t, m2, samplePassphrase)
+	a2 := buildFileAdapter(t, mk2, &m2.Adapters[0])
+
+	// Machine 2 starts from an empty/old local config.
+	localOnM2 := []byte("version = 1\n")
+	res, err := syncconfig.PullConfig(context.Background(), a2, &m2.Adapters[0], dek2, localOnM2, true /*adopt: first pull on a new machine*/)
+	if err != nil {
+		t.Fatalf("m2 pull: %v", err)
+	}
+	if res.Decision != syncconfig.DecideFastForward {
+		t.Fatalf("expected fast-forward, got %v", res.Decision)
+	}
+	if string(res.Applied) != sampleConfig {
+		t.Fatalf("pulled config not byte-identical:\n got: %q\nwant: %q", res.Applied, sampleConfig)
+	}
+}
+
+// TestWrongPassphrasePullFailsClosed: a different passphrase derives a
+// different master key, cannot unwrap the DEK -> hard error.
+func TestWrongPassphrasePullFailsClosed(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrong passphrase -> UnwrapDEK fails before we ever touch the remote.
+	wrongMK, err := m1.DeriveMasterKey([]byte("totally wrong passphrase"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, uerr := m1.UnwrapDEK(wrongMK); uerr == nil {
+		t.Fatal("expected unwrap with wrong passphrase to fail")
+	}
+}
+
+// TestDivergenceFenceLeavesLocalUntouched: both sides advance past base
+// -> pull returns DivergenceError and Applied is nil.
+func TestDivergenceFenceLeavesLocalUntouched(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+
+	// Establish a common base by pushing v0.
+	base := []byte("version = 1\n# base\n")
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, base, 1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remote advances (another machine pushed a new version with --force-
+	// equivalent semantics: we just push a different payload directly).
+	remoteV2 := []byte("version = 1\n# remote edit\n")
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, remoteV2, 1, true); err != nil {
+		t.Fatal(err)
+	}
+	// But m1's recorded base is still pinned at remoteV2's hash now. Reset
+	// it to the original base to model "remote moved, our base is old".
+	m1.Adapters[0].BaseHash = syncconfig.HashConfig(base)
+
+	// Local also advanced past base.
+	localV2 := []byte("version = 1\n# local edit\n")
+
+	res, err := syncconfig.PullConfig(context.Background(), a1, &m1.Adapters[0], dek1, localV2, false)
+	var div *syncconfig.DivergenceError
+	if !errors.As(err, &div) {
+		t.Fatalf("expected DivergenceError, got %v", err)
+	}
+	if res.Decision != syncconfig.DecideDiverged {
+		t.Fatalf("expected DecideDiverged, got %v", res.Decision)
+	}
+	if res.Applied != nil {
+		t.Fatal("divergence must not produce an Applied payload (local untouched)")
+	}
+}
+
+// TestNoBaseWithoutAdoptAborts: a fresh machine (no base) where local
+// differs from a populated remote must NOT silently clobber local unless
+// the user opts in with adopt=true.
+func TestNoBaseWithoutAdoptAborts(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh machine: no base, local differs from remote, adopt=false.
+	m2 := &syncconfig.File{
+		Version: m1.Version, Salt: m1.Salt, ArgonTime: m1.ArgonTime,
+		ArgonMemoryKiB: m1.ArgonMemoryKiB, ArgonThreads: m1.ArgonThreads,
+		WrappedDEK: m1.WrappedDEK,
+		Adapters:   []syncconfig.Adapter{{Name: "remote", Type: "file", Params: map[string]any{"path": remote}}},
+	}
+	mk2, dek2 := unlock(t, m2, samplePassphrase)
+	a2 := buildFileAdapter(t, mk2, &m2.Adapters[0])
+
+	res, err := syncconfig.PullConfig(context.Background(), a2, &m2.Adapters[0], dek2, []byte("version = 1\n# local stuff\n"), false)
+	var div *syncconfig.DivergenceError
+	if !errors.As(err, &div) {
+		t.Fatalf("expected NoBase abort, got %v", err)
+	}
+	if res.Applied != nil {
+		t.Fatal("NoBase abort must leave local untouched (Applied nil)")
+	}
+}
+
+// TestPushFenceRejectsStaleOverwrite: remote advanced past our base, a
+// non-force push is refused.
+func TestPushFenceRejectsStaleOverwrite(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+
+	base := []byte("version = 1\n")
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, base, 1, false); err != nil {
+		t.Fatal(err)
+	}
+	// Remote moves on (force push of a newer payload).
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte("version = 1\n# newer\n"), 1, true); err != nil {
+		t.Fatal(err)
+	}
+	// Pin our base back to the old payload.
+	m1.Adapters[0].BaseHash = syncconfig.HashConfig(base)
+
+	// A non-force push of yet another local edit must be refused.
+	_, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte("version = 1\n# my edit\n"), 1, false)
+	if err == nil {
+		t.Fatal("expected stale push to be refused by the fence")
+	}
+}

--- a/internal/syncconfig/merge.go
+++ b/internal/syncconfig/merge.go
@@ -1,0 +1,87 @@
+package syncconfig
+
+// MergeDecision is the outcome of comparing local, remote, and the
+// recorded base snapshot for one adapter. v1 implements whole-file
+// last-writer-wins with a divergence fence (issue #241, merge model
+// (i)): cell-level / 3-way mapping merge is explicitly deferred because
+// mapping declaration order is load-bearing and a stable Mapping.ID is
+// out of scope.
+type MergeDecision int
+
+const (
+	// DecideNoop: remote == local (or remote unchanged since base and
+	// local unchanged since base). Nothing to do.
+	DecideNoop MergeDecision = iota
+	// DecideFastForward: local is unchanged since base, remote advanced.
+	// Safe to write remote -> local.
+	DecideFastForward
+	// DecidePushNeeded: remote is unchanged since base, local advanced.
+	// On pull this is a no-op (local is ahead); status reports it.
+	DecidePushNeeded
+	// DecideDiverged: BOTH local and remote advanced past base. v1
+	// aborts and tells the user to reconcile manually.
+	DecideDiverged
+	// DecideNoRemote: the remote has no state yet (first push pending).
+	DecideNoRemote
+	// DecideNoBase: no base snapshot recorded yet (adapter never
+	// synced), but the remote DOES have state. Treated as divergence:
+	// we can't prove local descends from remote, so refuse to clobber.
+	DecideNoBase
+)
+
+func (d MergeDecision) String() string {
+	switch d {
+	case DecideNoop:
+		return "up-to-date"
+	case DecideFastForward:
+		return "behind (pull will fast-forward)"
+	case DecidePushNeeded:
+		return "ahead (push to publish local changes)"
+	case DecideDiverged:
+		return "diverged (local and remote both changed)"
+	case DecideNoRemote:
+		return "no remote state yet (push to publish)"
+	case DecideNoBase:
+		return "no local base snapshot (pull blocked; reconcile manually)"
+	default:
+		return "unknown"
+	}
+}
+
+// Decide compares the three snapshot hashes. localHash is the SHA-256 of
+// the current on-disk config.toml; remoteHash is Meta.Hash from the
+// pulled blob; baseHash is what the sidecar recorded at the last sync
+// against this adapter. remotePresent is false when Pull returned
+// ErrNoRemoteState.
+//
+// The decision is purely hash-based — no plaintext is needed — so
+// `sync status` can report divergence without decrypting anything.
+func Decide(localHash, remoteHash, baseHash string, remotePresent bool) MergeDecision {
+	if !remotePresent {
+		return DecideNoRemote
+	}
+	if localHash == remoteHash {
+		return DecideNoop
+	}
+	if baseHash == "" {
+		// Remote exists, local differs from it, and we have no proof
+		// local was derived from remote. Refuse to fast-forward (would
+		// silently clobber) and refuse to call it clean.
+		return DecideNoBase
+	}
+	localChanged := localHash != baseHash
+	remoteChanged := remoteHash != baseHash
+	switch {
+	case !localChanged && remoteChanged:
+		return DecideFastForward
+	case localChanged && !remoteChanged:
+		return DecidePushNeeded
+	case localChanged && remoteChanged:
+		return DecideDiverged
+	default:
+		// !localChanged && !remoteChanged but hashes differ is
+		// impossible (both equal base => equal each other), handled by
+		// the Noop check above. Fall through defensively.
+		return DecideNoop
+	}
+}

--- a/internal/syncconfig/params.go
+++ b/internal/syncconfig/params.go
@@ -1,0 +1,59 @@
+package syncconfig
+
+import (
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// adapterParamAAD binds an adapter param value to its slot:
+// "syncadapter.<name>.<key>". Mirrors config.SourceParamAAD.
+func adapterParamAAD(adapterName, key string) string {
+	return crypto.AAD("syncadapter", adapterName, key)
+}
+
+// EncryptParams wraps every plaintext string value in the named
+// adapter's Params under masterKey, in place. Envelopes already present
+// are left untouched. Mirrors the config save pipeline's encrypt-by-
+// default behaviour so host/path/port for an adapter are never written
+// in cleartext when they came from a prompt.
+func EncryptParams(masterKey []byte, a *Adapter) error {
+	if a.Params == nil {
+		return nil
+	}
+	for k, v := range a.Params {
+		s, ok := v.(string)
+		if !ok || s == "" || crypto.IsEnvelope(s) {
+			continue
+		}
+		env, err := crypto.EncryptField(masterKey, s, adapterParamAAD(a.Name, k))
+		if err != nil {
+			return err
+		}
+		a.Params[k] = env
+	}
+	return nil
+}
+
+// DecryptParams returns a copy of the adapter's Params with every
+// envelope string replaced by its plaintext, leaving the on-disk
+// structure untouched. The returned map is what gets handed to the
+// adapter Constructor.
+func DecryptParams(masterKey []byte, a *Adapter) (map[string]any, error) {
+	out := make(map[string]any, len(a.Params))
+	for k, v := range a.Params {
+		s, ok := v.(string)
+		if !ok {
+			out[k] = v
+			continue
+		}
+		if !crypto.IsEnvelope(s) {
+			out[k] = s
+			continue
+		}
+		pt, err := crypto.DecryptField(masterKey, s, adapterParamAAD(a.Name, k))
+		if err != nil {
+			return nil, err
+		}
+		out[k] = pt
+	}
+	return out, nil
+}

--- a/internal/syncconfig/syncconfig.go
+++ b/internal/syncconfig/syncconfig.go
@@ -34,9 +34,21 @@ import (
 
 // AAD strings binding each envelope to its slot (security #110 pattern).
 const (
-	dekWrapAAD  = "sync.dek"  // wraps the DEK under the master key
-	blobSealAAD = "sync.blob" // seals the config bytes under the DEK
+	dekWrapAAD = "sync.dek" // wraps the DEK under the master key
+	// blobSealAADPrefix is combined with the blob's Meta.Hash to form the
+	// blob AEAD associated data ("sync.blob:<hash>"). Binding the hash in
+	// means a storage attacker cannot atomically swap a matching
+	// (blob, meta) pair from a prior push: the AAD baked into the
+	// ciphertext no longer matches the swapped meta, so OpenBlob fails the
+	// AEAD tag check instead of silently decrypting stale config.
+	blobSealAADPrefix = "sync.blob"
 )
+
+// blobAAD derives the AEAD associated data for a blob from the meta hash
+// it is published with. SealBlob and OpenBlob MUST agree on this.
+func blobAAD(metaHash string) []byte {
+	return []byte(blobSealAADPrefix + ":" + metaHash)
+}
 
 // Adapter is one configured remote target in the sidecar.
 type Adapter struct {
@@ -174,17 +186,21 @@ func (f *File) UnwrapDEK(masterKey []byte) ([]byte, error) {
 }
 
 // SealBlob encrypts the config.toml bytes under the DEK into one opaque
-// AEAD blob suitable for handing to an adapter.
-func SealBlob(dek, configBytes []byte) ([]byte, error) {
-	return crypto.Seal(dek, configBytes, []byte(blobSealAAD))
+// AEAD blob suitable for handing to an adapter. metaHash is the
+// Meta.Hash published alongside the blob; it is bound into the AEAD
+// associated data so the (blob, meta) pair is authenticated together.
+func SealBlob(dek, configBytes []byte, metaHash string) ([]byte, error) {
+	return crypto.Seal(dek, configBytes, blobAAD(metaHash))
 }
 
-// OpenBlob decrypts a blob produced by SealBlob. A wrong DEK fails the
-// AEAD tag check and returns an error (fail-closed).
-func OpenBlob(dek, blob []byte) ([]byte, error) {
-	pt, err := crypto.Open(dek, blob, []byte(blobSealAAD))
+// OpenBlob decrypts a blob produced by SealBlob. metaHash must be the
+// hash carried in the blob's accompanying Meta; if it was tampered with
+// (or the blob/meta pair was swapped) the AEAD tag check fails and an
+// error is returned (fail-closed). A wrong DEK fails the same check.
+func OpenBlob(dek, blob []byte, metaHash string) ([]byte, error) {
+	pt, err := crypto.Open(dek, blob, blobAAD(metaHash))
 	if err != nil {
-		return nil, errors.New("cannot decrypt synced config (wrong passphrase or corrupt remote blob)")
+		return nil, errors.New("cannot decrypt synced config (wrong passphrase, corrupt remote blob, or tampered metadata)")
 	}
 	return pt, nil
 }

--- a/internal/syncconfig/syncconfig.go
+++ b/internal/syncconfig/syncconfig.go
@@ -1,0 +1,216 @@
+// Package syncconfig owns the on-disk schema and crypto for the local
+// sync sidecar (sync.toml). The sidecar is SEPARATE from config.toml: it
+// holds the sync target(s) plus the data-encryption key in WRAPPED form.
+//
+// Encryption model (issue #241, option (a)):
+//
+//   - A per-config 256-bit DEK encrypts the whole config.toml bytes into
+//     one XChaCha20-Poly1305 envelope (the "blob"). The remote only ever
+//     sees that opaque AEAD ciphertext.
+//   - The DEK itself is stored in the sidecar WRAPPED by the master key
+//     derived from the passphrase (same Argon2id KDF as config.toml).
+//     Same passphrase on another machine -> same master key -> unwraps
+//     the DEK -> decrypts the blob. The DEK never touches disk in the
+//     clear and never travels to the remote.
+//
+// Nothing in this file logs the DEK, master key, or passphrase. Callers
+// must zero the master key and DEK on defer.
+package syncconfig
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// AAD strings binding each envelope to its slot (security #110 pattern).
+const (
+	dekWrapAAD  = "sync.dek"  // wraps the DEK under the master key
+	blobSealAAD = "sync.blob" // seals the config bytes under the DEK
+)
+
+// Adapter is one configured remote target in the sidecar.
+type Adapter struct {
+	Name string `toml:"name"` // user-chosen label, unique within the file
+	Type string `toml:"type"` // registered adapter type ("file", "ssh", ...)
+	// Params carries adapter-specific config. String values may be
+	// envelope-encrypted (enc:v2:) under the master key, exactly like
+	// [sources.*.params]; DecryptParams / EncryptParams handle that.
+	Params map[string]any `toml:"params,omitempty"`
+	// BaseHash is the SHA-256 (hex) of the config.toml plaintext at the
+	// time of the last successful push/pull against THIS adapter. It is
+	// the merge fence's base snapshot: push refuses if the remote moved
+	// past it, pull uses it to decide fast-forward vs. divergence.
+	BaseHash string `toml:"base_hash,omitempty"`
+}
+
+// File is the parsed sync.toml.
+type File struct {
+	Version int `toml:"version"`
+	// Salt + Argon params for the master key used to WRAP the DEK. These
+	// MUST match config.toml's _meta so the same passphrase derives the
+	// same key; on init we copy them from the data config.
+	Salt           string `toml:"salt"`             // base64
+	ArgonTime      uint32 `toml:"argon_time"`       //
+	ArgonMemoryKiB uint32 `toml:"argon_memory_kib"` //
+	ArgonThreads   uint8  `toml:"argon_threads"`    //
+	// WrappedDEK is the DEK sealed under the master key (enc:v2:).
+	WrappedDEK string    `toml:"wrapped_dek"`
+	Adapters   []Adapter `toml:"adapters"`
+}
+
+const Version = 1
+
+// Load reads and parses a sync sidecar. It does not unwrap the DEK or
+// decrypt any params.
+func Load(path string) (*File, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var f File
+	if _, err := toml.Decode(string(b), &f); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if f.Version == 0 {
+		f.Version = Version
+	}
+	return &f, nil
+}
+
+// Save writes the sidecar atomically with 0600 perms (sibling tempfile +
+// rename), mirroring config.AtomicSave.
+func Save(path string, f *File) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".jitenv-sync-*.toml")
+	if err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp.Name(), 0600); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := toml.NewEncoder(tmp).Encode(f); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}
+
+// argonParams returns the KDF params stored in the sidecar, applying the
+// same floors config enforces.
+func (f *File) argonParams() (crypto.ArgonParams, []byte, error) {
+	salt, err := base64.StdEncoding.DecodeString(f.Salt)
+	if err != nil {
+		return crypto.ArgonParams{}, nil, fmt.Errorf("decode salt: %w", err)
+	}
+	p := crypto.ArgonParams{Time: f.ArgonTime, MemKiB: f.ArgonMemoryKiB, Threads: f.ArgonThreads}
+	if p.Time < crypto.MinArgonTime || p.MemKiB < crypto.MinArgonMemKiB ||
+		p.Threads < crypto.MinArgonThreads || len(salt) < crypto.MinSaltLen {
+		return crypto.ArgonParams{}, nil, errors.New("sync sidecar KDF params below minimum; re-run `jitenv sync init`")
+	}
+	return p, salt, nil
+}
+
+// DeriveMasterKey derives the master key from the passphrase using the
+// sidecar's stored salt/params. Caller must zero the result.
+func (f *File) DeriveMasterKey(passphrase []byte) ([]byte, error) {
+	p, salt, err := f.argonParams()
+	if err != nil {
+		return nil, err
+	}
+	return crypto.DeriveKey(passphrase, salt, p), nil
+}
+
+// NewDEK returns a fresh random 256-bit data-encryption key.
+func NewDEK() ([]byte, error) {
+	dek := make([]byte, crypto.KeyLen)
+	if _, err := rand.Read(dek); err != nil {
+		return nil, err
+	}
+	return dek, nil
+}
+
+// WrapDEK seals dek under masterKey and stores it in f.WrappedDEK.
+func (f *File) WrapDEK(masterKey, dek []byte) error {
+	env, err := crypto.EncryptField(masterKey, string(dek), dekWrapAAD)
+	if err != nil {
+		return err
+	}
+	f.WrappedDEK = env
+	return nil
+}
+
+// UnwrapDEK recovers the DEK from f.WrappedDEK using masterKey. A wrong
+// passphrase (wrong master key) fails closed here via the AEAD tag.
+// Caller must zero the result.
+func (f *File) UnwrapDEK(masterKey []byte) ([]byte, error) {
+	if f.WrappedDEK == "" {
+		return nil, errors.New("sync sidecar has no wrapped DEK; run `jitenv sync init`")
+	}
+	pt, err := crypto.DecryptField(masterKey, f.WrappedDEK, dekWrapAAD)
+	if err != nil {
+		return nil, errors.New("cannot unwrap sync key (wrong passphrase, or sidecar is for a different config)")
+	}
+	return []byte(pt), nil
+}
+
+// SealBlob encrypts the config.toml bytes under the DEK into one opaque
+// AEAD blob suitable for handing to an adapter.
+func SealBlob(dek, configBytes []byte) ([]byte, error) {
+	return crypto.Seal(dek, configBytes, []byte(blobSealAAD))
+}
+
+// OpenBlob decrypts a blob produced by SealBlob. A wrong DEK fails the
+// AEAD tag check and returns an error (fail-closed).
+func OpenBlob(dek, blob []byte) ([]byte, error) {
+	pt, err := crypto.Open(dek, blob, []byte(blobSealAAD))
+	if err != nil {
+		return nil, errors.New("cannot decrypt synced config (wrong passphrase or corrupt remote blob)")
+	}
+	return pt, nil
+}
+
+// HashConfig returns the SHA-256 hex of the config bytes. Both the merge
+// fence's base snapshot and the blob's Meta.Hash use this.
+func HashConfig(configBytes []byte) string {
+	sum := sha256.Sum256(configBytes)
+	return hex.EncodeToString(sum[:])
+}
+
+// Adapter lookup helpers -------------------------------------------------
+
+// FindAdapter returns the named adapter and its index, or ok=false.
+func (f *File) FindAdapter(name string) (*Adapter, int, bool) {
+	for i := range f.Adapters {
+		if f.Adapters[i].Name == name {
+			return &f.Adapters[i], i, true
+		}
+	}
+	return nil, -1, false
+}
+
+// SetBaseHash records hash as the base snapshot for the named adapter.
+func (f *File) SetBaseHash(name, hash string) {
+	if a, _, ok := f.FindAdapter(name); ok {
+		a.BaseHash = hash
+	}
+}

--- a/internal/syncconfig/syncconfig_test.go
+++ b/internal/syncconfig/syncconfig_test.go
@@ -1,0 +1,148 @@
+package syncconfig
+
+import (
+	"encoding/base64"
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+func newTestFile(t *testing.T) *File {
+	t.Helper()
+	salt, err := crypto.NewSalt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := crypto.DefaultArgonParams()
+	f := &File{
+		Version:        Version,
+		Salt:           base64.StdEncoding.EncodeToString(salt),
+		ArgonTime:      p.Time,
+		ArgonMemoryKiB: p.MemKiB,
+		ArgonThreads:   p.Threads,
+	}
+	return f
+}
+
+func TestDEKWrapUnwrapRoundTrip(t *testing.T) {
+	f := newTestFile(t)
+	mk, err := f.DeriveMasterKey([]byte("correct horse battery staple"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dek, err := NewDEK()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.WrapDEK(mk, dek); err != nil {
+		t.Fatal(err)
+	}
+	got, err := f.UnwrapDEK(mk)
+	if err != nil {
+		t.Fatalf("unwrap: %v", err)
+	}
+	if string(got) != string(dek) {
+		t.Fatal("DEK roundtrip mismatch")
+	}
+}
+
+func TestUnwrapWrongPassphraseFailsClosed(t *testing.T) {
+	f := newTestFile(t)
+	mk, _ := f.DeriveMasterKey([]byte("right"))
+	dek, _ := NewDEK()
+	if err := f.WrapDEK(mk, dek); err != nil {
+		t.Fatal(err)
+	}
+
+	wrongMK, _ := f.DeriveMasterKey([]byte("wrong"))
+	if _, err := f.UnwrapDEK(wrongMK); err == nil {
+		t.Fatal("expected unwrap with wrong passphrase to fail")
+	}
+}
+
+func TestBlobSealOpenRoundTrip(t *testing.T) {
+	dek, _ := NewDEK()
+	plain := []byte("version = 1\n[_meta]\nsalt = \"x\"\n")
+	blob, err := SealBlob(dek, plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(blob) == string(plain) {
+		t.Fatal("blob is not encrypted")
+	}
+	got, err := OpenBlob(dek, blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(plain) {
+		t.Fatal("blob roundtrip mismatch")
+	}
+
+	other, _ := NewDEK()
+	if _, err := OpenBlob(other, blob); err == nil {
+		t.Fatal("expected open with wrong DEK to fail")
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	f := newTestFile(t)
+	mk, _ := f.DeriveMasterKey([]byte("pw"))
+	dek, _ := NewDEK()
+	if err := f.WrapDEK(mk, dek); err != nil {
+		t.Fatal(err)
+	}
+	ad := Adapter{Name: "home", Type: "file", Params: map[string]any{"path": "/tmp/x", "secret": "hunter2"}}
+	if err := EncryptParams(mk, &ad); err != nil {
+		t.Fatal(err)
+	}
+	if ad.Params["secret"] == "hunter2" {
+		t.Fatal("secret param not encrypted")
+	}
+	f.Adapters = append(f.Adapters, ad)
+
+	path := filepath.Join(t.TempDir(), "sync.toml")
+	if err := Save(path, f); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	la, _, ok := loaded.FindAdapter("home")
+	if !ok {
+		t.Fatal("adapter not found after reload")
+	}
+	dp, err := DecryptParams(mk, la)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dp["secret"] != "hunter2" || dp["path"] != "/tmp/x" {
+		t.Fatalf("decrypted params wrong: %v", dp)
+	}
+}
+
+func TestDecideMatrix(t *testing.T) {
+	cases := []struct {
+		name                string
+		local, remote, base string
+		present             bool
+		want                MergeDecision
+	}{
+		{"no remote", "L", "", "", false, DecideNoRemote},
+		{"equal", "X", "X", "X", true, DecideNoop},
+		{"equal no base", "X", "X", "", true, DecideNoop},
+		{"fast-forward", "B", "R", "B", true, DecideFastForward},
+		{"push needed", "L", "B", "B", true, DecidePushNeeded},
+		{"diverged", "L", "R", "B", true, DecideDiverged},
+		{"no base remote present differs", "L", "R", "", true, DecideNoBase},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Decide(c.local, c.remote, c.base, c.present)
+			if got != c.want {
+				t.Fatalf("Decide(%q,%q,%q,%v) = %v, want %v", c.local, c.remote, c.base, c.present, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/syncconfig/syncconfig_test.go
+++ b/internal/syncconfig/syncconfig_test.go
@@ -64,14 +64,15 @@ func TestUnwrapWrongPassphraseFailsClosed(t *testing.T) {
 func TestBlobSealOpenRoundTrip(t *testing.T) {
 	dek, _ := NewDEK()
 	plain := []byte("version = 1\n[_meta]\nsalt = \"x\"\n")
-	blob, err := SealBlob(dek, plain)
+	hash := HashConfig(plain)
+	blob, err := SealBlob(dek, plain, hash)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(blob) == string(plain) {
 		t.Fatal("blob is not encrypted")
 	}
-	got, err := OpenBlob(dek, blob)
+	got, err := OpenBlob(dek, blob, hash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,8 +81,36 @@ func TestBlobSealOpenRoundTrip(t *testing.T) {
 	}
 
 	other, _ := NewDEK()
-	if _, err := OpenBlob(other, blob); err == nil {
+	if _, err := OpenBlob(other, blob, hash); err == nil {
 		t.Fatal("expected open with wrong DEK to fail")
+	}
+}
+
+// TestBlobAADBindsMetaHash proves the meta hash is authenticated into the
+// blob's AEAD associated data: opening with a different (tampered or
+// swapped) meta hash fails the tag check even with the correct DEK.
+func TestBlobAADBindsMetaHash(t *testing.T) {
+	dek, _ := NewDEK()
+	plain := []byte("version = 1\n# real\n")
+	hash := HashConfig(plain)
+	blob, err := SealBlob(dek, plain, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A storage attacker swaps in a different meta hash (e.g. from a
+	// prior push) while keeping the blob. OpenBlob must reject it.
+	tampered := HashConfig([]byte("version = 1\n# attacker swap\n"))
+	if _, err := OpenBlob(dek, blob, tampered); err == nil {
+		t.Fatal("expected open with tampered meta hash to fail (AAD not bound)")
+	}
+	// Empty/zeroed meta hash must also fail.
+	if _, err := OpenBlob(dek, blob, ""); err == nil {
+		t.Fatal("expected open with empty meta hash to fail")
+	}
+	// Sanity: the correct hash still opens.
+	if _, err := OpenBlob(dek, blob, hash); err != nil {
+		t.Fatalf("correct meta hash should open: %v", err)
 	}
 }
 

--- a/pkg/syncadapter/syncadapter.go
+++ b/pkg/syncadapter/syncadapter.go
@@ -1,0 +1,60 @@
+// Package syncadapter defines the public extension interface for jitenv
+// config-sync remote backends. It mirrors pkg/source: a remote adapter
+// is a small Push/Pull transport, registered at init time, that only
+// ever sees an opaque AEAD ciphertext blob — never plaintext config.
+//
+// The adapter layer is deliberately minimal for v1. Two future
+// extension points were considered and explicitly deferred so the
+// interface stays small until a concrete backend needs them:
+//
+//   - List(ctx) ([]Snapshot, error) — for adapters that natively expose
+//     versions (S3 with versioning, git refs) so a future 3-way merge
+//     layer could pick a common ancestor.
+//   - Lock(ctx) (Unlock, error) — write-fencing for concurrent pushes
+//     (flock(2) on SSH, a _lock object on S3).
+//
+// Neither is part of v1; the LWW + divergence-fence merge model in
+// internal/syncadapters' callers does not need them.
+package syncadapter
+
+import "context"
+
+// Meta is the small sidecar of metadata that travels alongside the
+// encrypted blob. It is NOT secret — it carries no key material — but it
+// IS authenticated: callers bind it into the blob's AEAD associated data
+// so a remote that tampers with the recorded hash is detected on pull.
+type Meta struct {
+	// Hash is the SHA-256 (hex) of the plaintext config bytes that were
+	// encrypted into the blob. The push side records the same hash in
+	// the local sync sidecar as its base snapshot; the pull side uses
+	// the pair to detect divergence (see the merge model in the CLI).
+	Hash string `json:"hash"`
+	// SchemaVersion is the on-disk Config.Version of the synced config.
+	// Lets a future cross-version pull refuse mismatches; v1 only ever
+	// writes/reads version 1.
+	SchemaVersion int `json:"schema_version"`
+}
+
+// Adapter is a remote transport for one encrypted config blob.
+// Implementations MUST be safe for concurrent use and MUST never
+// transmit anything but the opaque ciphertext blob handed to Push.
+type Adapter interface {
+	// Name returns the registered adapter type name (e.g. "file", "ssh").
+	Name() string
+	// Validate verifies reachability / credentials / destination
+	// without writing real data. It SHOULD reject obviously-unsafe
+	// destinations (e.g. a world-readable bucket) where detectable.
+	Validate(ctx context.Context) error
+	// Push uploads the encrypted blob and its (non-secret) meta,
+	// overwriting any previous remote state. The blob is already an
+	// AEAD ciphertext; the adapter treats it as opaque bytes.
+	Push(ctx context.Context, blob []byte, meta Meta) error
+	// Pull fetches the current remote blob + meta. If the remote has
+	// nothing yet, Pull returns ErrNoRemoteState.
+	Pull(ctx context.Context) (blob []byte, meta Meta, err error)
+}
+
+// Constructor builds an Adapter from its decrypted config block. cfg is
+// the contents of the adapter's params table in the sync sidecar after
+// envelope decryption (mirrors source.Constructor).
+type Constructor func(cfg map[string]any) (Adapter, error)


### PR DESCRIPTION
Closes #241

Ships a sound, well-tested **v1** of encrypted config sync, using the defaults the issue blessed as v1-acceptable. It does **not** build every option the issue enumerated — it builds the minimal coherent slice.

## What's in v1

`jitenv sync init | push | pull | status | list` — a top-level Cobra subtree.

### Encryption model (issue option (a))
- A per-config **256-bit DEK** seals the entire `config.toml` bytes into **one XChaCha20-Poly1305 envelope** (the existing `internal/crypto` AEAD shape). The remote sees only that opaque ciphertext blob — never plaintext, never secrets.
- The DEK lives in a **separate local sidecar** (`sync.toml`, NOT embedded in `config.toml`), stored **wrapped by the master key** derived from the passphrase (same Argon2id KDF + floors as `config.toml`). Same passphrase on another machine → same master key → unwraps the DEK → decrypts the blob.
- The DEK, master key, and passphrase are never logged and are `zeroBytes`-on-defer everywhere outside the agent.

### Pluggable adapter layer (mirrors the source plugin model exactly)
- Public interface in `pkg/syncadapter` (`Name`/`Validate`/`Push`/`Pull` + `Meta`) — deliberately minimal; `List`/`Lock` are documented future extension points, not built.
- Init-time registry `internal/syncadapters/registry.go`, per-adapter packages, blank-import aggregator `internal/syncadapters/builtin` wired into `cmd/jitenv/main.go`. Adding an adapter is a registration call, not a core change.
- **Two concrete adapters**: `file` (local / locally-mounted filesystem — fully unit-tested, doubles as a real backend for Dropbox/NFS/SMB mounts, the #116 use case) and `ssh` (shells out to the system `ssh` binary, inheriting the user's keys/agent/known_hosts).

### Merge model (issue option (i): LWW + safety fence)
- `push` records a base-snapshot hash in the sidecar and refuses to overwrite a remote that advanced past that base (unless `--force`).
- `pull`: remote unchanged → no-op; local unchanged but remote advanced → **fast-forward**; **both advanced → ABORT** with a clear reconcile-manually message, **local file left untouched**.
- First pull on a fresh machine (no base, remote populated) is a guarded **`--adopt`** opt-in; without it, that case aborts too rather than silently clobbering local.
- Cell-level / order-sensitive **mapping merge and the `Mapping.ID` schema change are explicitly out of scope** (deferred, as the issue directs).
- Pulled config is parsed + `Validate`d, integrity-checked against `Meta.Hash`, then written via `config.AtomicSave`, and the agent reload hook is pinged (same path the TUI/clone use).

### Sidecar resolution
- `config.ResolveSync` parallels `config.Resolve`, honoring `JITENV_CONFIG_SYNC` with the same semantics as `JITENV_CONFIG`; default `sync.toml` beside `config.toml`.

## Security defaults
- Adapters only ever transmit AEAD ciphertext (documented in package docs and `sync` help).
- Blobs written **0600** on both file and ssh adapters (`umask 077` + `chmod 600` on the remote).
- SSH adapter rejects shell-metacharacter host/path and single-quotes the remote path (defence in depth) and uses `BatchMode=yes`.

## Tests (credential-free)
- **Two-machine round-trip**: machine 1 push → machine 2 (same passphrase, separate sidecar, `--adopt`) pull → byte-identical config.
- **Wrong passphrase** → DEK unwrap fails closed before any remote contact.
- **Divergence fence**: both-advanced → `DivergenceError`, no `Applied` payload (local untouched). Plus a no-base-without-adopt abort test and a stale-push-refused test.
- Adapter **registry test** mirroring the sources registry test; file adapter 0600 + round-trip; ssh adapter round-trip via an injected in-memory fake remote (no SSH server, no creds).
- `Decide` merge-decision matrix table test.

## Deferred / follow-up
- **S3 adapter** — filed as #243. Deferred to keep the dependency footprint justified (no S3 service client vendored yet) and tests credential-free. `go mod tidy` confirms **zero new dependencies** in this PR. Adding S3 later is a pure registration call.

## Verification
- `go build ./...`, `go vet ./...`, `golangci-lint run`: clean.
- `go test ./...`: all touched/new packages pass. One pre-existing e2e failure in `internal/shell` (`TestCwdGlob_LockedVsUnlocked_WrapperIsLockIndependent`, an agent-spawn/environment issue in this sandbox) reproduces identically on untouched `main` and is unrelated to this change.
- `go mod tidy`: no `go.mod`/`go.sum` diff.