### PR TITLE
fix(zsh): normalize ../-relative command paths to match mappings (#245)

### DIFF
--- a/internal/shell/cwd_path_change_e2e_test.go
+++ b/internal/shell/cwd_path_change_e2e_test.go
@@ -634,6 +634,36 @@ func TestPathMapping_BareNameInvocationInjects_Zsh(t *testing.T) {
 	}
 }
 
+// TestPathMapping_ParentRelativeInvocationInjects_Zsh is the #245
+// regression: a `path` mapping for an absolute file must fire when the
+// command is invoked via a `../`-relative path from a subdirectory. The
+// zsh widget used to resolve `../foo` as `${PWD}/${first#./}` →
+// `$PWD/../foo`, an UNNORMALIZED path that never path-equality-matched
+// the canonical absolute mapping, so injection silently failed. The fix
+// mirrors bash.sh's `cd "$(dirname …)" && pwd` normalization, so the
+// resolved path is canonical and is-mapped matches. This test cd's into
+// a sibling subdir (projA) and invokes the mapped file in `bin/` as
+// `../bin/fakecmd`; with normalization that resolves to the mapped
+// absolute path and FOO is injected. Skips cleanly where zsh is absent
+// (exercised on ubuntu CI).
+func TestPathMapping_ParentRelativeInvocationInjects_Zsh(t *testing.T) {
+	f := newCPCFixture(t)
+	mapped := cpcConfig(f.pathMappingFor())
+	f.writeConfig(f.shellCfgPath, mapped)
+	key := f.writeConfig(f.agentCfgPath, mapped)
+	defer f.startAgent(key)()
+
+	// projA and bin are siblings under f.dir, so from projA the mapped
+	// file (f.fakeBin/fakecmd) is reachable as `../bin/fakecmd`. Without
+	// normalization this resolves to `<projA>/../bin/fakecmd` and fails
+	// the path-equality match against the canonical absolute mapping.
+	out := f.runZsh(fmt.Sprintf("cd %q", f.projA), "../bin/fakecmd")
+	t.Logf("output:\n%s", out)
+	if !strings.Contains(out, "FOO=from-cwd") {
+		t.Errorf("zsh ../-relative invocation: expected FOO=from-cwd (normalized path matches mapping); got:\n%s", out)
+	}
+}
+
 // TestCwdGlob_BareNameNotDoubleDispatched_Zsh is the zsh twin of the
 // double-dispatch guard (#237): once the cwd_glob wrapper is built it
 // sits first on $PATH, so a bare `fakecmd` resolves (via `whence -p`) to

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -124,7 +124,15 @@ __jitenv_accept_line() {
         first="${first#\'}"; first="${first%\'}"
         case "$first" in
             /*)        resolved="$first" ;;
-            ./*|../*)  resolved="${PWD}/${first#./}" ;;
+            ./*|../*)
+                # Normalize the same way bash.sh does so zsh and bash
+                # produce identical canonical absolute paths and stay in
+                # sync. The old `${PWD}/${first#./}` only stripped a
+                # leading `./`, so `../foo` became `$PWD/../foo` — an
+                # unnormalized path that won't path-equality-match a
+                # mapping stored in canonical absolute form (issue #245).
+                resolved="$(cd "$(dirname "$first")" 2>/dev/null && pwd)/$(basename "$first")"
+                ;;
             *)
                 # Bare name → resolve through $PATH so `path`/`glob`
                 # mappings fire on PATH-invoked commands too, not just


### PR DESCRIPTION
## Problem

The zsh accept-line hook in \`internal/shell/snippets/zsh.sh\` resolved a \`./\`-or-\`../\`-relative first token as \`\${PWD}/\${first#./}\`, which only strips a leading \`./\`. For \`../foo\` this yields \`\$PWD/../foo\` — an **unnormalized** path that never path-equality-matches a mapping stored in canonical absolute form. So \`path\`/\`glob\` mappings silently failed to fire for \`../\`-relative invocations in zsh (bash was already correct).

## Fix

Mirror \`bash.sh\`'s normalization idiom for the \`./\`/\`../\` branch:

\`\`\`sh
resolved="\$(cd "\$(dirname "\$first")" 2>/dev/null && pwd)/\$(basename "\$first")"
\`\`\`

so zsh and bash now produce identical canonical absolute paths and stay in sync. Absolute-path handling and the #242 bare-name PATH resolution are unchanged.

## Tests

Adds \`TestPathMapping_ParentRelativeInvocationInjects_Zsh\` (reuses the #242 \`runZsh\` harness): cd's into a sibling subdir and invokes a mapped absolute file as \`../bin/fakecmd\`, asserting the mapped env var IS injected — proving normalization makes the path-equality match succeed. Skips cleanly where zsh is absent; exercised on ubuntu CI (which ships zsh).

Verified locally: \`gofmt\`, \`go vet\`, and \`golangci-lint run\` clean; the path-mapping e2e tests pass and the new zsh test skips cleanly (zsh not installable in this sandbox). The normalization idiom was verified by hand to resolve \`../bin/fakecmd\` to the canonical absolute path matching the mapping.

Closes #245