### PR TITLE
feat(config): encrypt source/bag/key names via opaque IDs + sealed name-map (#248)

### DIFF
--- a/internal/agent/resolver_opaqueid_test.go
+++ b/internal/agent/resolver_opaqueid_test.go
@@ -1,0 +1,168 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+	_ "github.com/gv/jitenv/internal/sources/local"
+)
+
+// TestResolver_OpaqueIDRoundTrip is the #248 end-to-end regression: a
+// config sealed into the opaque-ID on-disk shape, then decrypted and
+// handed to BuildResolver, must inject env correctly — proving the
+// resolver sees REAL names (not IDs) after DecryptInPlace dereferences
+// var.Source / var.Ref / var.Key and the Sources/Secrets map keys.
+func TestResolver_OpaqueIDRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	loaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(loaded, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer func() {
+		for i := range key {
+			key[i] = 0
+		}
+	}()
+
+	abs, _ := filepath.Abs(filepath.Join(dir, "run.sh"))
+	loaded.Sources = map[string]config.SourceConfig{
+		"vault": {Type: "local"},
+	}
+	loaded.Secrets = map[string]map[string]string{
+		"stripe": {"STRIPE_SK": "sk-live-Y", "STRIPE_PK": "pk-live-X"},
+	}
+	loaded.Mappings = []config.Mapping{{
+		Path: abs,
+		Vars: []config.VarRef{
+			{Name: "STRIPE_SK", Source: "vault", Ref: "stripe", Key: "STRIPE_SK"},
+			{Source: "vault", Ref: "stripe"}, // expand-all
+		},
+	}}
+
+	// Seal to the opaque-ID on-disk form and write it.
+	if err := config.EncryptInPlace(loaded, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := config.AtomicSave(path, loaded); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Confirm the on-disk structure is ID-keyed (names are gone).
+	disk, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, ok := disk.Sources["vault"]; ok {
+		t.Fatal("on-disk Sources should be ID-keyed, not name-keyed")
+	}
+	if !config.HasOpaqueIDShape(disk) {
+		t.Fatal("on-disk config should be opaque-ID shaped")
+	}
+
+	// The unlock path: decrypt (translates IDs->names) then build the
+	// resolver.
+	if err := config.DecryptInPlace(disk, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	r, err := BuildResolver(disk)
+	if err != nil {
+		t.Fatalf("build resolver: %v", err)
+	}
+	if !r.IsMapped(abs) {
+		t.Fatal("expected mapped path")
+	}
+	env, err := r.FetchEnv(context.Background(), abs)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if env["STRIPE_SK"] != "sk-live-Y" {
+		t.Fatalf("STRIPE_SK = %q, want sk-live-Y (resolver did not dereference var.Key ID->name)", env["STRIPE_SK"])
+	}
+	// expand-all should have surfaced both keys.
+	if env["STRIPE_PK"] != "pk-live-X" {
+		t.Fatalf("expand-all STRIPE_PK = %q, want pk-live-X", env["STRIPE_PK"])
+	}
+}
+
+// TestResolver_AfterMigration is the explicit #248 e2e regression: a
+// LEGACY (name-keyed) config migrates to the opaque-ID shape, and the
+// post-migration decrypt → BuildResolver → FetchEnv cycle still injects
+// env correctly. This exercises the same path `jitenv unlock` runs
+// (migrate before spawn, then the daemon decrypts + builds the
+// resolver).
+func TestResolver_AfterMigration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	loaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(loaded, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer func() {
+		for i := range key {
+			key[i] = 0
+		}
+	}()
+
+	abs, _ := filepath.Abs(filepath.Join(dir, "run.sh"))
+	// Write a LEGACY config: name-keyed maps, values sealed under
+	// name-based AADs, no name_map (pre-#248 shape).
+	sk, _ := crypto.EncryptField(key, "sk-live-Z", config.SecretAAD("stripe", "STRIPE_SK"))
+	loaded.Sources = map[string]config.SourceConfig{"vault": {Type: "local"}}
+	loaded.Secrets = map[string]map[string]string{"stripe": {"STRIPE_SK": sk}}
+	loaded.Mappings = []config.Mapping{{
+		Path: abs,
+		Vars: []config.VarRef{{Name: "STRIPE_SK", Source: "vault", Ref: "stripe", Key: "STRIPE_SK"}},
+	}}
+	if err := config.Save(path, loaded); err != nil {
+		t.Fatalf("save legacy: %v", err)
+	}
+
+	// Migrate (the unlock-before-spawn step).
+	migrated, err := config.MigrateToOpaqueIDs(path, key)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration to run on a legacy config")
+	}
+
+	// Daemon path: load migrated form, decrypt, build resolver, fetch.
+	disk, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := config.DecryptInPlace(disk, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	r, err := BuildResolver(disk)
+	if err != nil {
+		t.Fatalf("build resolver: %v", err)
+	}
+	env, err := r.FetchEnv(context.Background(), abs)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if env["STRIPE_SK"] != "sk-live-Z" {
+		t.Fatalf("post-migration env STRIPE_SK = %q, want sk-live-Z", env["STRIPE_SK"])
+	}
+}

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -97,6 +97,16 @@ func runClone(cmd *cobra.Command, args []string, tokenStdin bool, bagOverride st
 		return err
 	}
 	defer zeroBytes(key)
+	// One-shot opaque-ID migration (#248) so a legacy config cloned into
+	// gets the sealed name_map + backup like the unlock/TUI paths, rather
+	// than silently migrating on save without a backup.
+	if err := migrateOpaqueIDsLocked(cfgPath, key); err != nil {
+		return err
+	}
+	cfg, err = config.Load(cfgPath)
+	if err != nil {
+		return err
+	}
 	if err := config.DecryptInPlace(cfg, key); err != nil {
 		return err
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -208,6 +208,28 @@ func resolveJitenvTUIPath() (string, error) {
 	)
 }
 
+// migrateOpaqueIDsLocked runs the one-shot opaque-ID migration (#248)
+// under the shared .tui.lock so the agent-spawn path and a concurrent
+// `jitenv config` TUI session can't both rewrite the config at once.
+// The lock is held only for the duration of the migration (a no-op when
+// the config is already migrated), then released so the TUI can still be
+// opened while the agent runs. A "lock already held" error is treated as
+// "another jitenv process is migrating/editing right now" and surfaced
+// so the user retries rather than proceeding on a possibly-half-written
+// config.
+func migrateOpaqueIDsLocked(cfgPath string, key []byte) error {
+	lock, lockErr := lockfile.Acquire(cfgPath + ".tui.lock")
+	if lockErr != nil {
+		if errors.Is(lockErr, os.ErrExist) {
+			return fmt.Errorf("another jitenv session is editing %s — close it, then retry", cfgPath)
+		}
+		return fmt.Errorf("acquire config lock for migration: %w", lockErr)
+	}
+	defer lock.Close()
+	_, err := config.MigrateToOpaqueIDs(cfgPath, key)
+	return err
+}
+
 func zeroBytes(b []byte) {
 	for i := range b {
 		b[i] = 0

--- a/internal/cli/sources.go
+++ b/internal/cli/sources.go
@@ -38,6 +38,24 @@ func newSourcesListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Post-#248 the source NAMES live only in the sealed
+			// _meta.name_map; the on-disk Sources map is keyed by opaque
+			// IDs. Decrypt so we can list the real names. (source.type
+			// stays plaintext, so a config with no name_map — pre-#248 or
+			// never-migrated — still lists fine after a no-op decrypt.)
+			pw, err := crypto.PromptPassphrase("jitenv sources passphrase: ", false)
+			if err != nil {
+				return err
+			}
+			defer zeroBytes(pw)
+			key, err := config.DeriveKeyFromMeta(cfg, pw)
+			if err != nil {
+				return err
+			}
+			defer zeroBytes(key)
+			if err := config.DecryptInPlace(cfg, key); err != nil {
+				return err
+			}
 			names := make([]string, 0, len(cfg.Sources))
 			for n := range cfg.Sources {
 				names = append(names, n)
@@ -79,10 +97,6 @@ func newSourcesTestCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sc, ok := cfg.Sources[args[0]]
-			if !ok {
-				return fmt.Errorf("source %q not found", args[0])
-			}
 
 			pw, err := crypto.PromptPassphrase("jitenv sources passphrase: ", false)
 			if err != nil {
@@ -94,10 +108,17 @@ func newSourcesTestCmd() *cobra.Command {
 				return err
 			}
 			defer zeroBytes(key)
+			// Decrypt first: post-#248 the on-disk Sources map is keyed by
+			// opaque IDs, and DecryptInPlace translates them back to the
+			// user-facing names this command looks up by.
 			if err := config.DecryptInPlace(cfg, key); err != nil {
 				return err
 			}
-			s, err := sources.Build(sc.Type, cfg.Sources[args[0]].Params)
+			sc, ok := cfg.Sources[args[0]]
+			if !ok {
+				return fmt.Errorf("source %q not found", args[0])
+			}
+			s, err := sources.Build(sc.Type, sc.Params)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -43,6 +43,21 @@ func newUnlockCmd() *cobra.Command {
 			defer zeroBytes(key)
 			defer lockKey(key)()
 
+			// One-shot opaque-ID migration (#248), before the agent is
+			// spawned and starts serving. Guarded by the same .tui.lock
+			// the TUI uses so a concurrent `jitenv config` migration can't
+			// race this one.
+			if err := migrateOpaqueIDsLocked(cfgPath, key); err != nil {
+				return err
+			}
+			// Reload cfg in case migration rewrote it (idle timeout etc.
+			// are unchanged by migration, but read the fresh bytes so the
+			// daemon hands over a config matching what's on disk).
+			cfg, err = config.Load(cfgPath)
+			if err != nil {
+				return err
+			}
+
 			paths, err := agent.DefaultPaths()
 			if err != nil {
 				return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,18 +16,32 @@ type Config struct {
 	Sources  map[string]SourceConfig      `toml:"sources"`
 	Mappings []Mapping                    `toml:"mappings"`
 	Secrets  map[string]map[string]string `toml:"secrets,omitempty"`
+
+	// IDMap is the decrypted opaque-ID↔name dictionary (#248). It is
+	// populated by DecryptInPlace from the sealed Meta.NameMap and is
+	// NOT serialized to TOML (the `-` tag). EncryptInPlace consumes it so
+	// renames keep IDs stable: the TUI updates the name carried here for
+	// an existing ID rather than letting a new name mint a fresh ID. nil
+	// on a freshly-loaded (still-encrypted) config and on configs that
+	// have never had named structure.
+	IDMap *NameMap `toml:"-"`
 }
 
 // Meta carries KDF parameters and a passphrase verification sentinel.
-// All fields are plaintext on disk; "Verify" is an enc:v1: blob whose
-// successful decryption proves the passphrase.
+// All scalar fields are plaintext on disk; "Verify" is an enc:v1: blob
+// whose successful decryption proves the passphrase. "NameMap" (#248) is
+// an AEAD-sealed JSON envelope holding the ID↔name dictionary that maps
+// the opaque s_/b_/k_ TOML keys back to the user-facing source / bag /
+// bag-key names. It is omitted entirely on configs that have no named
+// structure yet (a fresh `jitenv config init`).
 type Meta struct {
 	KDF            string `toml:"kdf"`
 	ArgonTime      uint32 `toml:"argon_time"`
 	ArgonMemoryKiB uint32 `toml:"argon_memory_kib"`
 	ArgonThreads   uint8  `toml:"argon_threads"`
-	Salt           string `toml:"salt"`   // base64
-	Verify         string `toml:"verify"` // enc:v1:...
+	Salt           string `toml:"salt"`               // base64
+	Verify         string `toml:"verify"`             // enc:v1:...
+	NameMap        string `toml:"name_map,omitempty"` // enc:v2: sealed JSON (#248)
 }
 
 type AgentConfig struct {

--- a/internal/config/decrypt.go
+++ b/internal/config/decrypt.go
@@ -6,39 +6,62 @@ import (
 	"github.com/gv/jitenv/internal/crypto"
 )
 
-// DecryptInPlace walks every envelope in c (Sources[*].Params and
-// Secrets[*][*]) and replaces it with its plaintext. Plaintext fields
-// are left untouched. Called once by the agent at unlock.
+// DecryptInPlace walks every envelope in c (Sources[*].Params,
+// Secrets[*][*], and vars[*]) and replaces it with its plaintext, then
+// translates the opaque on-disk IDs back to user-facing names so the
+// in-memory Config the resolver/TUI see is name-keyed (#248). Plaintext
+// fields are left untouched. Called once by the agent at unlock and by
+// every CLI/TUI path that needs the cleartext config.
 //
-// Each decrypt call passes the value's canonical AAD context so the
-// AEAD tag verifies the envelope is in the right slot (security #110).
-// Existing enc:v1 envelopes have no AAD to verify against and continue
-// to decrypt for backward compatibility — they upgrade to v2 on the
-// next save.
+// Each decrypt call passes the value's canonical AAD context — now
+// keyed by the value's opaque ID coordinates (source/bag/bag-key IDs) —
+// so the AEAD tag verifies the envelope is in the right slot
+// (security #110, #235). Existing enc:v1 envelopes have no AAD to verify
+// against and continue to decrypt for backward compatibility.
+//
+// PRECONDITION: c must already be in the opaque-ID on-disk shape. The
+// agent-spawn / TUI-unlock paths run MigrateToOpaqueIDs first, which
+// converts a legacy name-keyed config (and re-seals its envelopes under
+// ID-based AADs) before the first DecryptInPlace. Calling DecryptInPlace
+// directly on a legacy-shaped config decrypts the values but leaves the
+// (plaintext) source/bag/key map keys as-is, which is still a valid
+// name-keyed Config — translation is simply a no-op when there is no
+// name_map. See MigrateToOpaqueIDs for the migration contract.
 func DecryptInPlace(c *Config, key []byte) error {
-	for name, s := range c.Sources {
+	nm, err := openNameMap(key, c.Meta.NameMap)
+	if err != nil {
+		return err
+	}
+
+	// 1. Decrypt Sources[*].Params under the source ID's AAD (the map key
+	//    is the ID on disk).
+	for id, s := range c.Sources {
 		if s.Params == nil {
 			continue
 		}
-		if err := crypto.DecryptStringsInPlace(key, s.Params, crypto.AAD("src", name)); err != nil {
-			return fmt.Errorf("decrypt source %q: %w", name, err)
+		if err := crypto.DecryptStringsInPlace(key, s.Params, crypto.AAD("src", id)); err != nil {
+			return fmt.Errorf("decrypt source %q: %w", id, err)
 		}
 	}
-	for bag, kv := range c.Secrets {
-		for k, v := range kv {
+
+	// 2. Decrypt Secrets[*][*] under (bagID, keyID) AAD.
+	for bagID, kv := range c.Secrets {
+		for keyID, v := range kv {
 			if !crypto.IsEnvelope(v) {
 				continue
 			}
-			pt, err := crypto.DecryptField(key, v, SecretAAD(bag, k))
+			pt, err := crypto.DecryptField(key, v, SecretAAD(bagID, keyID))
 			if err != nil {
-				return fmt.Errorf("decrypt secret %q.%q: %w", bag, k, err)
+				return fmt.Errorf("decrypt secret %q.%q: %w", bagID, keyID, err)
 			}
-			kv[k] = pt
+			kv[keyID] = pt
 		}
 	}
-	// vars[*] scalar + extra fields (#235). Symmetric with the encrypt
-	// walker; plaintext fields (legacy configs not yet re-saved) pass
-	// through untouched.
+
+	// 3. vars[*] scalar + extra fields (#235). Symmetric with the encrypt
+	//    walker; plaintext fields (legacy configs not yet re-saved) pass
+	//    through untouched. The decrypted source/ref/key CONTENT is still
+	//    an ID at this point — translated to a name in step 4.
 	for i := range c.Mappings {
 		m := &c.Mappings[i]
 		for j := range m.Vars {
@@ -75,5 +98,96 @@ func DecryptInPlace(c *Config, key []byte) error {
 			}
 		}
 	}
+
+	// 4. Translate opaque IDs back to user-facing names in the in-memory
+	//    Config so the resolver and TUI never see an ID. No-op when
+	//    name_map is empty (legacy config without IDs).
+	translateIDsToNames(c, nm)
+
+	// 5. Carry the (decrypted) dictionary on the in-memory Config so the
+	//    TUI can keep IDs stable across renames and EncryptInPlace reuses
+	//    them. Stored AFTER translation so a downstream EncryptInPlace
+	//    sees the same ID set we just decoded.
+	c.IDMap = nm
 	return nil
+}
+
+// translateIDsToNames rewrites the in-memory Config from the opaque-ID
+// shape (Sources/Secrets keyed by ID, var.source/ref/key holding IDs)
+// to the name-keyed shape callers expect, using the decrypted
+// dictionary nm. Entries with no dictionary mapping are left as-is
+// (defensive: a hand-edited config could carry an ID with no name).
+func translateIDsToNames(c *Config, nm *NameMap) {
+	// var translation needs source-type-by-ID and bag/key-by-ID lookups
+	// BEFORE we rewrite the maps, so capture per-source type first.
+	srcTypeByID := map[string]string{}
+	for id, sc := range c.Sources {
+		srcTypeByID[id] = sc.Type
+	}
+
+	// Sources: rekey by name.
+	if len(nm.Sources) > 0 && len(c.Sources) > 0 {
+		named := make(map[string]SourceConfig, len(c.Sources))
+		for id, sc := range c.Sources {
+			if name, ok := nm.Sources[id]; ok {
+				named[name] = sc
+			} else {
+				named[id] = sc
+			}
+		}
+		c.Sources = named
+	}
+
+	// Secrets: rekey bag IDs -> names, and each bag's key IDs -> names.
+	if len(c.Secrets) > 0 {
+		named := make(map[string]map[string]string, len(c.Secrets))
+		for bagID, kv := range c.Secrets {
+			bagName := bagID
+			if n, ok := nm.Bags[bagID]; ok {
+				bagName = n
+			}
+			keyNames := nm.Keys[bagID]
+			nkv := make(map[string]string, len(kv))
+			for keyID, val := range kv {
+				keyName := keyID
+				if n, ok := keyNames[keyID]; ok {
+					keyName = n
+				}
+				nkv[keyName] = val
+			}
+			named[bagName] = nkv
+		}
+		c.Secrets = named
+	}
+
+	// vars: source ID -> name; for local-type sources, ref (bag ID ->
+	// name) and key (bag-key ID -> name).
+	for i := range c.Mappings {
+		m := &c.Mappings[i]
+		for j := range m.Vars {
+			v := &m.Vars[j]
+			if v.Source == "" {
+				continue
+			}
+			isLocal := srcTypeByID[v.Source] == "local"
+			if name, ok := nm.Sources[v.Source]; ok {
+				v.Source = name
+			}
+			if !isLocal {
+				continue
+			}
+			// v.Ref is a bag ID; v.Key is a bag-key ID scoped to that bag.
+			bagID := v.Ref
+			if v.Key != "" {
+				if keyNames, ok := nm.Keys[bagID]; ok {
+					if n, ok := keyNames[v.Key]; ok {
+						v.Key = n
+					}
+				}
+			}
+			if n, ok := nm.Bags[bagID]; ok {
+				v.Ref = n
+			}
+		}
+	}
 }

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -21,18 +21,25 @@ const verifySentinel = "jitenv-ok"
 const metaVerifyAAD = "meta.verify"
 
 // SourceParamAAD builds the AAD context for a value stored under
-// [sources.<name>.params.<key>]. Both the TUI save pipeline and the
+// [sources.<sourceID>.params.<key>]. Both the TUI save pipeline and the
 // agent's resolver must agree on this exact string; the dotted form
 // matches what DecryptStringsInPlace produces when fed ctx=
-// "src."+name.
-func SourceParamAAD(sourceName, paramKey string) string {
-	return crypto.AAD("src", sourceName, paramKey)
+// "src."+sourceID.
+//
+// Post-#248 the first coordinate is the source's opaque ID (s_xxxxxx),
+// not its human name — the ID is stable over the config's lifetime, so
+// a rename updates only the sealed name_map and never has to re-seal
+// every param envelope.
+func SourceParamAAD(sourceID, paramKey string) string {
+	return crypto.AAD("src", sourceID, paramKey)
 }
 
 // SecretAAD builds the AAD context for a value stored under
-// [secrets.<bag>.<key>].
-func SecretAAD(bag, key string) string {
-	return crypto.AAD("secret", bag, key)
+// [secrets.<bagID>.<keyID>]. Post-#248 both coordinates are opaque IDs
+// (b_xxxxxx / k_xxxxxx) rather than the bag / key names, for the same
+// rename-stability reason as SourceParamAAD.
+func SecretAAD(bagID, keyID string) string {
+	return crypto.AAD("secret", bagID, keyID)
 }
 
 // VarFieldAAD builds the AAD context for a scalar string field of
@@ -154,8 +161,20 @@ func atomicSave(path string, c *Config) error {
 }
 
 // AtomicSave is the exported variant for callers outside this package
-// (e.g. the TUI).
-func AtomicSave(path string, c *Config) error { return atomicSave(path, c) }
+// (e.g. the TUI). On a successful write it also consumes the pre-#248
+// migration backup escape hatch (#248): the FIRST config-modifying save
+// after a migration unlinks config.toml.pre-id-migration.bak. The
+// migration's own write goes through the unexported atomicSave so it
+// keeps the backup it just created — only the *next* user-facing save
+// removes it. A save that didn't follow a migration simply finds no
+// backup (no-op).
+func AtomicSave(path string, c *Config) error {
+	if err := atomicSave(path, c); err != nil {
+		return err
+	}
+	removeMigrationBackup(path)
+	return nil
+}
 
 func zero(b []byte) {
 	for i := range b {

--- a/internal/config/encrypt.go
+++ b/internal/config/encrypt.go
@@ -6,64 +6,185 @@ import (
 	"github.com/gv/jitenv/internal/crypto"
 )
 
-// EncryptInPlace is the inverse of DecryptInPlace: it walks every
-// sensitive plaintext field in c (Sources[*].Params and Secrets[*])
-// and replaces it with an enc:v2 envelope. Values that are already
-// envelopes (round-tripped through Decrypt + Encrypt within one
-// session) are skipped — re-wrapping wouldn't be wrong but would
-// rotate the nonce on every save for no reason.
+// EncryptInPlace is the inverse of DecryptInPlace. It takes a name-keyed
+// in-memory Config (Sources / Secrets keyed by user-facing names, var
+// fields holding real names) and rewrites it into the opaque-ID on-disk
+// form: every source / bag / bag-key name is replaced by a stable
+// s_/b_/k_ ID, the ID↔name dictionary is sealed into Meta.NameMap, and
+// every sensitive value (Sources[*].Params, Secrets[*], vars[*] scalar +
+// extra fields) is wrapped in an enc:v2 envelope bound to ID-based AAD
+// coordinates (#248, building on #235).
+//
+// IDs are stable: a prior Meta.NameMap is reused so a no-op save does
+// not churn IDs or rotate nonces on already-sealed values. New
+// sources/bags/keys get freshly-minted IDs.
 //
 // Encrypt-by-default: every non-envelope string param is encrypted,
-// regardless of whether the source's schema flagged it Sensitive.
-// A schema-only gate would silently leak params for sources without
-// a registered schema and for fields a source author forgot to flag
+// regardless of whether the source's schema flagged it Sensitive
 // (security #112). The schema's `Sensitive` bit still controls UI
 // masking; it no longer controls disk encryption.
 //
 // Used by the TUI's saveCmd and by `jitenv clone` (#179) before
-// AtomicSave.
+// AtomicSave. EncryptInPlace MUTATES c — callers that must keep a live
+// name-keyed view (the TUI) clone first (cloneForSave).
 func EncryptInPlace(c *Config, key []byte) error {
-	for name, sc := range c.Sources {
-		if sc.Params == nil {
-			continue
-		}
-		for k, v := range sc.Params {
-			s, ok := v.(string)
-			if !ok || s == "" {
-				continue
-			}
-			if crypto.IsEnvelope(s) {
-				continue
-			}
-			env, err := crypto.EncryptField(key, s, SourceParamAAD(name, k))
-			if err != nil {
-				return fmt.Errorf("source %q.%s: %w", name, k, err)
-			}
-			sc.Params[k] = env
+	// 1. Recover the existing dictionary so we reuse stable IDs, then
+	//    build a FRESH dictionary containing exactly the sources/bags/keys
+	//    present in c (reusing prior IDs, minting for new ones, pruning
+	//    deleted ones). Pruning keeps the sealed name_map from leaking the
+	//    names of deleted structure and keeps it minimal. We re-seal only
+	//    when the dictionary content actually changed, so a no-op save
+	//    doesn't rotate the name_map nonce (idempotency).
+	//
+	//    Prefer c.IDMap (the live, post-decrypt dictionary the TUI mutates
+	//    on rename) over the sealed Meta.NameMap, which goes stale the
+	//    moment a name is changed in memory. Carrying the dictionary is
+	//    what makes a rename keep the source/bag/key ID STABLE (#248):
+	//    the TUI rewrites IDMap[id]=newName, so the new name maps back to
+	//    the SAME id here rather than minting a fresh one.
+	prev := c.IDMap
+	if prev == nil {
+		var err error
+		prev, err = openNameMap(key, c.Meta.NameMap)
+		if err != nil {
+			return err
 		}
 	}
+	var err error
+
+	nm := &NameMap{
+		Sources: map[string]string{},
+		Bags:    map[string]string{},
+		Keys:    map[string]map[string]string{},
+	}
+	prevSrcNameToID := nameToID(prev.Sources)
+	prevBagNameToID := nameToID(prev.Bags)
+	srcNameToID := map[string]string{}
+	bagNameToID := map[string]string{}
+	// allIDs tracks every ID already in use (from the prior dictionary)
+	// so a freshly-minted ID can't collide with an existing one of any
+	// kind (the prefixes already separate the namespaces, but a shared
+	// set keeps the invariant obvious and cheap).
+	allIDs := map[string]string{}
+	for id := range prev.Sources {
+		allIDs[id] = ""
+	}
+	for id := range prev.Bags {
+		allIDs[id] = ""
+	}
+	for _, byBag := range prev.Keys {
+		for id := range byBag {
+			allIDs[id] = ""
+		}
+	}
+
+	// Source IDs: reuse the prior ID for an existing name, mint otherwise.
+	for name := range c.Sources {
+		id, ok := prevSrcNameToID[name]
+		if !ok {
+			id, err = newID(idPrefixSource, allIDs)
+			if err != nil {
+				return err
+			}
+			allIDs[id] = ""
+		}
+		nm.Sources[id] = name
+		srcNameToID[name] = id
+	}
+
+	// Bag IDs + per-bag key IDs. keyNameToID is keyed by bagID so a key
+	// name shared across bags gets distinct IDs. Existing key IDs are
+	// recovered from the prior bag-scoped dictionary so a re-save reuses
+	// them (no nonce churn).
+	keyNameToID := map[string]map[string]string{} // bagID -> keyName -> keyID
 	for bag, kv := range c.Secrets {
+		bagID, ok := prevBagNameToID[bag]
+		if !ok {
+			bagID, err = newID(idPrefixBag, allIDs)
+			if err != nil {
+				return err
+			}
+			allIDs[bagID] = ""
+		}
+		nm.Bags[bagID] = bag
+		bagNameToID[bag] = bagID
+
+		// Recover (keyName -> keyID) for this bag from the prior dict.
+		prevKeyNameToID := map[string]string{}
+		for kid, keyName := range prev.Keys[bagID] {
+			if _, ok := prevKeyNameToID[keyName]; !ok {
+				prevKeyNameToID[keyName] = kid
+			}
+		}
+		keyNameToID[bagID] = map[string]string{}
+		nm.Keys[bagID] = map[string]string{}
+		for keyName := range kv {
+			kid, ok := prevKeyNameToID[keyName]
+			if !ok {
+				kid, err = newID(idPrefixKey, allIDs)
+				if err != nil {
+					return err
+				}
+				allIDs[kid] = ""
+			}
+			nm.Keys[bagID][kid] = keyName
+			keyNameToID[bagID][keyName] = kid
+		}
+	}
+
+	// 2. Encrypt every sensitive value under ID-based AADs, building the
+	//    new ID-keyed Sources / Secrets maps as we go.
+	newSources := make(map[string]SourceConfig, len(c.Sources))
+	for name, sc := range c.Sources {
+		sid := srcNameToID[name]
+		if sc.Params != nil {
+			for k, v := range sc.Params {
+				s, ok := v.(string)
+				if !ok || s == "" || crypto.IsEnvelope(s) {
+					continue
+				}
+				env, err := crypto.EncryptField(key, s, SourceParamAAD(sid, k))
+				if err != nil {
+					return fmt.Errorf("source %q.%s: %w", name, k, err)
+				}
+				sc.Params[k] = env
+			}
+		}
+		newSources[sid] = sc
+	}
+	c.Sources = newSources
+
+	newSecrets := make(map[string]map[string]string, len(c.Secrets))
+	for bag, kv := range c.Secrets {
+		bagID := bagNameToID[bag]
+		idKV := make(map[string]string, len(kv))
 		for k, v := range kv {
+			keyID := keyNameToID[bagID][k]
 			if v == "" || crypto.IsEnvelope(v) {
+				idKV[keyID] = v
 				continue
 			}
-			env, err := crypto.EncryptField(key, v, SecretAAD(bag, k))
+			env, err := crypto.EncryptField(key, v, SecretAAD(bagID, keyID))
 			if err != nil {
 				return fmt.Errorf("secret %q.%s: %w", bag, k, err)
 			}
-			kv[k] = env
+			idKV[keyID] = env
 		}
+		newSecrets[bagID] = idKV
 	}
-	// vars[*] scalar + extra fields. Sealing these stops config.toml
-	// from leaking the secret topology (env var names, which source/
-	// ref/key each var pulls from, per-var lookup params, and literal
-	// values) to a passive reader (#235). An empty field stays empty:
-	// in particular an empty Name keeps the "expand the whole bag"
-	// semantics intact (a VarRef with no Name).
+	c.Secrets = newSecrets
+
+	// 3. vars[*]: translate the human names embedded in source/ref/key to
+	//    IDs, THEN seal. The slot-index AAD is unchanged from #235.
+	//    var.source always maps to a source ID. var.ref / var.key are
+	//    translated only when the var's source is a local-type source
+	//    (so they reference a bag / bag-key); for remote sources they are
+	//    arbitrary opaque strings and pass through unchanged.
 	for i := range c.Mappings {
 		m := &c.Mappings[i]
 		for j := range m.Vars {
 			v := &m.Vars[j]
+			translateVarNamesToIDs(c, v, srcNameToID, bagNameToID, keyNameToID)
 			fields := []struct {
 				field string
 				ptr   *string
@@ -96,5 +217,96 @@ func EncryptInPlace(c *Config, key []byte) error {
 			}
 		}
 	}
+
+	// 4. Seal the rebuilt dictionary back into Meta.NameMap, but only if
+	//    its content changed vs. the prior one — otherwise leave the
+	//    existing envelope untouched so a no-op save produces byte-
+	//    identical output (no nonce churn).
+	if c.Meta.NameMap == "" || !nameMapEqual(prev, nm) {
+		sealed, err := sealNameMap(key, nm)
+		if err != nil {
+			return err
+		}
+		c.Meta.NameMap = sealed
+	}
+	// Keep the in-memory dictionary in sync with what we just sealed so a
+	// caller that reuses c (or a clone of it) sees the freshly-minted IDs.
+	c.IDMap = nm
 	return nil
+}
+
+// nameMapEqual reports whether two dictionaries carry the same ID↔name
+// content (order-independent). Used to skip a re-seal on a no-op save.
+func nameMapEqual(a, b *NameMap) bool {
+	if !stringMapEqual(a.Sources, b.Sources) || !stringMapEqual(a.Bags, b.Bags) {
+		return false
+	}
+	if len(a.Keys) != len(b.Keys) {
+		return false
+	}
+	for bagID, am := range a.Keys {
+		bm, ok := b.Keys[bagID]
+		if !ok || !stringMapEqual(am, bm) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringMapEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+// translateVarNamesToIDs rewrites v.Source / v.Ref / v.Key from real
+// names to opaque IDs, in place, ahead of sealing. It must run BEFORE
+// the source/ref/key fields are wrapped in envelopes. The var's source
+// type is resolved against the still-name-keyed c.Sources (this helper
+// is called before c.Sources is consulted by ID); the caller has already
+// rebuilt c.Sources by ID, so we re-derive type from the source ID via
+// the reverse maps instead.
+func translateVarNamesToIDs(
+	c *Config,
+	v *VarRef,
+	srcNameToID, bagNameToID map[string]string,
+	keyNameToID map[string]map[string]string,
+) {
+	if v.Source == "" || crypto.IsEnvelope(v.Source) {
+		return
+	}
+	srcID, ok := srcNameToID[v.Source]
+	if !ok {
+		// Unknown source name (config will fail ValidatePost). Leave the
+		// fields untouched so the failure surfaces as "source not
+		// defined" rather than a confusing crypto error.
+		return
+	}
+	// Is this a local-type source? c.Sources is already ID-keyed at this
+	// point in EncryptInPlace, so look it up by ID.
+	local := false
+	if sc, ok := c.Sources[srcID]; ok {
+		local = sc.Type == "local"
+	}
+	v.Source = srcID
+	if !local {
+		return
+	}
+	if v.Ref != "" && !crypto.IsEnvelope(v.Ref) {
+		if bagID, ok := bagNameToID[v.Ref]; ok {
+			refBagID := bagID
+			if v.Key != "" && !crypto.IsEnvelope(v.Key) {
+				if keyID, ok := keyNameToID[refBagID][v.Key]; ok {
+					v.Key = keyID
+				}
+			}
+			v.Ref = refBagID
+		}
+	}
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// MigrationBackupSuffix is appended to the config path for the verbatim
+// pre-migration backup written by MigrateToOpaqueIDs. The backup is
+// removed automatically by the next successful AtomicSave from a
+// master-key-holding path (see AtomicSave).
+const MigrationBackupSuffix = ".pre-id-migration.bak"
+
+// MigrateToOpaqueIDs upgrades a legacy name-keyed config (pre-#248) to
+// the opaque-ID on-disk shape: source/bag/bag-key names move into the
+// sealed [_meta].name_map and the TOML structure is rekeyed by random
+// s_/b_/k_ IDs, with every affected value re-sealed under the new
+// ID-based AADs.
+//
+// It is idempotent: a config already in the opaque-ID shape is detected
+// (NeedsIDMigration == false) and the function returns (false, nil)
+// without touching disk.
+//
+// Flow (DECIDED in #248):
+//  1. Detect old shape; short-circuit if already migrated.
+//  2. Copy the file verbatim to a sibling backup. If the backup already
+//     exists, abort with a conflict error (it may be a prior half-
+//     migration) — never overwrite it.
+//  3. Decrypt under the OLD (name-based) AADs. On a legacy config the
+//     map keys are names, so DecryptInPlace's AAD derivation reproduces
+//     the old name-based context exactly, and translation is a no-op.
+//  4. Re-encrypt via EncryptInPlace, which mints IDs, builds + seals the
+//     name_map, and re-seals every value under the new ID-based AADs.
+//  5. AtomicSave the new form.
+//
+// Failure handling: a decrypt or save error leaves the ORIGINAL file
+// untouched (we only AtomicSave at the very end) and retains the backup,
+// so the next run under a fixed binary/passphrase is a clean retry. The
+// backup written here is removed by the next successful AtomicSave.
+//
+// Returns migrated=true only when the on-disk file was rewritten.
+//
+// IRREVERSIBILITY: once migrated, the names live only inside the sealed
+// name_map; an older jitenv binary (pre-#248) cannot read the opaque-ID
+// config. The backup is the escape hatch until the next save consumes
+// it.
+func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
+	c, err := Load(path)
+	if err != nil {
+		return false, err
+	}
+	if !NeedsIDMigration(c) {
+		return false, nil
+	}
+
+	backupPath := path + MigrationBackupSuffix
+	if err := writeVerbatimBackup(path, backupPath); err != nil {
+		return false, err
+	}
+
+	// Decrypt under the legacy (name-based) AADs. DecryptInPlace derives
+	// AADs from the map keys, which are names on a legacy config, so this
+	// reproduces the pre-#248 context. There is no name_map yet, so the
+	// ID→name translation step is a no-op and c stays name-keyed.
+	if err := DecryptInPlace(c, key); err != nil {
+		return false, fmt.Errorf("migrate: decrypt legacy config: %w (original left untouched; backup at %s)", err, backupPath)
+	}
+
+	// Re-seal under the new ID-based AADs + build the sealed name_map.
+	// c.Meta.NameMap is empty here, so EncryptInPlace mints fresh IDs.
+	if err := EncryptInPlace(c, key); err != nil {
+		return false, fmt.Errorf("migrate: re-encrypt under opaque IDs: %w (original left untouched; backup at %s)", err, backupPath)
+	}
+
+	// Write via the unexported atomicSave so the migration does NOT
+	// remove the backup it just created — the backup is the escape hatch
+	// until the NEXT user-facing AtomicSave (#248).
+	if err := atomicSave(path, c); err != nil {
+		return false, fmt.Errorf("migrate: save migrated config: %w (original left untouched; backup at %s)", err, backupPath)
+	}
+	return true, nil
+}
+
+// writeVerbatimBackup copies src to dst byte-for-byte at mode 0600. It
+// refuses to overwrite an existing backup: a leftover backup signals a
+// prior interrupted migration, and clobbering it would discard the only
+// pristine copy of the user's original config.
+func writeVerbatimBackup(src, dst string) error {
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("migration backup %s already exists; refusing to overwrite (it may be a prior interrupted migration — inspect it, then remove it to retry)", dst)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat backup path %s: %w", dst, err)
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	// O_EXCL so a backup that appears between the Stat and the Open
+	// (TOCTOU) still aborts rather than truncating.
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("migration backup %s already exists; refusing to overwrite", dst)
+		}
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(dst)
+		return fmt.Errorf("write backup %s: %w", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(dst)
+		return fmt.Errorf("close backup %s: %w", dst, err)
+	}
+	return nil
+}
+
+// removeMigrationBackup unlinks the pre-migration backup sibling for
+// path, if present. Called from AtomicSave after a successful rename so
+// the escape-hatch copy is cleaned up on the first config-modifying save
+// under the new binary. Best-effort: a failure to remove is non-fatal
+// (the save already succeeded), so the error is swallowed.
+func removeMigrationBackup(path string) {
+	_ = os.Remove(path + MigrationBackupSuffix)
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,205 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// writeLegacyConfig builds and writes a pre-#248 (name-keyed,
+// name-AAD-sealed) config to path and returns the derived master key.
+// This is the on-disk shape an older jitenv binary produced: source /
+// bag / bag-key NAMES are plaintext TOML map keys, values are enc:v2
+// envelopes bound to NAME-based AADs, and there is no _meta.name_map.
+func writeLegacyConfig(t *testing.T, path string) []byte {
+	t.Helper()
+	pw := []byte("hunter2")
+	if err := InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	t.Cleanup(func() { zero(key) })
+
+	// Seal values under the LEGACY name-based AADs (SourceParamAAD /
+	// SecretAAD take the name as the first coordinate when the map key is
+	// a name).
+	awsParam, _ := crypto.EncryptField(key, "AKsecret", SourceParamAAD("aws", "secret_access_key"))
+	stripeSK, _ := crypto.EncryptField(key, "sk_live_x", SecretAAD("stripe", "SECRET_KEY"))
+
+	c.Sources = map[string]SourceConfig{
+		"vault": {Type: "local"},
+		"aws":   {Type: "aws", Params: map[string]any{"region": "us-east-1", "secret_access_key": awsParam}},
+	}
+	c.Secrets = map[string]map[string]string{
+		"stripe": {"SECRET_KEY": stripeSK},
+	}
+	// vars sealed under slot-index AADs (unchanged across #248).
+	vName, _ := crypto.EncryptField(key, "STRIPE_SK", VarFieldAAD(0, 0, "name"))
+	vSrc, _ := crypto.EncryptField(key, "vault", VarFieldAAD(0, 0, "source"))
+	vRef, _ := crypto.EncryptField(key, "stripe", VarFieldAAD(0, 0, "ref"))
+	vKey, _ := crypto.EncryptField(key, "SECRET_KEY", VarFieldAAD(0, 0, "key"))
+	c.Mappings = []Mapping{{
+		Path: "/abs/run.sh",
+		Vars: []VarRef{{Name: vName, Source: vSrc, Ref: vRef, Key: vKey}},
+	}}
+	if err := Save(path, c); err != nil {
+		t.Fatalf("save legacy: %v", err)
+	}
+	return key
+}
+
+// TestMigrateToOpaqueIDs_Golden is the migration acceptance test: a
+// legacy config migrates to the opaque-ID shape, the values decrypt to
+// identical plaintext under the new ID-based AADs, a verbatim backup is
+// written, and a second migration is a no-op.
+func TestMigrateToOpaqueIDs_Golden(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+
+	// Sanity: pre-migration it's name-keyed and needs migration.
+	pre, err := Load(path)
+	if err != nil {
+		t.Fatalf("load pre: %v", err)
+	}
+	if !NeedsIDMigration(pre) {
+		t.Fatal("legacy config should need migration")
+	}
+
+	migrated, err := MigrateToOpaqueIDs(path, key)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migrated=true for a legacy config")
+	}
+
+	// Backup written verbatim.
+	backup := path + MigrationBackupSuffix
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("expected backup at %s: %v", backup, err)
+	}
+
+	// On disk: opaque IDs + sealed name_map, no plaintext names.
+	post, err := Load(path)
+	if err != nil {
+		t.Fatalf("load post: %v", err)
+	}
+	if NeedsIDMigration(post) {
+		t.Fatal("post-migration config should NOT need migration")
+	}
+	if !HasOpaqueIDShape(post) {
+		t.Fatal("post-migration config should be opaque-ID shaped")
+	}
+	if post.Meta.NameMap == "" {
+		t.Fatal("post-migration config missing sealed name_map")
+	}
+	if _, ok := post.Sources["vault"]; ok {
+		t.Fatal("source name 'vault' still a plaintext key post-migration")
+	}
+
+	// Values decrypt to the ORIGINAL plaintext.
+	if err := DecryptInPlace(post, key); err != nil {
+		t.Fatalf("decrypt post: %v", err)
+	}
+	if post.Sources["aws"].Params["secret_access_key"] != "AKsecret" {
+		t.Fatalf("aws param not preserved: %v", post.Sources["aws"].Params["secret_access_key"])
+	}
+	if post.Sources["aws"].Params["region"] != "us-east-1" {
+		t.Fatalf("aws region not preserved: %v", post.Sources["aws"].Params["region"])
+	}
+	if post.Secrets["stripe"]["SECRET_KEY"] != "sk_live_x" {
+		t.Fatalf("stripe secret not preserved: %v", post.Secrets["stripe"]["SECRET_KEY"])
+	}
+	v := post.Mappings[0].Vars[0]
+	if v.Name != "STRIPE_SK" || v.Source != "vault" || v.Ref != "stripe" || v.Key != "SECRET_KEY" {
+		t.Fatalf("var not preserved across migration: %#v", v)
+	}
+
+	// Second migration is a no-op (idempotent).
+	migrated2, err := MigrateToOpaqueIDs(path, key)
+	if err != nil {
+		t.Fatalf("second migrate: %v", err)
+	}
+	if migrated2 {
+		t.Fatal("second migration should be a no-op")
+	}
+}
+
+// TestMigrateToOpaqueIDs_BackupConflict asserts a pre-existing backup
+// aborts the migration (it may be a prior interrupted run).
+func TestMigrateToOpaqueIDs_BackupConflict(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+
+	// Plant a stale backup.
+	if err := os.WriteFile(path+MigrationBackupSuffix, []byte("stale"), 0600); err != nil {
+		t.Fatalf("plant backup: %v", err)
+	}
+	if _, err := MigrateToOpaqueIDs(path, key); err == nil {
+		t.Fatal("migration must abort when a backup already exists")
+	}
+	// Original untouched (still legacy).
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !NeedsIDMigration(c) {
+		t.Fatal("original config must be left untouched (still legacy) on backup conflict")
+	}
+}
+
+// TestMigrateToOpaqueIDs_ValidateStructure confirms ValidateStructure
+// passes on the post-migration (ID-keyed, sealed) form — the cross-ref
+// works on IDs as TOML keys without the master key.
+func TestMigrateToOpaqueIDs_ValidateStructure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	post, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := post.ValidateStructure(); err != nil {
+		t.Fatalf("ValidateStructure on migrated form should pass: %v", err)
+	}
+}
+
+// TestAtomicSave_RemovesMigrationBackup verifies the first config-
+// modifying save after a migration consumes the backup escape hatch.
+func TestAtomicSave_RemovesMigrationBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	backup := path + MigrationBackupSuffix
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("backup should exist immediately after migration: %v", err)
+	}
+
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(backup); !os.IsNotExist(err) {
+		t.Fatalf("backup should be removed after the next AtomicSave, stat err=%v", err)
+	}
+}

--- a/internal/config/nameid.go
+++ b/internal/config/nameid.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// Opaque-ID scheme (#248). Source / bag / bag-key NAMES never land on
+// disk in cleartext: the TOML structure is keyed by short random IDs
+// (s_/b_/k_ + 6 hex chars) and the ID→name dictionary is sealed into
+// [_meta].name_map. The in-memory Config still uses real names — the
+// translation happens at the encrypt/decrypt boundary — so the
+// resolver and TUI are unaffected.
+const (
+	idPrefixSource = "s_"
+	idPrefixBag    = "b_"
+	idPrefixKey    = "k_"
+	idHexLen       = 6 // hex chars after the prefix
+)
+
+// nameMapAAD binds the sealed name-map envelope to its [_meta] slot, the
+// same way metaVerifyAAD binds the passphrase sentinel (security #110).
+const nameMapAAD = "meta.name_map"
+
+// NameMap is the decrypted ID↔name dictionary. The JSON form (sealed
+// into Meta.NameMap) keys by ID; reverse lookups are built on demand.
+type NameMap struct {
+	// Sources maps a source ID (s_xxxxxx) to its user-facing name.
+	Sources map[string]string `json:"sources,omitempty"`
+	// Bags maps a bag ID (b_xxxxxx) to its user-facing name.
+	Bags map[string]string `json:"bags,omitempty"`
+	// Keys is bag-scoped: Keys[bagID][keyID] = keyName. Scoping the key
+	// dictionary by bag lets a decrypt→re-encrypt round trip recover the
+	// (bag, keyName) → keyID association from the dictionary alone, so
+	// IDs stay stable across saves even though key names like "token"
+	// repeat across bags.
+	Keys map[string]map[string]string `json:"keys,omitempty"`
+}
+
+// IsSourceID / IsBagID / IsKeyID report whether s is a well-formed
+// opaque ID of the given kind. Used to tell the new on-disk shape from
+// the legacy name-keyed shape (migration trigger) and to decide whether
+// a decrypted var.ref / var.key value is an ID to translate.
+func IsSourceID(s string) bool { return isID(s, idPrefixSource) }
+func IsBagID(s string) bool    { return isID(s, idPrefixBag) }
+func IsKeyID(s string) bool    { return isID(s, idPrefixKey) }
+
+func isID(s, prefix string) bool {
+	if !strings.HasPrefix(s, prefix) {
+		return false
+	}
+	rest := s[len(prefix):]
+	if len(rest) != idHexLen {
+		return false
+	}
+	for _, r := range rest {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// newID mints a random opaque ID with the given prefix that is not
+// already present in taken. Collision-checked within the config so two
+// sources/bags/keys never share an ID.
+func newID(prefix string, taken map[string]string) (string, error) {
+	for attempt := 0; attempt < 64; attempt++ {
+		buf := make([]byte, idHexLen/2+1)
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("mint id: %w", err)
+		}
+		id := prefix + hex.EncodeToString(buf)[:idHexLen]
+		if _, exists := taken[id]; !exists {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("mint id: exhausted attempts finding a free %s id", prefix)
+}
+
+// nameToID inverts a {id:name} map. On a duplicate name (which the TUI
+// rejects, but a hand-edited config could carry) the first ID wins; the
+// caller is encrypting from a name-keyed in-memory Config whose own map
+// keys are already unique, so duplicates can only arise from a corrupt
+// name_map and are harmless to the encrypt direction.
+func nameToID(idToName map[string]string) map[string]string {
+	out := make(map[string]string, len(idToName))
+	for id, name := range idToName {
+		if _, exists := out[name]; !exists {
+			out[name] = id
+		}
+	}
+	return out
+}
+
+// sealNameMap serialises nm to JSON and wraps it in an enc:v2 envelope
+// bound to nameMapAAD. An empty map (no sources/bags/keys) seals to an
+// empty-object envelope rather than being omitted, so a config that
+// once had structure and then had it all deleted still round-trips.
+func sealNameMap(key []byte, nm *NameMap) (string, error) {
+	b, err := json.Marshal(nm)
+	if err != nil {
+		return "", fmt.Errorf("marshal name_map: %w", err)
+	}
+	env, err := crypto.EncryptField(key, string(b), nameMapAAD)
+	if err != nil {
+		return "", fmt.Errorf("seal name_map: %w", err)
+	}
+	// Best-effort wipe of the plaintext JSON (which carries names, not
+	// secret values, but still operational metadata #248).
+	for i := range b {
+		b[i] = 0
+	}
+	return env, nil
+}
+
+// openNameMap decrypts Meta.NameMap. A blank envelope (legacy / freshly
+// migrated-from-empty config) yields an empty, non-nil NameMap so
+// callers can range over it unconditionally.
+func openNameMap(key []byte, env string) (*NameMap, error) {
+	nm := &NameMap{
+		Sources: map[string]string{},
+		Bags:    map[string]string{},
+		Keys:    map[string]map[string]string{},
+	}
+	if env == "" {
+		return nm, nil
+	}
+	pt, err := crypto.DecryptField(key, env, nameMapAAD)
+	if err != nil {
+		return nil, fmt.Errorf("open name_map: %w", err)
+	}
+	if err := json.Unmarshal([]byte(pt), nm); err != nil {
+		return nil, fmt.Errorf("parse name_map: %w", err)
+	}
+	if nm.Sources == nil {
+		nm.Sources = map[string]string{}
+	}
+	if nm.Bags == nil {
+		nm.Bags = map[string]string{}
+	}
+	if nm.Keys == nil {
+		nm.Keys = map[string]map[string]string{}
+	}
+	return nm, nil
+}
+
+// HasOpaqueIDShape reports whether every source / bag TOML key in c is
+// already an opaque ID, i.e. the config is in the post-#248 on-disk
+// form. An empty config (no sources, no secrets) counts as already in
+// the new shape so a fresh init isn't flagged for migration. Note this
+// inspects map KEYS only (which are plaintext on disk); it never needs
+// the master key.
+func HasOpaqueIDShape(c *Config) bool {
+	for name := range c.Sources {
+		if !IsSourceID(name) {
+			return false
+		}
+	}
+	for bag, kv := range c.Secrets {
+		if !IsBagID(bag) {
+			return false
+		}
+		for k := range kv {
+			if !IsKeyID(k) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// NeedsIDMigration reports whether c is in the legacy name-keyed shape
+// and must be migrated to opaque IDs on first decrypt under this binary.
+// True when any source/bag/bag-key TOML key is not an opaque ID.
+// Idempotent: an already-migrated config (all-ID keys, or an empty
+// config with no structure) returns false. Inspects map keys only, so
+// it never needs the master key.
+func NeedsIDMigration(c *Config) bool {
+	return !HasOpaqueIDShape(c)
+}

--- a/internal/config/nameid_test.go
+++ b/internal/config/nameid_test.go
@@ -1,0 +1,273 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// fullConfig returns a name-keyed in-memory config exercising all three
+// name layers (source, bag, bag-key) plus a local-source var that
+// references a bag + key by name.
+func fullConfig() *Config {
+	return &Config{
+		Version: Version,
+		Sources: map[string]SourceConfig{
+			"vault": {Type: "local"},
+			"aws":   {Type: "aws", Params: map[string]any{"region": "us-east-1", "secret_access_key": "AKsecret"}},
+		},
+		Secrets: map[string]map[string]string{
+			"stripe": {"SECRET_KEY": "sk_live_x", "PUB": "pk_live_y"},
+			"db":     {"SECRET_KEY": "pg-pw"}, // same key name, different bag
+		},
+		Mappings: []Mapping{{
+			Path: "/abs/run.sh",
+			Vars: []VarRef{
+				{Name: "STRIPE_SK", Source: "vault", Ref: "stripe", Key: "SECRET_KEY"},
+				{Name: "DB_PW", Source: "vault", Ref: "db", Key: "SECRET_KEY"},
+				{Name: "REGION", Source: "aws", Ref: "anything", Key: "region"},
+				{Source: "vault", Ref: "stripe"}, // expand-all
+			},
+		}},
+	}
+}
+
+// TestNameLayers_RoundTrip seals a config and asserts that on disk every
+// source/bag/bag-key key is an opaque ID and the names are gone, then
+// decrypts and asserts the in-memory form is back to real names with
+// every value round-tripped (#248).
+func TestNameLayers_RoundTrip(t *testing.T) {
+	key := newTestKey(t)
+	c := fullConfig()
+
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	// On-disk: all structural keys are opaque IDs; names are absent.
+	for id := range c.Sources {
+		if !IsSourceID(id) {
+			t.Fatalf("source key %q is not an opaque ID", id)
+		}
+	}
+	for bagID, kv := range c.Secrets {
+		if !IsBagID(bagID) {
+			t.Fatalf("bag key %q is not an opaque ID", bagID)
+		}
+		for keyID := range kv {
+			if !IsKeyID(keyID) {
+				t.Fatalf("bag-key %q is not an opaque ID", keyID)
+			}
+		}
+	}
+	if c.Meta.NameMap == "" || !crypto.IsEnvelope(c.Meta.NameMap) {
+		t.Fatalf("name_map not sealed: %q", c.Meta.NameMap)
+	}
+	// var.source / ref / key are sealed envelopes whose DECRYPTED content
+	// is an ID, not the name — verify the names don't appear in cleartext
+	// anywhere in the serialized structure.
+	if _, ok := c.Sources["vault"]; ok {
+		t.Fatal("source name 'vault' still a plaintext map key")
+	}
+	if _, ok := c.Secrets["stripe"]; ok {
+		t.Fatal("bag name 'stripe' still a plaintext map key")
+	}
+
+	// Decrypt back.
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	want := fullConfig()
+	if _, ok := c.Sources["vault"]; !ok {
+		t.Fatal("source 'vault' not restored after decrypt")
+	}
+	if _, ok := c.Sources["aws"]; !ok {
+		t.Fatal("source 'aws' not restored after decrypt")
+	}
+	if c.Sources["aws"].Params["secret_access_key"] != "AKsecret" {
+		t.Fatalf("aws param not round-tripped: %v", c.Sources["aws"].Params["secret_access_key"])
+	}
+	if c.Sources["aws"].Params["region"] != "us-east-1" {
+		t.Fatalf("aws region not round-tripped: %v", c.Sources["aws"].Params["region"])
+	}
+	if c.Secrets["stripe"]["SECRET_KEY"] != "sk_live_x" {
+		t.Fatalf("stripe.SECRET_KEY not round-tripped: %v", c.Secrets["stripe"]["SECRET_KEY"])
+	}
+	if c.Secrets["db"]["SECRET_KEY"] != "pg-pw" {
+		t.Fatalf("db.SECRET_KEY (shared key name) not round-tripped: %v", c.Secrets["db"]["SECRET_KEY"])
+	}
+	for i := range want.Mappings[0].Vars {
+		g := c.Mappings[0].Vars[i]
+		w := want.Mappings[0].Vars[i]
+		if g.Name != w.Name || g.Source != w.Source || g.Ref != w.Ref || g.Key != w.Key {
+			t.Errorf("vars[%d] mismatch:\n got=%#v\nwant=%#v", i, g, w)
+		}
+	}
+}
+
+// TestNameLayers_Idempotent verifies that a no-op save cycle (decrypt
+// then re-encrypt, the exact flow the TUI runs) does NOT churn the
+// opaque IDs and does NOT rotate the sealed name_map nonce. Value
+// envelopes legitimately get fresh nonces on each encrypt (decrypt
+// destroys the prior ciphertext); the stability that matters for #248 is
+// that the ID↔name dictionary stays put across saves.
+func TestNameLayers_Idempotent(t *testing.T) {
+	key := newTestKey(t)
+	c := fullConfig()
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	srcIDs := map[string]bool{}
+	for id := range c.Sources {
+		srcIDs[id] = true
+	}
+	bagIDs := map[string]bool{}
+	for id := range c.Secrets {
+		bagIDs[id] = true
+	}
+	firstNameMap := c.Meta.NameMap
+
+	// No-op save cycle.
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("re-encrypt: %v", err)
+	}
+
+	if len(c.Sources) != len(srcIDs) {
+		t.Fatalf("source count changed: %d -> %d", len(srcIDs), len(c.Sources))
+	}
+	for id := range c.Sources {
+		if !srcIDs[id] {
+			t.Fatalf("re-encrypt churned a source ID: %q is new", id)
+		}
+	}
+	for id := range c.Secrets {
+		if !bagIDs[id] {
+			t.Fatalf("re-encrypt churned a bag ID: %q is new", id)
+		}
+	}
+	if c.Meta.NameMap != firstNameMap {
+		t.Fatal("re-encrypt rotated the name_map nonce on a no-op save")
+	}
+}
+
+// TestSecretAAD_RejectsTransplantAcrossIDs is the #248 analogue of the
+// #235 transplant test: a secret sealed under (bagID_A, keyID) must fail
+// to decrypt when moved under a different bag ID. Because the AAD is now
+// ID-bound (not name-bound), the rejection holds even if the bag is
+// later renamed.
+func TestSecretAAD_RejectsTransplantAcrossIDs(t *testing.T) {
+	key := newTestKey(t)
+
+	bagA := "b_aaaaaa"
+	bagB := "b_bbbbbb"
+	keyID := "k_111111"
+	env, err := crypto.EncryptField(key, "topsecret", SecretAAD(bagA, keyID))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	// Transplant the (bagA,keyID)-bound envelope under bagB.
+	c := &Config{
+		Version: Version,
+		Secrets: map[string]map[string]string{
+			bagB: {keyID: env},
+		},
+	}
+	if err := DecryptInPlace(c, key); err == nil {
+		t.Fatal("DecryptInPlace must reject a secret transplanted across bag IDs")
+	}
+
+	// Same envelope in its bound slot decrypts.
+	c.Secrets = map[string]map[string]string{bagA: {keyID: env}}
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("envelope in bound slot must decrypt: %v", err)
+	}
+}
+
+// TestSourceParamAAD_RejectsTransplantAcrossIDs mirrors the above for
+// source params bound to a source ID.
+func TestSourceParamAAD_RejectsTransplantAcrossIDs(t *testing.T) {
+	key := newTestKey(t)
+	srcA := "s_aaaaaa"
+	srcB := "s_bbbbbb"
+	env, err := crypto.EncryptField(key, "AKsecret", SourceParamAAD(srcA, "secret_access_key"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	c := &Config{
+		Version: Version,
+		Sources: map[string]SourceConfig{
+			srcB: {Type: "aws", Params: map[string]any{"secret_access_key": env}},
+		},
+	}
+	if err := DecryptInPlace(c, key); err == nil {
+		t.Fatal("DecryptInPlace must reject a param transplanted across source IDs")
+	}
+}
+
+// TestNameMap_Sealed confirms the sealed name_map is bound to its slot
+// AAD: an envelope sealed under a different AAD can't masquerade as the
+// name_map.
+func TestNameMap_Sealed(t *testing.T) {
+	key := newTestKey(t)
+	c := fullConfig()
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	// Replace name_map with an envelope sealed under the WRONG AAD.
+	wrong, err := crypto.EncryptField(key, `{"sources":{}}`, "meta.not_name_map")
+	if err != nil {
+		t.Fatalf("seal wrong: %v", err)
+	}
+	c.Meta.NameMap = wrong
+	if err := DecryptInPlace(c, key); err == nil {
+		t.Fatal("DecryptInPlace must reject a name_map sealed under the wrong AAD")
+	}
+}
+
+// TestIDForms validates the ID predicates.
+func TestIDForms(t *testing.T) {
+	good := map[string]func(string) bool{
+		"s_3f7a2b": IsSourceID,
+		"b_9c1e4d": IsBagID,
+		"k_a7e2b1": IsKeyID,
+	}
+	for id, pred := range good {
+		if !pred(id) {
+			t.Errorf("%q should be a valid ID", id)
+		}
+	}
+	bad := []string{"", "vault", "s_", "s_3f7a2", "s_3f7a2bb", "s_3F7A2B", "s_zzzzzz", "x_3f7a2b"}
+	for _, id := range bad {
+		if IsSourceID(id) || IsBagID(id) || IsKeyID(id) {
+			if strings.HasPrefix(id, "s_") || strings.HasPrefix(id, "b_") || strings.HasPrefix(id, "k_") {
+				t.Errorf("%q should NOT be a valid ID", id)
+			}
+		}
+	}
+}
+
+// TestHasOpaqueIDShape covers the migration-trigger detector.
+func TestHasOpaqueIDShape(t *testing.T) {
+	empty := &Config{Version: Version}
+	if !HasOpaqueIDShape(empty) || NeedsIDMigration(empty) {
+		t.Fatal("empty config should be treated as already in opaque-ID shape")
+	}
+	legacy := fullConfig()
+	if HasOpaqueIDShape(legacy) || !NeedsIDMigration(legacy) {
+		t.Fatal("name-keyed config should need migration")
+	}
+	migrated := fullConfig()
+	key := newTestKey(t)
+	if err := EncryptInPlace(migrated, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if !HasOpaqueIDShape(migrated) || NeedsIDMigration(migrated) {
+		t.Fatal("encrypted config should be in opaque-ID shape")
+	}
+}

--- a/internal/tui/references.go
+++ b/internal/tui/references.go
@@ -2,6 +2,60 @@ package tui
 
 import "github.com/gv/jitenv/internal/config"
 
+// renameIDMapSource updates the carried ID↔name dictionary so the
+// stable opaque ID for a renamed source now points at newName (#248).
+// Keeping the ID and only swapping the name is what stops a rename from
+// minting a fresh ID (and thus re-sealing every referencing var
+// envelope) on the next save. No-op when the config has no dictionary
+// yet (a brand-new source that hasn't been saved — it'll get an ID on
+// first save under its current name).
+func renameIDMapSource(c *config.Config, oldName, newName string) {
+	if c.IDMap == nil {
+		return
+	}
+	for id, n := range c.IDMap.Sources {
+		if n == oldName {
+			c.IDMap.Sources[id] = newName
+		}
+	}
+}
+
+// renameIDMapBag updates the dictionary for a renamed secret bag.
+func renameIDMapBag(c *config.Config, oldName, newName string) {
+	if c.IDMap == nil {
+		return
+	}
+	for id, n := range c.IDMap.Bags {
+		if n == oldName {
+			c.IDMap.Bags[id] = newName
+		}
+	}
+}
+
+// renameIDMapKey updates the dictionary for a renamed key inside a bag.
+// The key dictionary is bag-scoped, so we locate the bag's ID first,
+// then rename the matching key entry under it.
+func renameIDMapKey(c *config.Config, bagName, oldKey, newKey string) {
+	if c.IDMap == nil {
+		return
+	}
+	bagID := ""
+	for id, n := range c.IDMap.Bags {
+		if n == bagName {
+			bagID = id
+			break
+		}
+	}
+	if bagID == "" {
+		return
+	}
+	for kid, n := range c.IDMap.Keys[bagID] {
+		if n == oldKey {
+			c.IDMap.Keys[bagID][kid] = newKey
+		}
+	}
+}
+
 // This file centralises the "rename → rewrite references" logic so
 // that every UI rename flow updates the in-memory config consistently.
 // Mapping VarRefs are the only place where renamed names are reused,

--- a/internal/tui/rename_id_test.go
+++ b/internal/tui/rename_id_test.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+)
+
+// sourceIDForName returns the opaque ID bound to a source name in the
+// carried dictionary, or "" if absent.
+func sourceIDForName(c *config.Config, name string) string {
+	if c.IDMap == nil {
+		return ""
+	}
+	for id, n := range c.IDMap.Sources {
+		if n == name {
+			return id
+		}
+	}
+	return ""
+}
+
+// TestRenameKeepsSourceIDStable is the #248 rename-UX contract: renaming
+// a source updates only the sealed name_map entry (ID -> newName) and
+// keeps the opaque ID stable. The in-memory var references are renamed
+// (they're name-keyed in memory), but the underlying ID — and thus the
+// AAD coordinates of every value sealed under that source — does NOT
+// change, so no var/source envelope is needlessly re-keyed.
+func TestRenameKeepsSourceIDStable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+
+	c.Sources = map[string]config.SourceConfig{
+		"vault": {Type: "local"},
+		"aws":   {Type: "aws", Params: map[string]any{"region": "us-east-1"}},
+	}
+	c.Mappings = []config.Mapping{{
+		Path: "/x",
+		Vars: []config.VarRef{
+			{Name: "R", Source: "aws", Key: "region"},
+		},
+	}}
+
+	// First save mints IDs; reload+decrypt to populate IDMap with names.
+	out := cloneForSave(c)
+	if err := encryptForSave(out, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := config.AtomicSave(path, out); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	reloaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := config.DecryptInPlace(reloaded, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	awsIDBefore := sourceIDForName(reloaded, "aws")
+	if awsIDBefore == "" || !config.IsSourceID(awsIDBefore) {
+		t.Fatalf("expected an opaque ID for 'aws', got %q", awsIDBefore)
+	}
+
+	// Simulate the TUI rename flow (sources_screen.go).
+	reloaded.Sources["aws-staging"] = reloaded.Sources["aws"]
+	delete(reloaded.Sources, "aws")
+	rewriteSourceRefs(reloaded, "aws", "aws-staging")
+	renameIDMapSource(reloaded, "aws", "aws-staging")
+
+	// var ref was rewritten in memory (name-keyed).
+	if reloaded.Mappings[0].Vars[0].Source != "aws-staging" {
+		t.Fatalf("var source not renamed in memory: %q", reloaded.Mappings[0].Vars[0].Source)
+	}
+
+	// The ID must now bind to the NEW name, and be the SAME ID.
+	awsIDAfter := sourceIDForName(reloaded, "aws-staging")
+	if awsIDAfter != awsIDBefore {
+		t.Fatalf("rename churned the source ID: before=%q after=%q", awsIDBefore, awsIDAfter)
+	}
+	if sourceIDForName(reloaded, "aws") != "" {
+		t.Fatal("old name 'aws' still present in the dictionary after rename")
+	}
+
+	// Save the renamed config; on disk the same ID is used as the map key.
+	out2 := cloneForSave(reloaded)
+	if err := encryptForSave(out2, key); err != nil {
+		t.Fatalf("encrypt2: %v", err)
+	}
+	if _, ok := out2.Sources[awsIDBefore]; !ok {
+		t.Fatalf("on-disk source map should still key on the stable ID %q; got keys %v", awsIDBefore, mapKeys(out2.Sources))
+	}
+}
+
+func mapKeys(m map[string]config.SourceConfig) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/tui/save.go
+++ b/internal/tui/save.go
@@ -29,6 +29,11 @@ func saveCmd(r *rootModel) tea.Cmd {
 			if err := config.AtomicSave(r.cfgPath, out); err != nil {
 				return errorMsg(fmt.Sprintf("save: %v", err))
 			}
+			// Propagate the freshly-built ID↔name dictionary (with any
+			// IDs minted for new sources/bags/keys) back into the live
+			// config so a subsequent rename/save reuses the same IDs
+			// instead of minting new ones (#248 ID stability).
+			r.cfg.IDMap = out.IDMap
 			return savedMsg{}
 		},
 		func() tea.Msg {

--- a/internal/tui/save_test.go
+++ b/internal/tui/save_test.go
@@ -61,28 +61,45 @@ func TestEncryptForSave_RoundTrip(t *testing.T) {
 		t.Fatalf("live secret mutated: %v", c.Secrets["stripe"]["SK"])
 	}
 
-	// Re-load and inspect the on-disk form.
+	// Re-load and inspect the on-disk form. Post-#248 the Sources /
+	// Secrets maps are keyed by opaque IDs, and the source / bag / key
+	// NAMES are gone from the structure (sealed into _meta.name_map), so
+	// we can't index by name before decrypt — assert encryption by
+	// walking the maps instead.
 	reloaded, err := config.Load(path)
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	sak := reloaded.Sources["prod_aws"].Params["secret_access_key"].(string)
-	if !crypto.IsEnvelope(sak) {
-		t.Fatalf("secret_access_key not encrypted on disk: %q", sak)
+	for id := range reloaded.Sources {
+		if !config.IsSourceID(id) {
+			t.Fatalf("source key %q is not an opaque ID on disk", id)
+		}
 	}
-	// Security #112: encrypt-by-default. Every non-envelope string
-	// param must land on disk as an envelope, regardless of whether
-	// the schema flagged it Sensitive. The previous behaviour treated
-	// the schema as the sole gate, which silently leaked params from
-	// sources without a registered schema (or sources where an author
-	// forgot the Sensitive flag).
-	region := reloaded.Sources["prod_aws"].Params["region"].(string)
-	if !crypto.IsEnvelope(region) {
-		t.Fatalf("non-sensitive region was NOT encrypted on disk: %q", region)
+	if reloaded.Meta.NameMap == "" {
+		t.Fatalf("expected sealed _meta.name_map on disk")
 	}
-	for _, v := range reloaded.Secrets["stripe"] {
-		if !crypto.IsEnvelope(v) {
-			t.Fatalf("secret not encrypted: %q", v)
+	// Security #112: encrypt-by-default. Every non-envelope string param
+	// must land on disk as an envelope, regardless of the schema's
+	// Sensitive flag.
+	for _, sc := range reloaded.Sources {
+		for pk, pv := range sc.Params {
+			s, _ := pv.(string)
+			if !crypto.IsEnvelope(s) {
+				t.Fatalf("param %q not encrypted on disk: %q", pk, s)
+			}
+		}
+	}
+	for bagID, kv := range reloaded.Secrets {
+		if !config.IsBagID(bagID) {
+			t.Fatalf("bag key %q is not an opaque ID on disk", bagID)
+		}
+		for keyID, v := range kv {
+			if !config.IsKeyID(keyID) {
+				t.Fatalf("bag-key %q is not an opaque ID on disk", keyID)
+			}
+			if !crypto.IsEnvelope(v) {
+				t.Fatalf("secret not encrypted: %q", v)
+			}
 		}
 	}
 
@@ -146,9 +163,13 @@ func TestEncryptForSave_EncryptsParamsWithoutSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	v := reloaded.Sources["myop"].Params["opaque_token"].(string)
-	if !crypto.IsEnvelope(v) {
-		t.Fatalf("schema-less param was NOT encrypted on disk: %q", v)
+	// Opaque-ID on-disk form: assert encryption by walking, since the
+	// "myop" name is sealed into _meta.name_map (#248).
+	for _, sc := range reloaded.Sources {
+		v, _ := sc.Params["opaque_token"].(string)
+		if !crypto.IsEnvelope(v) {
+			t.Fatalf("schema-less param was NOT encrypted on disk: %q", v)
+		}
 	}
 	if err := config.DecryptInPlace(reloaded, key); err != nil {
 		t.Fatalf("decrypt: %v", err)

--- a/internal/tui/secrets_screen.go
+++ b/internal/tui/secrets_screen.go
@@ -211,6 +211,7 @@ func newRenameBagScreen(r *rootModel, oldName string) screen {
 		r.cfg.Secrets[newName] = r.cfg.Secrets[oldName]
 		delete(r.cfg.Secrets, oldName)
 		rewriteLocalBagRefs(r.cfg, oldName, newName)
+		renameIDMapBag(r.cfg, oldName, newName)
 		return tea.Sequence(
 			emit(popMsg{}),
 			emit(dirtyMsg{}),
@@ -609,6 +610,7 @@ func (s *kvEditScreen) commit() tea.Cmd {
 			delete(bag, s.existingKey)
 			bag[key] = val
 			rewriteLocalKeyRefs(s.root.cfg, s.bag, s.existingKey, key)
+			renameIDMapKey(s.root.cfg, s.bag, s.existingKey, key)
 		} else {
 			bag[key] = val
 		}

--- a/internal/tui/sources_screen.go
+++ b/internal/tui/sources_screen.go
@@ -173,6 +173,7 @@ func newRenameSourceScreen(r *rootModel, oldName string) screen {
 		r.cfg.Sources[newName] = r.cfg.Sources[oldName]
 		delete(r.cfg.Sources, oldName)
 		rewriteSourceRefs(r.cfg, oldName, newName)
+		renameIDMapSource(r.cfg, oldName, newName)
 		return tea.Sequence(
 			emit(popMsg{}),
 			emit(dirtyMsg{}),

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -74,6 +74,14 @@ func RunWithMappingTemplate(cfgPath string, key []byte, template *config.Mapping
 	if err != nil {
 		return err
 	}
+	if migrated, err := config.MigrateToOpaqueIDs(cfgPath, key); err != nil {
+		return fmt.Errorf("migrate config for post-clone follow-up: %w", err)
+	} else if migrated {
+		cfg, err = config.Load(cfgPath)
+		if err != nil {
+			return err
+		}
+	}
 	if err := config.DecryptInPlace(cfg, key); err != nil {
 		return fmt.Errorf("decrypt config for post-clone follow-up: %w", err)
 	}
@@ -188,6 +196,20 @@ func loadOrInit(cfgPath string) (*config.Config, []byte, error) {
 	key, err := config.DeriveKeyFromMeta(c, pw)
 	if err != nil {
 		return nil, nil, err
+	}
+	// One-shot opaque-ID migration (#248). Runs under the TUI lock held
+	// by `jitenv config`, so it can't race the agent-spawn migration.
+	if migrated, err := config.MigrateToOpaqueIDs(cfgPath, key); err != nil {
+		zero(key)
+		return nil, nil, err
+	} else if migrated {
+		// Reload the rewritten (opaque-ID) form so DecryptInPlace below
+		// works on the migrated bytes.
+		c, err = config.Load(cfgPath)
+		if err != nil {
+			zero(key)
+			return nil, nil, err
+		}
 	}
 	if err := config.DecryptInPlace(c, key); err != nil {
 		zero(key)


### PR DESCRIPTION
## What

Finishes the work #235 started. #235 sealed every **value** under `mappings[*].vars[*]` and per-bag secret values, but the TOML **map keys** — `[sources.vault]`, `[secrets.stripe]`, bag-key names like `"SECRET_KEY"` — stayed plaintext on disk, leaking the full secret topology (which sources, which bags, which key names) to a passive reader of `config.toml`.

This replaces those user-facing names in the on-disk structure with random **opaque IDs** and stores a sealed ID↔name dictionary in `[_meta].name_map`.

## On-disk shape

```toml
[_meta]
  name_map = "enc:v2:..."        # NEW: AEAD-sealed ID<->name JSON
[sources.s_3f7a2b]               # opaque ID, not "vault"
  type = "local"                 # type STAYS PLAINTEXT (registry needs it pre-decrypt)
[secrets.b_9c1e4d]               # opaque ID, not "stripe"
  "k_a7e2b1" = "enc:v2:..."      # opaque key ID, not "SECRET_KEY"
[[mappings]]
  path = "/abs/run.sh"           # path/glob/cwd_glob/commands STAY PLAINTEXT (out of scope)
  [[mappings.vars]]
    source = "enc:v2:..."        # sealed by #235; decrypted content is now the ID "s_3f7a2b"
    key    = "enc:v2:..."        # sealed; content now "k_a7e2b1"
```

IDs are `s_`/`b_`/`k_` + 6 random hex chars, collision-checked within the config.

## How

- **In-memory `Config` still uses real names.** `DecryptInPlace` opens the sealed `name_map` first, decrypts values under ID-based AADs, then translates IDs→names (re-keys `Sources`/`Secrets`, rewrites `var.source`/`ref`/`key`). The resolver and TUI see real names — `pickValue` still indexes by the user's real key name. No display changes.
- **`EncryptInPlace`** mints stable IDs (reused across saves via a carried `Config.IDMap`, so a no-op save doesn't churn IDs or rotate the `name_map` nonce), rekeys the structure to IDs, and re-seals values under **ID-based AAD coordinates** (`SourceParamAAD`/`SecretAAD` now take IDs). Var-field AADs keep their slot-index form.
- **Rename UX changed (as specced):** a rename updates the `name_map` entry and keeps the **ID stable** — it does *not* regenerate the ID or rewrite var references at the ID level. The TUI rename handlers call new `renameIDMap{Source,Bag,Key}` helpers.

## Migration (implicit, on first decrypt under the new binary)

Triggered from `jitenv unlock` (before the agent spawns), `jitenv config` (TUI unlock), and `jitenv clone`. Flow:

1. Detect the legacy name-keyed shape (idempotent — already-migrated configs short-circuit).
2. Copy the file verbatim to a sibling backup `config.toml.pre-id-migration.bak` (mode 0600). **Refuses to overwrite** an existing backup (possible prior half-migration).
3. Decrypt under the OLD name-based AADs (reproduced automatically — on a legacy config the map keys *are* the names).
4. Mint IDs, build + seal the `name_map`, **re-seal** every affected envelope under the new ID-based AADs.
5. `AtomicSave` the new form.

Failure mid-migration leaves the original untouched and retains the backup; the next run is a clean, idempotent retry. The backup is removed automatically by the next config-modifying `AtomicSave`. Migration is guarded by the existing `.tui.lock` so agent-spawn and TUI-edit migrations can't race.

**⚠️ Irreversibility:** once migrated, the names live only inside the sealed `name_map`; an older (pre-#248) jitenv binary cannot read the opaque-ID config. The `.pre-id-migration.bak` is the escape hatch until the next save consumes it.

## Out of scope (deliberately NOT sealed)

- `source.type` (registry builds the Source from it before decrypt).
- mapping `path`/`glob`/`cwd_glob`/`commands` (the hook needs them plaintext).

## Tests

- Encrypt/decrypt round-trip across all three name layers (source/bag/bag-key), incl. a key name shared across bags and an expand-all var.
- No-op-save stability: IDs don't churn and the `name_map` nonce doesn't rotate.
- ID-bound AAD transplant rejection for source params and secrets (mirrors `TestDecryptInPlace_RejectsTransplantedVarEnvelope`), plus `name_map` slot-AAD binding.
- Migration golden: legacy `[sources.vault]` shape → migrate → opaque IDs + new-AAD envelopes that decrypt to identical plaintext; backup written; second migration is a no-op. Plus backup-conflict abort, post-migration `ValidateStructure`, and backup-cleanup-on-next-save.
- TUI rename keeps the source ID stable.
- Agent e2e: encrypt→decrypt→`BuildResolver`→`FetchEnv` injects env correctly, and a legacy→migrate→resolver cycle still injects env (resolver dereferences `var.Source`/`var.Key` IDs→names).

`go test ./...`, `go vet ./...`, `go mod tidy`, and `golangci-lint run` all clean (incl. the slow `internal/run` + `internal/shell` e2e suites).

Closes #248