### PR TITLE
feat(bag): import KEY=VALUE pairs from files, env vars, and stdin (#250)

### DIFF
--- a/internal/cli/bag.go
+++ b/internal/cli/bag.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// newBagCmd aggregates the `jitenv bag <subcommand>` group. Today it
+// hosts only `import` (#250); future bag-scoped operations (export,
+// rename, …) hang off the same noun.
+func newBagCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "bag",
+		Short: "Manage encrypted local secret bags.",
+		Long:  `Operate on local secret bags — collections of KEY=VALUE pairs stored encrypted in the jitenv config and exposed to mapped commands via a local source.`,
+	}
+	c.AddCommand(newBagImportCmd())
+	return c
+}
+
+// collisionPolicy controls what bagUpsert does when an incoming key
+// already exists in the target bag.
+type collisionPolicy int
+
+const (
+	// collisionAsk asks the caller's resolver function per colliding key.
+	collisionAsk collisionPolicy = iota
+	// collisionOverwrite replaces existing values without asking.
+	collisionOverwrite
+	// collisionSkip keeps existing values, dropping the incoming one.
+	collisionSkip
+)
+
+// upsertStats summarises a bagUpsert run for a one-line caller report.
+type upsertStats struct {
+	Added       int
+	Overwritten int
+	Skipped     int
+}
+
+// Total returns the number of keys actually written (added + overwritten).
+func (u upsertStats) Total() int { return u.Added + u.Overwritten }
+
+// bagUpsert mints the bag named `name` if absent, then merges `pairs`
+// into it under the given collision policy. It is the single merge path
+// shared by `jitenv clone`-style bag creation and `jitenv bag import`
+// so collision handling doesn't fork between them.
+//
+// For collisionAsk, `ask` is called once per colliding key with the
+// key name; returning true overwrites that key, false skips it. `ask`
+// is never called for non-colliding keys, and never called at all
+// under the overwrite/skip policies (which are designed to be
+// non-interactive for scripts).
+//
+// Values are merged as CLEARTEXT into cfg.Secrets — the caller is
+// responsible for the EncryptInPlace + AtomicSave round-trip that seals
+// them (and mints opaque IDs for any newly-created bag / keys, #248),
+// exactly as `jitenv clone` does via saveAndReencrypt.
+func bagUpsert(cfg *config.Config, name string, pairs []importPair, policy collisionPolicy, ask func(key string) bool) upsertStats {
+	if cfg.Secrets == nil {
+		cfg.Secrets = map[string]map[string]string{}
+	}
+	bag := cfg.Secrets[name]
+	if bag == nil {
+		bag = map[string]string{}
+		cfg.Secrets[name] = bag
+	}
+
+	var stats upsertStats
+	for _, p := range pairs {
+		if _, exists := bag[p.Key]; exists {
+			overwrite := false
+			switch policy {
+			case collisionOverwrite:
+				overwrite = true
+			case collisionSkip:
+				overwrite = false
+			case collisionAsk:
+				overwrite = ask != nil && ask(p.Key)
+			}
+			if !overwrite {
+				stats.Skipped++
+				continue
+			}
+			bag[p.Key] = p.Value
+			stats.Overwritten++
+			continue
+		}
+		bag[p.Key] = p.Value
+		stats.Added++
+	}
+	return stats
+}
+
+// importPair is the (already-deduplicated) key/value unit bagUpsert
+// merges. It is parser-agnostic so both the dotenv path and the
+// --from-env path feed the same merge logic.
+type importPair struct {
+	Key   string
+	Value string
+}

--- a/internal/cli/bag_import.go
+++ b/internal/cli/bag_import.go
@@ -1,0 +1,336 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+	"github.com/gv/jitenv/internal/dotenv"
+)
+
+// newBagImportCmd implements `jitenv bag import <bag> [flags]` (#250) —
+// a non-interactive, scriptable counterpart to the TUI bulk-import
+// screen. It reads KEY=VALUE pairs from one of three sources (a .env
+// file, named process-environment variables, or stdin), resolves
+// collisions with any existing keys in the bag per --on-collision, and
+// merges the result into an encrypted local bag.
+func newBagImportCmd() *cobra.Command {
+	var (
+		fromFile    string
+		fromEnv     []string
+		fromStdin   bool
+		onCollision string
+		dryRun      bool
+	)
+	c := &cobra.Command{
+		Use:   "import <bag>",
+		Short: "Import KEY=VALUE pairs into an encrypted local bag.",
+		Long: `Import KEY=VALUE pairs into a local secret bag, creating the bag if it does not exist.
+
+Exactly one input source must be selected:
+
+  --from-file PATH      read KEY=VALUE lines from a .env-style file
+  --from-env VAR1,VAR2  copy the NAMED variables from this process's
+                        environment into the bag, by name only
+  --stdin               read KEY=VALUE lines from standard input
+
+Collisions with keys already in the bag are resolved by --on-collision:
+
+  ask        (default) prompt y/n per colliding key on the controlling
+             terminal; requires a tty
+  overwrite  replace existing values without asking (non-interactive)
+  skip       keep existing values, drop the incoming ones (non-interactive)
+
+SECURITY: --from-env is by NAME ONLY — there is deliberately no wildcard
+or "import everything" mode. A hostile or misconfigured parent shell can
+export arbitrary variables, and a wildcard import would silently seal
+whatever happened to be in the environment (PATH, tokens belonging to
+other tools, prompt-injection payloads) into your config. Name each
+variable you intend to import.
+
+Secret VALUES never appear on the command line. Use --stdin (or
+--from-file) so values are not exposed in the process argument list or
+shell history; --from-env reads values out of the environment, not argv.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := importOpts{
+				bag:         args[0],
+				fromFile:    fromFile,
+				fromEnv:     fromEnv,
+				fromStdin:   fromStdin,
+				onCollision: onCollision,
+				dryRun:      dryRun,
+			}
+			return runBagImport(cmd, opts)
+		},
+	}
+	c.Flags().StringVar(&fromFile, "from-file", "", "read KEY=VALUE lines from a .env file")
+	c.Flags().StringSliceVar(&fromEnv, "from-env", nil, "copy the named variables from the current environment (comma-separated; by name only)")
+	c.Flags().BoolVar(&fromStdin, "stdin", false, "read KEY=VALUE lines from stdin")
+	c.Flags().StringVar(&onCollision, "on-collision", "ask", "how to handle keys already in the bag: ask|overwrite|skip")
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "parse and report what would change, without writing the config")
+	return c
+}
+
+// importPassphraseFn is the passphrase reader bag import uses. It is a
+// package var so tests can inject a fixed passphrase without a tty; in
+// production it points at crypto.PromptPassphrase.
+var importPassphraseFn = func() ([]byte, error) {
+	return crypto.PromptPassphrase("jitenv bag import passphrase: ", false)
+}
+
+type importOpts struct {
+	bag         string
+	fromFile    string
+	fromEnv     []string
+	fromStdin   bool
+	onCollision string
+	dryRun      bool
+}
+
+func runBagImport(cmd *cobra.Command, opts importOpts) error {
+	// Resolve the collision policy first — a typo here should fail before
+	// we prompt for a passphrase or read any secrets.
+	policy, err := parseCollisionPolicy(opts.onCollision)
+	if err != nil {
+		return err
+	}
+
+	// Exactly one input source. Combining them is a usage error.
+	pairs, err := gatherImportPairs(cmd, opts)
+	if err != nil {
+		return err
+	}
+	if len(pairs) == 0 {
+		return errors.New("nothing to import — no KEY=VALUE pairs found in the input")
+	}
+
+	// Load + decrypt the config (mirrors `jitenv clone`).
+	cfgPath, err := config.Resolve(os.Getenv("JITENV_CONFIG"))
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return fmt.Errorf("load %s: %w (run `jitenv config init` first)", cfgPath, err)
+	}
+	pw, err := importPassphraseFn()
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(pw)
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		return err
+	}
+	defer zeroBytes(key)
+	defer lockKey(key)()
+
+	// One-shot opaque-ID migration (#248) so a legacy config gets the
+	// sealed name_map + backup before we mint a new bag/keys into it,
+	// matching the clone/unlock paths.
+	if err := migrateOpaqueIDsLocked(cfgPath, key); err != nil {
+		return err
+	}
+	cfg, err = config.Load(cfgPath)
+	if err != nil {
+		return err
+	}
+	if err := config.DecryptInPlace(cfg, key); err != nil {
+		return err
+	}
+
+	// Merge through the shared upsert path so collision handling matches
+	// clone. The ask callback is only consulted under --on-collision=ask.
+	stats := bagUpsert(cfg, opts.bag, pairs, policy, func(k string) bool {
+		return askOverwrite(cmd, opts.bag, k)
+	})
+
+	if opts.dryRun {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"dry-run: would import %d keys (%d new, %d overwritten, %d skipped) into bag %q (config not written)\n",
+			stats.Total(), stats.Added, stats.Overwritten, stats.Skipped, opts.bag)
+		return nil
+	}
+
+	// Ensure a local source exists to expose the bag (mirrors clone).
+	if cfg.Sources == nil {
+		cfg.Sources = map[string]config.SourceConfig{}
+	}
+	if _, ok := cfg.Sources[localSourceName(cfg)]; !ok {
+		cfg.Sources["local"] = config.SourceConfig{Type: "local"}
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("internal: config invalid after import: %w", err)
+	}
+	// EncryptInPlace mints opaque IDs for the freshly-created bag / keys
+	// (#248) and re-seals every value before AtomicSave.
+	if err := saveAndReencrypt(cfgPath, cfg, key); err != nil {
+		return err
+	}
+	pingAgentReloadFromClone()
+
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"imported %d keys (%d new, %d overwritten, %d skipped) into bag %q\n",
+		stats.Total(), stats.Added, stats.Overwritten, stats.Skipped, opts.bag)
+	return nil
+}
+
+// gatherImportPairs enforces the exactly-one-source rule and returns the
+// deduplicated pairs from whichever source was selected.
+func gatherImportPairs(cmd *cobra.Command, opts importOpts) ([]importPair, error) {
+	n := 0
+	if opts.fromFile != "" {
+		n++
+	}
+	if len(opts.fromEnv) > 0 {
+		n++
+	}
+	if opts.fromStdin {
+		n++
+	}
+	switch {
+	case n == 0:
+		return nil, errors.New("choose an input source: one of --from-file, --from-env, or --stdin")
+	case n > 1:
+		return nil, errors.New("--from-file, --from-env, and --stdin are mutually exclusive; pick one")
+	}
+
+	switch {
+	case opts.fromFile != "":
+		data, err := os.ReadFile(opts.fromFile)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", opts.fromFile, err)
+		}
+		return parseDotenvPairs(string(data))
+	case opts.fromStdin:
+		data, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return parseDotenvPairs(string(data))
+	default:
+		return pairsFromEnv(cmd, opts.fromEnv)
+	}
+}
+
+// parseDotenvPairs runs the shared parser and, on any parse error,
+// returns a single error listing every offending line so the caller can
+// exit non-zero WITHOUT touching the config.
+func parseDotenvPairs(input string) ([]importPair, error) {
+	pairs, perrs := dotenv.Parse(input)
+	if len(perrs) > 0 {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d parse error(s):", len(perrs))
+		for _, e := range perrs {
+			b.WriteString("\n  " + e.Error())
+		}
+		return nil, errors.New(b.String())
+	}
+	return dedupePairs(pairs), nil
+}
+
+// pairsFromEnv reads each named variable out of the current process
+// environment. Names are validated and de-duplicated; a name that is
+// not set in the environment is reported as a warning to stderr and
+// skipped (so `--from-env A,B` still imports A when B is unset). A name
+// that is not a valid env identifier is a hard error.
+func pairsFromEnv(cmd *cobra.Command, names []string) ([]importPair, error) {
+	seen := map[string]struct{}{}
+	var pairs []importPair
+	var missing []string
+	for _, raw := range names {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if !isValidEnvName(name) {
+			return nil, fmt.Errorf("--from-env: %q is not a valid environment variable name", name)
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		val, ok := os.LookupEnv(name)
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		pairs = append(pairs, importPair{Key: name, Value: val})
+	}
+	if len(missing) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"warning: not set in environment, skipped: %s\n", strings.Join(missing, ", "))
+	}
+	return pairs, nil
+}
+
+// dedupePairs collapses duplicate keys keeping the LAST occurrence,
+// matching `set -a; source .env` semantics and the TUI bulk-import
+// behaviour.
+func dedupePairs(pairs []dotenv.Pair) []importPair {
+	lastIdx := make(map[string]int, len(pairs))
+	for i, p := range pairs {
+		lastIdx[p.Key] = i
+	}
+	out := make([]importPair, 0, len(lastIdx))
+	for i, p := range pairs {
+		if lastIdx[p.Key] == i {
+			out = append(out, importPair{Key: p.Key, Value: p.Value})
+		}
+	}
+	return out
+}
+
+// askOverwrite prompts y/n on the controlling terminal for a single
+// colliding key. Talks to /dev/tty (not stdin) so it works even when
+// the import data is piped in on stdin. Anything but an affirmative
+// answer is treated as "skip".
+func askOverwrite(cmd *cobra.Command, bag, key string) bool {
+	line, err := crypto.PromptTTYLine(fmt.Sprintf("bag %q already has %q — overwrite? [y/N] ", bag, key))
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "no terminal for collision prompt (%v) — skipping %q\n", err, key)
+		return false
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes"
+}
+
+func parseCollisionPolicy(s string) (collisionPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "ask", "":
+		return collisionAsk, nil
+	case "overwrite":
+		return collisionOverwrite, nil
+	case "skip":
+		return collisionSkip, nil
+	default:
+		return collisionAsk, fmt.Errorf("--on-collision: %q is not one of ask|overwrite|skip", s)
+	}
+}
+
+// isValidEnvName mirrors the conservative key rule the dotenv parser
+// enforces: start with a letter/underscore, then letters/digits/_.
+func isValidEnvName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/bag_import.go
+++ b/internal/cli/bag_import.go
@@ -132,6 +132,27 @@ func runBagImport(cmd *cobra.Command, opts importOpts) error {
 	defer zeroBytes(key)
 	defer lockKey(key)()
 
+	// Dry-run must be byte-for-byte side-effect-free: no opaque-ID
+	// migration (which would write the migrated config + a
+	// .pre-id-migration.bak), no save, and no TTY prompts. We decrypt the
+	// config IN MEMORY ONLY to read the target bag's existing keys, then
+	// report what WOULD change. A legacy (pre-#248) config decrypts under
+	// its name-based AADs into a name-keyed cfg.Secrets — exactly the
+	// shape bagUpsert's collision check needs — so no in-memory migration
+	// is required for the report either.
+	if opts.dryRun {
+		if err := config.DecryptInPlace(cfg, key); err != nil {
+			return err
+		}
+		// Under --on-collision=ask, dry-run must NOT prompt: report every
+		// collision as "would overwrite" instead of reading from the tty.
+		stats := bagUpsert(cfg, opts.bag, pairs, policy, func(string) bool { return true })
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"dry-run: would import %d keys (%d new, %d overwritten, %d skipped) into bag %q (config not written)\n",
+			stats.Total(), stats.Added, stats.Overwritten, stats.Skipped, opts.bag)
+		return nil
+	}
+
 	// One-shot opaque-ID migration (#248) so a legacy config gets the
 	// sealed name_map + backup before we mint a new bag/keys into it,
 	// matching the clone/unlock paths.
@@ -151,13 +172,6 @@ func runBagImport(cmd *cobra.Command, opts importOpts) error {
 	stats := bagUpsert(cfg, opts.bag, pairs, policy, func(k string) bool {
 		return askOverwrite(cmd, opts.bag, k)
 	})
-
-	if opts.dryRun {
-		fmt.Fprintf(cmd.OutOrStdout(),
-			"dry-run: would import %d keys (%d new, %d overwritten, %d skipped) into bag %q (config not written)\n",
-			stats.Total(), stats.Added, stats.Overwritten, stats.Skipped, opts.bag)
-		return nil
-	}
 
 	// Ensure a local source exists to expose the bag (mirrors clone).
 	if cfg.Sources == nil {

--- a/internal/cli/bag_import_e2e_test.go
+++ b/internal/cli/bag_import_e2e_test.go
@@ -1,0 +1,133 @@
+//go:build !windows
+
+package cli_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// buildJitenv builds the real jitenv binary against a temp output path,
+// mirroring the run-package e2e harness.
+func buildJitenv(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "jitenv")
+	cmd := exec.Command("go", "build", "-o", out, "../../cmd/jitenv")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return out
+}
+
+// TestBagImport_E2E_FileRoundTrip drives the real binary through a PTY:
+// it runs `jitenv bag import fresh --from-file <env>`, types the
+// passphrase at the prompt, and then asserts the on-disk config decrypts
+// to the imported values — proving the freshly-minted bag + keys
+// round-trip through the #248 opaque-ID name_map.
+func TestBagImport_E2E_FileRoundTrip(t *testing.T) {
+	bin := buildJitenv(t)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-bag-import")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile,
+		[]byte("TOKEN=s3cr3t\nexport DB_URL=\"postgres://localhost/x\"\n"), 0o600); err != nil {
+		t.Fatalf("write env: %v", err)
+	}
+
+	cmd := exec.Command(bin, "bag", "import", "fresh", "--from-file", envFile)
+	cmd.Env = append(os.Environ(),
+		"JITENV_CONFIG="+cfgPath,
+		"TERM=dumb",
+	)
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty start: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = cmd.Process.Kill() }()
+
+	mu := make(chan string, 1)
+	mu <- ""
+	go func() {
+		buf := make([]byte, 4096)
+		acc := ""
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				acc += string(buf[:n])
+				<-mu
+				mu <- acc
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	readAll := func() string { s := <-mu; mu <- s; return s }
+	waitFor := func(substr string, d time.Duration) bool {
+		deadline := time.Now().Add(d)
+		for time.Now().Before(deadline) {
+			if strings.Contains(readAll(), substr) {
+				return true
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return false
+	}
+
+	if !waitFor("passphrase", 10*time.Second) {
+		t.Fatalf("never saw passphrase prompt; output=%q", readAll())
+	}
+	if _, err := ptmx.Write(append(pw, '\n')); err != nil {
+		t.Fatalf("write passphrase: %v", err)
+	}
+	if !waitFor("imported", 10*time.Second) {
+		t.Fatalf("never saw import summary; output=%q", readAll())
+	}
+
+	// Wait for the process to exit so AtomicSave has completed.
+	_ = cmd.Wait()
+
+	// On-disk TOML must hold opaque IDs, not the real names.
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "TOKEN") || strings.Contains(string(raw), "fresh") {
+		t.Errorf("real names leaked into on-disk TOML:\n%s", raw)
+	}
+
+	// Decrypt and verify the round-trip.
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if err := config.DecryptInPlace(cfg, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	bag := cfg.Secrets["fresh"]
+	if bag["TOKEN"] != "s3cr3t" || bag["DB_URL"] != "postgres://localhost/x" {
+		t.Errorf("round-trip mismatch: %v", bag)
+	}
+}

--- a/internal/cli/bag_import_test.go
+++ b/internal/cli/bag_import_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
 )
 
 const testPassphrase = "correct horse battery staple"
@@ -300,5 +301,123 @@ func TestBagUpsert_AskCallback(t *testing.T) {
 	}
 	if asked["Z"] {
 		t.Errorf("ask must not be called for non-colliding key Z")
+	}
+}
+
+// newLegacyImportTestConfig writes a pre-#248 (name-keyed, name-AAD-sealed)
+// config to a temp dir, seeds the named bag with a single colliding key,
+// points JITENV_CONFIG at it, and returns the config path. This is the
+// on-disk shape an older jitenv binary produced: bag NAMES are plaintext
+// TOML map keys, values are envelopes bound to NAME-based AADs, and there
+// is no _meta.name_map (so config.NeedsIDMigration == true).
+func newLegacyImportTestConfig(t *testing.T, bag, key, val string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte(testPassphrase)
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("InitNew: %v", err)
+	}
+	c, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	mkey, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	t.Cleanup(func() {
+		for i := range mkey {
+			mkey[i] = 0
+		}
+	})
+	// Seal the seed value under the LEGACY name-based AAD (the bag NAME is
+	// the first coordinate, matching what a pre-#248 binary wrote).
+	sealed, err := crypto.EncryptField(mkey, val, config.SecretAAD(bag, key))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	c.Sources = map[string]config.SourceConfig{"local": {Type: "local"}}
+	c.Secrets = map[string]map[string]string{bag: {key: sealed}}
+	// config.Save writes the struct verbatim (no re-encrypt / no ID minting),
+	// preserving the legacy name-keyed shape on disk.
+	if err := config.Save(cfgPath, c); err != nil {
+		t.Fatalf("save legacy: %v", err)
+	}
+	// Sanity: this really is a legacy config that would trigger migration.
+	reloaded, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !config.NeedsIDMigration(reloaded) {
+		t.Fatal("fixture should be a legacy config needing migration")
+	}
+	t.Setenv("JITENV_CONFIG", cfgPath)
+	return cfgPath
+}
+
+// TestBagImport_DryRun_LegacyConfig_NoSideEffects locks in the #254
+// dry-run contract against a LEGACY (pre-#248) config: a dry-run must
+// neither run the opaque-ID migration (which would rewrite the config and
+// drop a .pre-id-migration.bak) nor write anything else. After the run the
+// on-disk config.toml must be byte-identical and no backup may exist.
+func TestBagImport_DryRun_LegacyConfig_NoSideEffects(t *testing.T) {
+	cfgPath := newLegacyImportTestConfig(t, "prod", "A", "old")
+	before, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runImport(t, "B=2\n", "prod", "--stdin", "--dry-run")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "dry-run") || !strings.Contains(out, "not written") {
+		t.Errorf("summary = %q", out)
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("dry-run must not modify a legacy config on disk")
+	}
+	if _, err := os.Stat(cfgPath + config.MigrationBackupSuffix); !os.IsNotExist(err) {
+		t.Errorf("dry-run must not create a %s backup (stat err: %v)",
+			config.MigrationBackupSuffix, err)
+	}
+}
+
+// TestBagImport_DryRun_OnCollisionAsk_NoTTY locks in the #254 fix that
+// --on-collision=ask under --dry-run does NOT read from the tty: the
+// import must complete without any interactive prompt and report the
+// colliding key as "would overwrite" in the summary. askOverwrite reads
+// from /dev/tty, which is unavailable in tests, so if dry-run reached it
+// the command would hang or error — proving the prompt is bypassed.
+func TestBagImport_DryRun_OnCollisionAsk_NoTTY(t *testing.T) {
+	cfgPath := newImportTestConfig(t, map[string]map[string]string{
+		"prod": {"A": "old"},
+	})
+	before, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A=new collides with the seeded A; B=2 is new. Under ask+dry-run the
+	// collision is REPORTED as "would overwrite", with no tty interaction.
+	out, _, err := runImport(t, "A=new\nB=2\n", "prod", "--stdin", "--on-collision=ask", "--dry-run")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "2 keys (1 new, 1 overwritten, 0 skipped)") {
+		t.Errorf("dry-run ask summary = %q (want collision reported as would-overwrite)", out)
+	}
+	if !strings.Contains(out, "dry-run") || !strings.Contains(out, "not written") {
+		t.Errorf("summary = %q", out)
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("dry-run must not modify the config")
 	}
 }

--- a/internal/cli/bag_import_test.go
+++ b/internal/cli/bag_import_test.go
@@ -1,0 +1,304 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+const testPassphrase = "correct horse battery staple"
+
+// newImportTestConfig writes a fresh encrypted config to a temp dir,
+// optionally seeding a bag, and points JITENV_CONFIG at it. It returns
+// the config path and the derived master key (for assertions).
+func newImportTestConfig(t *testing.T, seed map[string]map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := config.InitNew(cfgPath, []byte(testPassphrase)); err != nil {
+		t.Fatalf("InitNew: %v", err)
+	}
+	if len(seed) > 0 {
+		cfg, err := config.Load(cfgPath)
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		key, err := config.DeriveKeyFromMeta(cfg, []byte(testPassphrase))
+		if err != nil {
+			t.Fatalf("derive: %v", err)
+		}
+		if err := config.DecryptInPlace(cfg, key); err != nil {
+			t.Fatalf("decrypt: %v", err)
+		}
+		cfg.Secrets = seed
+		cfg.Sources = map[string]config.SourceConfig{"local": {Type: "local"}}
+		if err := config.EncryptInPlace(cfg, key); err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		if err := config.AtomicSave(cfgPath, cfg); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+	}
+	t.Setenv("JITENV_CONFIG", cfgPath)
+	return cfgPath
+}
+
+// readBag decrypts the config at path and returns the named bag's
+// real-name keyed cleartext values.
+func readBag(t *testing.T, path, bag string) map[string]string {
+	t.Helper()
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(cfg, []byte(testPassphrase))
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if err := config.DecryptInPlace(cfg, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	return cfg.Secrets[bag]
+}
+
+// runImport drives the bag import command with the given args and
+// stdin, injecting a fixed passphrase. Returns stdout, stderr, err.
+func runImport(t *testing.T, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	prev := importPassphraseFn
+	importPassphraseFn = func() ([]byte, error) { return []byte(testPassphrase), nil }
+	t.Cleanup(func() { importPassphraseFn = prev })
+
+	cmd := newBagImportCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errBuf.String(), err
+}
+
+func TestBagImport_FromFile_NewBag(t *testing.T) {
+	cfgPath := newImportTestConfig(t, nil)
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("FOO=bar\nexport BAZ=\"q u x\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runImport(t, "", "prod", "--from-file", envFile)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, `2 keys (2 new, 0 overwritten, 0 skipped) into bag "prod"`) {
+		t.Errorf("summary = %q", out)
+	}
+	bag := readBag(t, cfgPath, "prod")
+	if bag["FOO"] != "bar" || bag["BAZ"] != "q u x" {
+		t.Errorf("bag round-trip = %v", bag)
+	}
+}
+
+func TestBagImport_Stdin(t *testing.T) {
+	cfgPath := newImportTestConfig(t, nil)
+	out, _, err := runImport(t, "A=1\nB=2\n", "prod", "--stdin")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "2 new") {
+		t.Errorf("summary = %q", out)
+	}
+	bag := readBag(t, cfgPath, "prod")
+	if bag["A"] != "1" || bag["B"] != "2" {
+		t.Errorf("bag = %v", bag)
+	}
+}
+
+func TestBagImport_Stdin_EmptyEOF(t *testing.T) {
+	newImportTestConfig(t, nil)
+	_, _, err := runImport(t, "", "prod", "--stdin")
+	if err == nil || !strings.Contains(err.Error(), "nothing to import") {
+		t.Fatalf("want nothing-to-import error, got %v", err)
+	}
+}
+
+func TestBagImport_FromEnv_MixedPresentMissing(t *testing.T) {
+	cfgPath := newImportTestConfig(t, nil)
+	t.Setenv("JITENV_TEST_PRESENT", "yes")
+	os.Unsetenv("JITENV_TEST_ABSENT")
+	out, errOut, err := runImport(t, "", "prod", "--from-env", "JITENV_TEST_PRESENT,JITENV_TEST_ABSENT")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "1 new") {
+		t.Errorf("summary = %q", out)
+	}
+	if !strings.Contains(errOut, "JITENV_TEST_ABSENT") {
+		t.Errorf("expected missing-var warning, got stderr %q", errOut)
+	}
+	bag := readBag(t, cfgPath, "prod")
+	if bag["JITENV_TEST_PRESENT"] != "yes" {
+		t.Errorf("bag = %v", bag)
+	}
+	if _, ok := bag["JITENV_TEST_ABSENT"]; ok {
+		t.Errorf("absent var should not be imported")
+	}
+}
+
+func TestBagImport_OnCollision_Overwrite(t *testing.T) {
+	cfgPath := newImportTestConfig(t, map[string]map[string]string{
+		"prod": {"A": "old", "KEEP": "untouched"},
+	})
+	out, _, err := runImport(t, "A=new\nB=2\n", "prod", "--stdin", "--on-collision=overwrite")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "1 new, 1 overwritten, 0 skipped") {
+		t.Errorf("summary = %q", out)
+	}
+	bag := readBag(t, cfgPath, "prod")
+	if bag["A"] != "new" || bag["B"] != "2" || bag["KEEP"] != "untouched" {
+		t.Errorf("bag = %v", bag)
+	}
+}
+
+func TestBagImport_OnCollision_Skip(t *testing.T) {
+	cfgPath := newImportTestConfig(t, map[string]map[string]string{
+		"prod": {"A": "old"},
+	})
+	out, _, err := runImport(t, "A=new\nB=2\n", "prod", "--stdin", "--on-collision=skip")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "1 new, 0 overwritten, 1 skipped") {
+		t.Errorf("summary = %q", out)
+	}
+	bag := readBag(t, cfgPath, "prod")
+	if bag["A"] != "old" || bag["B"] != "2" {
+		t.Errorf("bag = %v", bag)
+	}
+}
+
+func TestBagImport_ParseError_ConfigUntouched(t *testing.T) {
+	cfgPath := newImportTestConfig(t, nil)
+	before, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, runErr := runImport(t, "GOOD=1\nthis is broken\n9BAD=x\n", "prod", "--stdin")
+	if runErr == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(runErr.Error(), "parse error") {
+		t.Errorf("err = %v", runErr)
+	}
+	if !strings.Contains(runErr.Error(), "line 2") {
+		t.Errorf("expected line numbers in error, got %v", runErr)
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("config must be untouched on parse error")
+	}
+}
+
+func TestBagImport_DryRun_DoesNotWrite(t *testing.T) {
+	cfgPath := newImportTestConfig(t, nil)
+	before, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runImport(t, "A=1\n", "prod", "--stdin", "--dry-run")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "dry-run") || !strings.Contains(out, "not written") {
+		t.Errorf("summary = %q", out)
+	}
+	after, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("dry-run must not modify the config")
+	}
+}
+
+func TestBagImport_MutuallyExclusiveSources(t *testing.T) {
+	newImportTestConfig(t, nil)
+	envFile := filepath.Join(t.TempDir(), ".env")
+	_ = os.WriteFile(envFile, []byte("A=1\n"), 0o600)
+	_, _, err := runImport(t, "", "prod", "--from-file", envFile, "--stdin")
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("want mutually-exclusive error, got %v", err)
+	}
+}
+
+func TestBagImport_NoSource(t *testing.T) {
+	newImportTestConfig(t, nil)
+	_, _, err := runImport(t, "", "prod")
+	if err == nil || !strings.Contains(err.Error(), "input source") {
+		t.Fatalf("want no-source error, got %v", err)
+	}
+}
+
+func TestBagImport_BadCollisionPolicy(t *testing.T) {
+	newImportTestConfig(t, nil)
+	_, _, err := runImport(t, "A=1\n", "prod", "--stdin", "--on-collision=nope")
+	if err == nil || !strings.Contains(err.Error(), "on-collision") {
+		t.Fatalf("want on-collision error, got %v", err)
+	}
+}
+
+// TestBagImport_NewBagRoundTripsThroughIDLayer is the #248 interaction
+// check: a brand-new bag with brand-new keys minted by import must
+// survive a save → reload → decrypt cycle with values intact, proving
+// the opaque-ID name_map sealed the freshly-minted IDs correctly.
+func TestBagImport_NewBagRoundTripsThroughIDLayer(t *testing.T) {
+	cfgPath := newImportTestConfig(t, nil)
+	out, _, err := runImport(t, "TOKEN=s3cr3t\nDB_URL=postgres://x\n", "fresh", "--stdin")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(out, "2 new") {
+		t.Errorf("summary = %q", out)
+	}
+	// On-disk TOML must NOT contain the real names (they are opaque IDs).
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "TOKEN") || strings.Contains(string(raw), "fresh") {
+		t.Errorf("real names leaked into on-disk TOML")
+	}
+	bag := readBag(t, cfgPath, "fresh")
+	if bag["TOKEN"] != "s3cr3t" || bag["DB_URL"] != "postgres://x" {
+		t.Errorf("round-trip = %v", bag)
+	}
+}
+
+func TestBagUpsert_AskCallback(t *testing.T) {
+	cfg := &config.Config{Secrets: map[string]map[string]string{
+		"b": {"X": "old", "Y": "keep"},
+	}}
+	pairs := []importPair{{Key: "X", Value: "new"}, {Key: "Y", Value: "new2"}, {Key: "Z", Value: "z"}}
+	asked := map[string]bool{}
+	stats := bagUpsert(cfg, "b", pairs, collisionAsk, func(k string) bool {
+		asked[k] = true
+		return k == "X" // overwrite X, skip Y
+	})
+	if stats.Added != 1 || stats.Overwritten != 1 || stats.Skipped != 1 {
+		t.Errorf("stats = %+v", stats)
+	}
+	if cfg.Secrets["b"]["X"] != "new" || cfg.Secrets["b"]["Y"] != "keep" || cfg.Secrets["b"]["Z"] != "z" {
+		t.Errorf("bag = %v", cfg.Secrets["b"])
+	}
+	if asked["Z"] {
+		t.Errorf("ask must not be called for non-colliding key Z")
+	}
+}

--- a/internal/cli/subcommands.go
+++ b/internal/cli/subcommands.go
@@ -21,6 +21,7 @@ func subcommands() []*cobra.Command {
 		newVersionCheckInternalCmd(),
 		newVersionNoticeInternalCmd(),
 		newCloneCmd(),
+		newBagCmd(),
 		newSyncCmd(),
 		newGitAskpassInternalCmd(),
 	}

--- a/internal/crypto/passphrase.go
+++ b/internal/crypto/passphrase.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"bufio"
 	"crypto/subtle"
 	"errors"
 	"fmt"
@@ -66,4 +67,31 @@ func PromptPassphrase(prompt string, confirm bool) ([]byte, error) {
 		return nil, errors.New("empty passphrase")
 	}
 	return pw, nil
+}
+
+// PromptTTYLine writes prompt to the controlling terminal and reads one
+// echoed line back from it, returning the line without its trailing
+// newline. Like PromptPassphrase it talks directly to /dev/tty
+// (CONIN$/CONOUT$ on Windows) rather than os.Stdin, so an interactive
+// prompt still works while stdin is occupied by piped import data —
+// that's exactly the `jitenv bag import --stdin --on-collision=ask`
+// case. The input is NOT secret (a y/n answer), so it is echoed.
+func PromptTTYLine(prompt string) (string, error) {
+	in, out, err := openTTY()
+	if err != nil {
+		return "", fmt.Errorf("open tty: %w", err)
+	}
+	defer in.Close()
+	if out != in {
+		defer out.Close()
+	}
+	fmt.Fprint(out, prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && line == "" {
+		return "", err
+	}
+	for len(line) > 0 && (line[len(line)-1] == '\n' || line[len(line)-1] == '\r') {
+		line = line[:len(line)-1]
+	}
+	return line, nil
 }

--- a/internal/dotenv/dotenv.go
+++ b/internal/dotenv/dotenv.go
@@ -1,29 +1,33 @@
-package tui
+// Package dotenv parses dotenv-style KEY=VALUE blocks into pairs. It is
+// the single shared parser used by both the TUI bulk-import screen and
+// the `jitenv bag import` CLI command (#70, #250) so the two entry
+// points accept exactly the same syntax.
+package dotenv
 
 import (
 	"fmt"
 	"strings"
 )
 
-// dotenvPair is one KEY = VALUE pair parsed from a dotenv-style block.
-type dotenvPair struct {
+// Pair is one KEY = VALUE pair parsed from a dotenv-style block.
+type Pair struct {
 	Key   string
 	Value string
 	Line  int // 1-based source line for error reporting
 }
 
-// dotenvError is a single parse error tied to a source line. It exists
+// ParseError is a single parse error tied to a source line. It exists
 // as its own type so callers can render line numbers cleanly.
-type dotenvError struct {
+type ParseError struct {
 	Line int
 	Msg  string
 }
 
-func (e dotenvError) Error() string {
+func (e ParseError) Error() string {
 	return fmt.Sprintf("line %d: %s", e.Line, e.Msg)
 }
 
-// parseDotenv parses dotenv-style content into pairs. Recognised syntax:
+// Parse parses dotenv-style content into pairs. Recognised syntax:
 //
 //	KEY=VALUE                   bare value, no surrounding whitespace required
 //	KEY="quoted value"          double-quoted; supports \n \r \t \\ \" escapes
@@ -38,9 +42,9 @@ func (e dotenvError) Error() string {
 //
 // On a duplicate key inside the same input the later value wins; the
 // caller decides what to do with collisions against the existing bag.
-func parseDotenv(input string) ([]dotenvPair, []dotenvError) {
-	var pairs []dotenvPair
-	var errs []dotenvError
+func Parse(input string) ([]Pair, []ParseError) {
+	var pairs []Pair
+	var errs []ParseError
 
 	// Normalise line endings so a Windows-style \r\n paste behaves like
 	// a Unix one. We split on \n then strip a trailing \r per line.
@@ -60,27 +64,27 @@ func parseDotenv(input string) ([]dotenvPair, []dotenvError) {
 
 		eq := strings.IndexByte(line, '=')
 		if eq < 0 {
-			errs = append(errs, dotenvError{Line: lineNo, Msg: "no '=' separator"})
+			errs = append(errs, ParseError{Line: lineNo, Msg: "no '=' separator"})
 			continue
 		}
 
 		key := strings.TrimSpace(line[:eq])
 		if key == "" {
-			errs = append(errs, dotenvError{Line: lineNo, Msg: "empty key"})
+			errs = append(errs, ParseError{Line: lineNo, Msg: "empty key"})
 			continue
 		}
 		if !isValidEnvKey(key) {
-			errs = append(errs, dotenvError{Line: lineNo, Msg: fmt.Sprintf("invalid key %q", key)})
+			errs = append(errs, ParseError{Line: lineNo, Msg: fmt.Sprintf("invalid key %q", key)})
 			continue
 		}
 
 		rawVal := strings.TrimLeft(line[eq+1:], " \t")
 		val, err := unquoteValue(rawVal)
 		if err != nil {
-			errs = append(errs, dotenvError{Line: lineNo, Msg: err.Error()})
+			errs = append(errs, ParseError{Line: lineNo, Msg: err.Error()})
 			continue
 		}
-		pairs = append(pairs, dotenvPair{Key: key, Value: val, Line: lineNo})
+		pairs = append(pairs, Pair{Key: key, Value: val, Line: lineNo})
 	}
 	return pairs, errs
 }

--- a/internal/dotenv/dotenv_test.go
+++ b/internal/dotenv/dotenv_test.go
@@ -1,4 +1,4 @@
-package tui
+package dotenv
 
 import (
 	"strings"
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseDotenv_Simple(t *testing.T) {
-	pairs, errs := parseDotenv("FOO=bar\nBAZ=qux\n")
+	pairs, errs := Parse("FOO=bar\nBAZ=qux\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -22,7 +22,7 @@ func TestParseDotenv_Simple(t *testing.T) {
 }
 
 func TestParseDotenv_DoubleQuoted(t *testing.T) {
-	pairs, errs := parseDotenv(`FOO="hello world"` + "\n" + `BAR="line1\nline2"` + "\n")
+	pairs, errs := Parse(`FOO="hello world"` + "\n" + `BAR="line1\nline2"` + "\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -35,7 +35,7 @@ func TestParseDotenv_DoubleQuoted(t *testing.T) {
 }
 
 func TestParseDotenv_DoubleQuoted_EscapedQuote(t *testing.T) {
-	pairs, errs := parseDotenv(`KEY="he said \"hi\""` + "\n")
+	pairs, errs := Parse(`KEY="he said \"hi\""` + "\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -45,7 +45,7 @@ func TestParseDotenv_DoubleQuoted_EscapedQuote(t *testing.T) {
 }
 
 func TestParseDotenv_SingleQuoted_NoEscape(t *testing.T) {
-	pairs, errs := parseDotenv(`FOO='no \n escape here'` + "\n")
+	pairs, errs := Parse(`FOO='no \n escape here'` + "\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -55,7 +55,7 @@ func TestParseDotenv_SingleQuoted_NoEscape(t *testing.T) {
 }
 
 func TestParseDotenv_ExportPrefix(t *testing.T) {
-	pairs, errs := parseDotenv("export FOO=bar\nexport\tBAZ=qux\n")
+	pairs, errs := Parse("export FOO=bar\nexport\tBAZ=qux\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -69,7 +69,7 @@ func TestParseDotenv_ExportPrefix(t *testing.T) {
 
 func TestParseDotenv_ExportLookalike(t *testing.T) {
 	// A key literally named "exported" is not the export prefix.
-	pairs, errs := parseDotenv("exported=1\n")
+	pairs, errs := Parse("exported=1\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -87,7 +87,7 @@ FOO=bar
 # trailing comment
 BAZ=qux
 `
-	pairs, errs := parseDotenv(input)
+	pairs, errs := Parse(input)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -97,7 +97,7 @@ BAZ=qux
 }
 
 func TestParseDotenv_InlineCommentOnBareValue(t *testing.T) {
-	pairs, errs := parseDotenv("FOO=bar # trailing\n")
+	pairs, errs := Parse("FOO=bar # trailing\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -107,7 +107,7 @@ func TestParseDotenv_InlineCommentOnBareValue(t *testing.T) {
 }
 
 func TestParseDotenv_HashInsideQuotes(t *testing.T) {
-	pairs, errs := parseDotenv(`FOO="a # not a comment"` + "\n")
+	pairs, errs := Parse(`FOO="a # not a comment"` + "\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -117,7 +117,7 @@ func TestParseDotenv_HashInsideQuotes(t *testing.T) {
 }
 
 func TestParseDotenv_Malformed_NoEquals(t *testing.T) {
-	_, errs := parseDotenv("FOO=bar\nthis is not a pair\nBAZ=qux\n")
+	_, errs := Parse("FOO=bar\nthis is not a pair\nBAZ=qux\n")
 	if len(errs) != 1 {
 		t.Fatalf("want 1 err, got %d (%v)", len(errs), errs)
 	}
@@ -130,7 +130,7 @@ func TestParseDotenv_Malformed_NoEquals(t *testing.T) {
 }
 
 func TestParseDotenv_Malformed_EmptyKey(t *testing.T) {
-	_, errs := parseDotenv("=value\n")
+	_, errs := Parse("=value\n")
 	if len(errs) != 1 {
 		t.Fatalf("want 1 err, got %d", len(errs))
 	}
@@ -140,7 +140,7 @@ func TestParseDotenv_Malformed_EmptyKey(t *testing.T) {
 }
 
 func TestParseDotenv_Malformed_InvalidKey(t *testing.T) {
-	_, errs := parseDotenv("9FOO=bar\n")
+	_, errs := Parse("9FOO=bar\n")
 	if len(errs) != 1 {
 		t.Fatalf("want 1 err, got %d", len(errs))
 	}
@@ -150,7 +150,7 @@ func TestParseDotenv_Malformed_InvalidKey(t *testing.T) {
 }
 
 func TestParseDotenv_UnterminatedQuote(t *testing.T) {
-	_, errs := parseDotenv(`FOO="oops` + "\n")
+	_, errs := Parse(`FOO="oops` + "\n")
 	if len(errs) != 1 {
 		t.Fatalf("want 1 err, got %d", len(errs))
 	}
@@ -160,7 +160,7 @@ func TestParseDotenv_UnterminatedQuote(t *testing.T) {
 }
 
 func TestParseDotenv_Empty(t *testing.T) {
-	pairs, errs := parseDotenv("")
+	pairs, errs := Parse("")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -170,7 +170,7 @@ func TestParseDotenv_Empty(t *testing.T) {
 }
 
 func TestParseDotenv_WhitespaceOnly(t *testing.T) {
-	pairs, errs := parseDotenv("   \n\t\n\n")
+	pairs, errs := Parse("   \n\t\n\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -180,7 +180,7 @@ func TestParseDotenv_WhitespaceOnly(t *testing.T) {
 }
 
 func TestParseDotenv_CRLFEndings(t *testing.T) {
-	pairs, errs := parseDotenv("FOO=bar\r\nBAZ=qux\r\n")
+	pairs, errs := Parse("FOO=bar\r\nBAZ=qux\r\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -190,7 +190,7 @@ func TestParseDotenv_CRLFEndings(t *testing.T) {
 }
 
 func TestParseDotenv_TrimsTrailingWhitespaceOnBare(t *testing.T) {
-	pairs, errs := parseDotenv("FOO=bar   \n")
+	pairs, errs := Parse("FOO=bar   \n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -200,7 +200,7 @@ func TestParseDotenv_TrimsTrailingWhitespaceOnBare(t *testing.T) {
 }
 
 func TestParseDotenv_DuplicateKeyLaterWins(t *testing.T) {
-	pairs, errs := parseDotenv("FOO=one\nFOO=two\n")
+	pairs, errs := Parse("FOO=one\nFOO=two\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}
@@ -214,7 +214,7 @@ func TestParseDotenv_DuplicateKeyLaterWins(t *testing.T) {
 }
 
 func TestParseDotenv_EmptyValueAllowed(t *testing.T) {
-	pairs, errs := parseDotenv("FOO=\n")
+	pairs, errs := Parse("FOO=\n")
 	if len(errs) != 0 {
 		t.Fatalf("unexpected errs: %v", errs)
 	}

--- a/internal/tui/bag_bulk_import.go
+++ b/internal/tui/bag_bulk_import.go
@@ -2,11 +2,14 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/dotenv"
 )
 
 // bagBulkImportScreen lets the user paste a block of dotenv-style
@@ -36,9 +39,9 @@ type bagBulkImportScreen struct {
 	btnFocus int
 	buttons  []button
 
-	parseErrs  []dotenvError
-	pairs      []dotenvPair // last parse result (in input order, dedup'd)
-	collisions []string     // keys present in both pairs and existing bag
+	parseErrs  []dotenv.ParseError
+	pairs      []dotenv.Pair // last parse result (in input order, dedup'd)
+	collisions []string      // keys present in both pairs and existing bag
 }
 
 const (
@@ -61,7 +64,7 @@ func newBagBulkImportScreen(r *rootModel, bag string) screen {
 		phase:    phaseEdit,
 		area:     ta,
 		btnFocus: -1,
-		buttons:  []button{newButton("Parse"), newButton("Back")},
+		buttons:  []button{newButton("Parse"), newButton("Load from file"), newButton("Back")},
 	}
 }
 
@@ -83,6 +86,13 @@ func (s *bagBulkImportScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 // ----- edit phase --------------------------------------------------
 
 func (s *bagBulkImportScreen) updateEdit(msg tea.Msg) (screen, tea.Cmd) {
+	// pathPickedMsg arrives from filePickerScreen (#223) after the user
+	// picks a .env file via "Load from file". Read it and run the shared
+	// parser on its contents — then fall through to the SAME preview /
+	// collision-resolution / apply flow as a pasted block.
+	if pm, ok := msg.(pathPickedMsg); ok {
+		return s, s.loadFromFile(pm.path)
+	}
 	if k, ok := msg.(tea.KeyMsg); ok {
 		switch k.String() {
 		case "esc":
@@ -98,7 +108,9 @@ func (s *bagBulkImportScreen) updateEdit(msg tea.Msg) (screen, tea.Cmd) {
 				label := s.buttons[s.btnFocus].label
 				switch label {
 				case "Parse":
-					return s, s.runParse()
+					return s, s.runParse(s.area.Value())
+				case "Load from file":
+					return s, emit(pushMsg{s: newFilePickerScreen(s.root, pickFile, pickerStartDir(""))})
 				case "Back":
 					return s, emit(popMsg{})
 				}
@@ -143,11 +155,26 @@ func (s *bagBulkImportScreen) advance(dir int) {
 	s.area.Focus()
 }
 
-// runParse parses the textarea contents. On success it advances to the
+// loadFromFile reads the picked file and runs the shared parser on its
+// contents, reusing runParse so a file import lands in the exact same
+// preview / collision-resolution / apply flow as a pasted block. A read
+// failure keeps the user on the edit screen with an error flash.
+func (s *bagBulkImportScreen) loadFromFile(path string) tea.Cmd {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return emit(errorMsg(fmt.Sprintf("read %s: %v", path, err)))
+	}
+	// Mirror the loaded contents into the textarea so the user can see
+	// (and tweak) what was imported before applying.
+	s.area.SetValue(string(data))
+	return s.runParse(string(data))
+}
+
+// runParse parses the given input. On success it advances to the
 // preview phase; on parse errors it stays on the edit screen and lets
 // the user see / fix the errors.
-func (s *bagBulkImportScreen) runParse() tea.Cmd {
-	pairs, errs := parseDotenv(s.area.Value())
+func (s *bagBulkImportScreen) runParse(input string) tea.Cmd {
+	pairs, errs := dotenv.Parse(input)
 	s.parseErrs = errs
 	if len(errs) > 0 {
 		s.pairs = nil
@@ -166,7 +193,7 @@ func (s *bagBulkImportScreen) runParse() tea.Cmd {
 	for i, p := range pairs {
 		dedup[p.Key] = i
 	}
-	kept := make([]dotenvPair, 0, len(dedup))
+	kept := make([]dotenv.Pair, 0, len(dedup))
 	for i, p := range pairs {
 		if dedup[p.Key] == i {
 			kept = append(kept, p)
@@ -219,7 +246,7 @@ func (s *bagBulkImportScreen) updatePreview(msg tea.Msg) (screen, tea.Cmd) {
 			case "Back to edit":
 				s.phase = phaseEdit
 				s.btnFocus = -1
-				s.buttons = []button{newButton("Parse"), newButton("Back")}
+				s.buttons = []button{newButton("Parse"), newButton("Load from file"), newButton("Back")}
 				s.area.Focus()
 				return s, nil
 			}
@@ -296,7 +323,7 @@ func (s *bagBulkImportScreen) viewEdit() string {
 	var b strings.Builder
 	b.WriteString(labelStyle.Render("Paste KEY=VALUE pairs to import into "+s.bag) + "\n")
 	b.WriteString(dimText("Supported: KEY=value, KEY=\"quoted\", KEY='single', export KEY=value, # comments.") + "\n")
-	b.WriteString(dimText("Tab moves to the buttons. Use Parse to validate, then Apply to merge.") + "\n\n")
+	b.WriteString(dimText("Tab moves to the buttons. Parse validates the paste, or Load from file picks a .env. Then Apply to merge.") + "\n\n")
 	b.WriteString(s.area.View() + "\n\n")
 	if len(s.parseErrs) > 0 {
 		b.WriteString(errorStyle.Render(fmt.Sprintf("%d parse error(s):", len(s.parseErrs))) + "\n")


### PR DESCRIPTION
## Summary

Extends the bulk-import flow (follow-up to #70) so secrets can be loaded from a `.env` file path and from named shell env vars — both in the TUI and via a new CLI command. Builds on #248's opaque-ID name encryption.

### Shared parser refactor
- Moved `parseDotenv` + its types out of `internal/tui` into a new shared package `internal/dotenv` (`dotenv.Parse` / `dotenv.Pair` / `dotenv.ParseError`). Tests moved alongside with no logic change. The TUI and the new CLI command now use the single parser.

### TUI — "Load from file"
- `bagBulkImportScreen` gains a **Load from file** button that opens the #223 file picker, reads the chosen file, and feeds the contents through the existing parse → preview → collision-resolution → apply flow unchanged.

### CLI — `jitenv bag import <bag>`
- New top-level `bag` noun aggregating `bag import`. Flags: `--from-file` / `--from-env` / `--stdin` (exactly one; combining them is a usage error), `--on-collision=ask|overwrite|skip` (ask = per-key y/n on `/dev/tty`), `--dry-run`.
- Loads + decrypts config (same flow as `clone`), runs the one-shot #248 opaque-ID migration, merges via a shared `bagUpsert` helper, then `EncryptInPlace` + `AtomicSave` so values land sealed, freshly-minted bag/keys get opaque IDs, and the agent reload hook fires. Prints `imported N keys (X new, Y overwritten, Z skipped) into bag "..."`.

### Security
- `--from-env` is **by-name only** — no wildcard / import-everything. The hostile-parent-shell threat is documented in the command's `--help`.
- Secret values never touch argv: `--stdin` carries values off the arg list, and the collision prompt reads from a separate `/dev/tty` handle (new `crypto.PromptTTYLine`) so it works while stdin carries piped import data.
- Master key follows the `defer zeroBytes` + `lockKey` convention.

### Shared with clone
- `bagUpsert(cfg, name, pairs, policy, ask)` factors the mint-if-absent + merge collision logic so it doesn't fork between `clone` and `import`.

## Tests
- Moved dotenv tests pass unchanged in the new package.
- CLI table-driven: parse-failure leaves config byte-identical, all three collision modes against a seeded bag, `--from-env` mixed present/missing, `--dry-run` no-op on disk, `--stdin` EOF, mutually-exclusive usage error, bad policy.
- PTY-driven e2e against the real built binary: imports a temp `.env`, types the passphrase, asserts the on-disk TOML holds opaque IDs (real names don't leak) and decrypts back to the expected values — proving a fresh bag round-trips through the #248 ID layer.
- `go test ./...`, `go vet ./...`, `golangci-lint run` all clean.

Closes #250