### PR TITLE
feat(config): warn on intra-mapping env-var collisions (#251)

### DIFF
--- a/internal/cli/agent_internal.go
+++ b/internal/cli/agent_internal.go
@@ -59,6 +59,21 @@ func newAgentInternalCmd() *cobra.Command {
 				return err
 			}
 
+			// Emit intra-mapping env-var collision warnings (#251) once,
+			// on the daemon's FIRST config load after spawn — not per
+			// fetch request and not on every reload. slog goes to
+			// agent.log; the user-facing copy is printed by `jitenv
+			// unlock`. A re-load + re-decrypt here is cheap relative to
+			// the daemon lifetime and keeps the loadAndBuild closure (also
+			// used on reload) free of side effects.
+			if wcfg, werr := config.Load(cfgArg); werr == nil {
+				if config.DecryptInPlace(wcfg, key) == nil {
+					for _, warn := range wcfg.Warnings() {
+						slog.Warn("config collision", "detail", warn.String())
+					}
+				}
+			}
+
 			paths, err := agent.DefaultPaths()
 			if err != nil {
 				return err

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -205,6 +205,11 @@ func runClone(cmd *cobra.Command, args []string, tokenStdin bool, bagOverride st
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("internal: generated config is invalid: %w", err)
 	}
+	// Surface intra-mapping env-var collision warnings (#251) on the
+	// decrypted, ID→name-translated config BEFORE re-encrypting for
+	// save. Advisory only — the clone already succeeded; this never
+	// blocks the write.
+	emitConfigWarnings(cmd.ErrOrStderr(), cfg)
 	if err := saveAndReencrypt(cfgPath, cfg, key); err != nil {
 		return err
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -89,10 +89,25 @@ func newConfigShowCmd() *cobra.Command {
 }
 
 func newConfigValidateCmd() *cobra.Command {
-	return &cobra.Command{
+	var strict bool
+	c := &cobra.Command{
 		Use:   "validate",
 		Short: "Parse and structurally validate the config",
-		Args:  cobra.NoArgs,
+		Long: `Parse and structurally validate the config.
+
+The structural check (shape, required fields, command-name safety) runs
+WITHOUT the master key, so it stays CI-friendly: no secret is decrypted.
+
+Advisory collision warnings (#251 — two vars in one mapping setting the
+same env var name, where the later one silently wins) require the
+decrypted view, so they are only computed when a passphrase is provided
+on a TTY. In a non-interactive context (no controlling terminal) the
+command skips the passphrase prompt and emits structural results only.
+
+Warnings never fail the command on their own; pass --strict to escalate
+any warning to a non-zero exit (useful in CI once a passphrase is
+available, e.g. via an expect-style wrapper).`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path, err := config.Resolve(configPath)
 			if err != nil {
@@ -110,9 +125,40 @@ func newConfigValidateCmd() *cobra.Command {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "ok")
-			return nil
+
+			// Collision warnings (#251) need the decrypted, ID→name
+			// translated view. Only attempt the passphrase prompt on a
+			// TTY so the no-key structural check (CI's bread and butter)
+			// keeps working unprompted. If we can't decrypt, we simply
+			// don't emit warnings — never an error.
+			if !crypto.HasTerminal() {
+				return nil
+			}
+			pw, err := crypto.PromptPassphrase("jitenv config validate passphrase (warnings; Enter to skip): ", false)
+			if err != nil {
+				// Treat a prompt failure / cancellation as "skip
+				// warnings" — structural validation already passed.
+				return nil
+			}
+			defer zeroBytes(pw)
+			if len(pw) == 0 {
+				return nil
+			}
+			key, err := config.DeriveKeyFromMeta(c, pw)
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "note: could not decrypt to compute warnings: %v\n", err)
+				return nil
+			}
+			defer zeroBytes(key)
+			if err := config.DecryptInPlace(c, key); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "note: could not decrypt to compute warnings: %v\n", err)
+				return nil
+			}
+			return reportConfigWarnings(cmd.ErrOrStderr(), c, strict)
 		},
 	}
+	c.Flags().BoolVar(&strict, "strict", false, "exit non-zero if any advisory warning is found (requires a passphrase to compute)")
+	return c
 }
 
 func runConfigTUI() error {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -132,6 +132,17 @@ available, e.g. via an expect-style wrapper).`,
 			// keeps working unprompted. If we can't decrypt, we simply
 			// don't emit warnings — never an error.
 			if !crypto.HasTerminal() {
+				// The Long help advertises --strict for CI use, so a
+				// caller who passes it deserves to know the strict
+				// check could not run here: with no TTY we can't prompt
+				// for the passphrase, so collision warnings were never
+				// computed. Exit code stays as the no-TTY path's (0) —
+				// the warnings genuinely couldn't be evaluated, so the
+				// right behavior is to tell the user, not hard-fail.
+				if strict {
+					fmt.Fprintln(cmd.ErrOrStderr(),
+						"note: --strict ignored: no TTY available to prompt for the passphrase, so collision warnings were not evaluated")
+				}
 				return nil
 			}
 			pw, err := crypto.PromptPassphrase("jitenv config validate passphrase (warnings; Enter to skip): ", false)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,11 +1,16 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
 )
 
 // TestRunConfigTUICreatesConfigDirOnFreshInstall covers the #190
@@ -58,4 +63,77 @@ func TestRunConfigTUICreatesConfigDirOnFreshInstall(t *testing.T) {
 	if mode := st.Mode().Perm(); mode != 0o700 {
 		t.Errorf("config dir mode = %v, want 0700", mode)
 	}
+}
+
+// runConfigValidate invokes the `config validate` command's RunE against
+// the config at cfgPath, returning the command's stdout, stderr, and
+// error. Under `go test` stdin/stdout are not TTYs, so crypto.HasTerminal
+// reports false and the command takes the no-TTY structural-only path —
+// exactly the path a CI caller hits.
+func runConfigValidate(t *testing.T, cfgPath string, strict bool) (stdout, stderr string, err error) {
+	t.Helper()
+	if crypto.HasTerminal() {
+		t.Skip("test requires a non-TTY stdin/stdout to exercise the no-TTY path")
+	}
+
+	saved := configPath
+	configPath = cfgPath
+	t.Cleanup(func() { configPath = saved })
+
+	cmd := newConfigValidateCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+	args := []string{}
+	if strict {
+		args = append(args, "--strict")
+	}
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// TestConfigValidate_NoTTYStrictNote covers the [MED] finding on #255: a
+// CI caller who passes --strict with no TTY still gets the structural
+// check (exit 0), but must be told the strict check didn't run because
+// the passphrase couldn't be prompted and warnings were never computed.
+//
+//   - Without --strict on the no-TTY path: structural "ok", exit 0, no note.
+//   - With --strict on the no-TTY path: structural "ok", exit 0, plus the
+//     note on stderr. The exit code is unchanged from the no-TTY default —
+//     --strict does NOT hard-fail when the warnings couldn't be evaluated.
+func TestConfigValidate_NoTTYStrictNote(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.toml")
+	if err := config.InitNew(cfgPath, []byte("correct horse battery staple")); err != nil {
+		t.Fatalf("InitNew: %v", err)
+	}
+
+	const note = "--strict ignored: no TTY available"
+
+	t.Run("no-strict has no note", func(t *testing.T) {
+		out, errOut, err := runConfigValidate(t, cfgPath, false)
+		if err != nil {
+			t.Fatalf("validate (no --strict) returned error: %v", err)
+		}
+		if !strings.Contains(out, "ok") {
+			t.Errorf("stdout missing structural %q, got: %q", "ok", out)
+		}
+		if strings.Contains(errOut, note) {
+			t.Errorf("stderr should not contain the strict note without --strict, got: %q", errOut)
+		}
+	})
+
+	t.Run("strict prints note, exit unchanged", func(t *testing.T) {
+		out, errOut, err := runConfigValidate(t, cfgPath, true)
+		if err != nil {
+			t.Fatalf("validate --strict on no-TTY path must not hard-fail, got error: %v", err)
+		}
+		if !strings.Contains(out, "ok") {
+			t.Errorf("stdout missing structural %q, got: %q", "ok", out)
+		}
+		if !strings.Contains(errOut, note) {
+			t.Errorf("stderr missing strict note %q, got: %q", note, errOut)
+		}
+	})
 }

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -64,6 +64,18 @@ func newUnlockCmd() *cobra.Command {
 			}
 			idle := parseIdle(cfg.Agent.IdleTimeout)
 
+			// Surface intra-mapping env-var collision warnings (#251)
+			// once at unlock time. Decrypt a throwaway copy so we have
+			// the ID→name-translated view; the spawned daemon also logs
+			// these on its own first load, but the user reads stderr
+			// here, not agent.log. Best-effort: a decrypt failure here
+			// is non-fatal (the daemon will surface real load errors).
+			if wcfg, werr := config.Load(cfgPath); werr == nil {
+				if config.DecryptInPlace(wcfg, key) == nil {
+					emitConfigWarnings(cmd.ErrOrStderr(), wcfg)
+				}
+			}
+
 			if unlockForeground {
 				// Build a real resolver so the foreground agent
 				// actually injects secrets — previously it was started

--- a/internal/cli/warnings.go
+++ b/internal/cli/warnings.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// emitConfigWarnings prints one advisory line per collision warning
+// (#251) to w. It is the shared post-decrypt surface used by the
+// unlock and clone paths so a user who writes/loads a config with an
+// intra-mapping env-var collision sees it once at load time rather than
+// silently getting the last-wins value at fetch time. cfg MUST already
+// be decrypted (var.Name/Source are sealed envelopes otherwise, #235).
+// Returns the number of warnings emitted.
+func emitConfigWarnings(w io.Writer, cfg *config.Config) int {
+	warnings := cfg.Warnings()
+	for _, warn := range warnings {
+		fmt.Fprintf(w, "warning: %s\n", warn.String())
+	}
+	return len(warnings)
+}
+
+// reportConfigWarnings is the `jitenv config validate` post-decrypt
+// surface (#251). It prints each warning to w and, when strict is set
+// and any warning exists, returns a non-zero-exit error so CI can gate
+// on a clean config. cfg MUST already be decrypted. By default
+// (strict=false) it always returns nil — warnings are advisory and the
+// command exits 0.
+func reportConfigWarnings(w io.Writer, cfg *config.Config, strict bool) error {
+	n := emitConfigWarnings(w, cfg)
+	if strict && n > 0 {
+		return fmt.Errorf("%d warning(s) found (--strict)", n)
+	}
+	return nil
+}

--- a/internal/cli/warnings_test.go
+++ b/internal/cli/warnings_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+func collisionConfig() *config.Config {
+	return &config.Config{
+		Version: config.Version,
+		Sources: map[string]config.SourceConfig{
+			"vault": {Type: "local"},
+			"aws":   {Type: "local"},
+		},
+		Mappings: []config.Mapping{
+			{
+				Path: "/usr/bin/myapp",
+				Vars: []config.VarRef{
+					{Name: "DATABASE_URL", Source: "vault", Ref: "r1", Key: "k"},
+					{Name: "OK", Source: "aws", Ref: "r2", Key: "k"},
+					{Name: "DATABASE_URL", Source: "aws", Ref: "r3", Key: "k"},
+				},
+			},
+		},
+	}
+}
+
+func cleanConfig() *config.Config {
+	return &config.Config{
+		Version: config.Version,
+		Sources: map[string]config.SourceConfig{"local": {Type: "local"}},
+		Mappings: []config.Mapping{
+			{
+				Path: "/usr/bin/myapp",
+				Vars: []config.VarRef{
+					{Name: "A", Source: "local", Ref: "r1", Key: "k"},
+					{Name: "B", Source: "local", Ref: "r2", Key: "k"},
+				},
+			},
+		},
+	}
+}
+
+// TestReportConfigWarnings_DefaultExitsZero confirms that warnings are
+// emitted to the writer but the function returns nil (exit 0) without
+// --strict — the CI-friendly default.
+func TestReportConfigWarnings_DefaultExitsZero(t *testing.T) {
+	var buf bytes.Buffer
+	err := reportConfigWarnings(&buf, collisionConfig(), false)
+	if err != nil {
+		t.Fatalf("non-strict reportConfigWarnings returned error: %v", err)
+	}
+	out := buf.String()
+	for _, sub := range []string{
+		`warning:`,
+		`mapping[0]`,
+		`env var "DATABASE_URL" is set twice`,
+		`vars[0] from source "vault"`,
+		`vars[2] from source "aws"`,
+		`vars[2] wins at fetch time`,
+	} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("stderr missing %q\ngot:\n%s", sub, out)
+		}
+	}
+}
+
+// TestReportConfigWarnings_StrictExitsNonZero confirms --strict
+// escalates a warning to a non-zero exit (returned error).
+func TestReportConfigWarnings_StrictExitsNonZero(t *testing.T) {
+	var buf bytes.Buffer
+	err := reportConfigWarnings(&buf, collisionConfig(), true)
+	if err == nil {
+		t.Fatalf("strict reportConfigWarnings returned nil; want non-nil error for a collision config")
+	}
+	if !strings.Contains(err.Error(), "--strict") {
+		t.Errorf("error %q should mention --strict", err.Error())
+	}
+}
+
+// TestReportConfigWarnings_CleanConfig confirms a collision-free config
+// emits nothing and exits 0 even under --strict.
+func TestReportConfigWarnings_CleanConfig(t *testing.T) {
+	var buf bytes.Buffer
+	if err := reportConfigWarnings(&buf, cleanConfig(), true); err != nil {
+		t.Fatalf("clean config under --strict returned error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("clean config emitted output: %q", buf.String())
+	}
+}
+
+// TestEmitConfigWarnings_Count confirms the shared emitter reports the
+// number of warnings it printed (used by unlock/clone surfaces).
+func TestEmitConfigWarnings_Count(t *testing.T) {
+	var buf bytes.Buffer
+	if n := emitConfigWarnings(&buf, collisionConfig()); n != 1 {
+		t.Errorf("emitConfigWarnings count = %d, want 1", n)
+	}
+	if n := emitConfigWarnings(&buf, cleanConfig()); n != 0 {
+		t.Errorf("clean config count = %d, want 0", n)
+	}
+}

--- a/internal/config/warnings.go
+++ b/internal/config/warnings.go
@@ -1,0 +1,116 @@
+package config
+
+import "fmt"
+
+// Warning is an ADVISORY config diagnostic — never a hard error. The
+// only warning today is an intra-mapping env-var-name collision (#251):
+// two VarRefs in the same mapping set the same env var Name, so the
+// later one silently wins at fetch time (the agent resolver merges into
+// a map keyed by env var name). This is almost always a config mistake
+// (mid-migration leftovers, source rename/replace, copy-paste), but
+// same-Name-different-source is technically legal as a fallback chain,
+// so it is surfaced as a warning rather than rejected by Validate.
+type Warning struct {
+	// MappingIdx is the index into Config.Mappings.
+	MappingIdx int
+	// VarIdxA is the index of the first (shadowed / earlier) VarRef in
+	// the mapping's Vars slice; VarIdxB is the later one that wins.
+	VarIdxA int
+	VarIdxB int
+	// Name is the colliding env var name.
+	Name string
+	// EffectiveSource describes where the WINNING value (VarIdxB) comes
+	// from; ShadowedSource describes the losing one (VarIdxA). Both use
+	// the human-readable describeVarSource form ("source \"vault\"",
+	// "literal value").
+	EffectiveSource string
+	ShadowedSource  string
+	// Duplicate is true when the two VarRefs are an exact
+	// (Source,Ref,Key,Value) match — a true redundant duplicate that
+	// can simply be deleted, as opposed to two distinct sources racing
+	// for the same name.
+	Duplicate bool
+}
+
+// String renders an actionable, single-line message. It uses
+// "shadowed by later entry" framing (not "duplicate", which reads like
+// a hard error) so users understand the save still succeeded.
+func (w Warning) String() string {
+	if w.Duplicate {
+		return fmt.Sprintf(
+			"mapping[%d]: env var %q is set twice (vars[%d] and vars[%d] from %s) — vars[%d] is a redundant duplicate; delete one",
+			w.MappingIdx, w.Name, w.VarIdxA, w.VarIdxB, w.EffectiveSource, w.VarIdxB,
+		)
+	}
+	return fmt.Sprintf(
+		"mapping[%d]: env var %q is set twice (vars[%d] from %s, vars[%d] from %s) — vars[%d] wins at fetch time",
+		w.MappingIdx, w.Name, w.VarIdxA, w.ShadowedSource, w.VarIdxB, w.EffectiveSource, w.VarIdxB,
+	)
+}
+
+// describeVarSource renders the human-readable origin of a VarRef for
+// warning messages. A literal Value is treated as a source for
+// collision purposes (#251).
+func describeVarSource(v VarRef) string {
+	if v.Value != "" {
+		return "literal value"
+	}
+	return fmt.Sprintf("source %q", v.Source)
+}
+
+// sameOrigin reports whether two VarRefs point at the identical
+// (Source, Ref, Key, Value) origin — i.e. they would fetch the exact
+// same secret. Such a pair is a true duplicate (delete one), as opposed
+// to two distinct origins racing for the same env var name.
+func sameOrigin(a, b VarRef) bool {
+	return a.Source == b.Source && a.Ref == b.Ref && a.Key == b.Key && a.Value == b.Value
+}
+
+// Warnings returns advisory diagnostics for the config. It MUST run on
+// a DECRYPTED, ID→name-translated in-memory Config: var.Name and
+// var.Source are encrypted on disk (#235/#248) and only readable after
+// DecryptInPlace. Calling it on a still-encrypted config would compare
+// opaque envelope strings and produce meaningless results, so callers
+// must invoke it only in the same places ValidatePost runs.
+//
+// Today the only check is the intra-mapping env-var-name collision
+// (#251): within a single mapping, two VarRefs with identical non-empty
+// Name but distinct origins (or an exact duplicate) collide, and the
+// later one wins at fetch time. Empty-Name (expand-whole-bag) VarRefs
+// are skipped — their effective env var names aren't statically
+// knowable without fetching the source, so bag-expansion collisions are
+// out of scope (tracked as a follow-up). Cross-mapping (exact+glob)
+// collisions are likewise out of scope.
+//
+// The scan is O(n) per mapping via a name→first-slot map.
+func (c *Config) Warnings() []Warning {
+	var out []Warning
+	for mi, m := range c.Mappings {
+		// first maps an env var name to the index of the earliest
+		// VarRef that declared it. The first declaration is treated as
+		// the "shadowed" entry for every later collision against it.
+		first := make(map[string]int, len(m.Vars))
+		for vi, v := range m.Vars {
+			if v.Name == "" {
+				// Expand-whole-bag VarRef: effective names unknown
+				// without a fetch. Out of scope (#251 follow-up).
+				continue
+			}
+			fi, seen := first[v.Name]
+			if !seen {
+				first[v.Name] = vi
+				continue
+			}
+			out = append(out, Warning{
+				MappingIdx:      mi,
+				VarIdxA:         fi,
+				VarIdxB:         vi,
+				Name:            v.Name,
+				EffectiveSource: describeVarSource(v),
+				ShadowedSource:  describeVarSource(m.Vars[fi]),
+				Duplicate:       sameOrigin(m.Vars[fi], v),
+			})
+		}
+	}
+	return out
+}

--- a/internal/config/warnings_test.go
+++ b/internal/config/warnings_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWarnings(t *testing.T) {
+	tests := []struct {
+		name      string
+		mappings  []Mapping
+		wantCount int
+		// wantSubstrs, if set, must all appear in the joined String()
+		// output of the warnings.
+		wantSubstrs []string
+		// wantDuplicate asserts the Duplicate flag of the single
+		// expected warning (only checked when wantCount == 1).
+		wantDuplicate bool
+	}{
+		{
+			name: "same-name different-source warns",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "DATABASE_URL", Source: "vault", Ref: "r1"},
+					{Name: "OTHER", Source: "vault", Ref: "r2"},
+					{Name: "Z", Source: "vault", Ref: "r3"},
+					{Name: "DATABASE_URL", Source: "aws", Ref: "r4"},
+				},
+			}},
+			wantCount: 1,
+			wantSubstrs: []string{
+				`env var "DATABASE_URL" is set twice`,
+				`vars[0] from source "vault"`,
+				`vars[3] from source "aws"`,
+				`vars[3] wins at fetch time`,
+			},
+		},
+		{
+			name: "same-name same-source-ref-key is a duplicate",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "TOKEN", Source: "vault", Ref: "r1", Key: "k"},
+					{Name: "TOKEN", Source: "vault", Ref: "r1", Key: "k"},
+				},
+			}},
+			wantCount:     1,
+			wantDuplicate: true,
+			wantSubstrs: []string{
+				`redundant duplicate`,
+			},
+		},
+		{
+			name: "same-name same-source different-ref warns (not duplicate)",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "TOKEN", Source: "vault", Ref: "r1"},
+					{Name: "TOKEN", Source: "vault", Ref: "r2"},
+				},
+			}},
+			wantCount:     1,
+			wantDuplicate: false,
+		},
+		{
+			name: "different names do not warn",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "A", Source: "vault", Ref: "r1"},
+					{Name: "B", Source: "aws", Ref: "r2"},
+				},
+			}},
+			wantCount: 0,
+		},
+		{
+			name: "empty name (expand-whole-bag) is skipped",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "", Source: "vault", Ref: "r1"},
+					{Name: "", Source: "aws", Ref: "r2"},
+				},
+			}},
+			wantCount: 0,
+		},
+		{
+			name: "literal value vs sourced same name warns",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "GIT_ASKPASS", Value: "/path/to/shim"},
+					{Name: "GIT_ASKPASS", Source: "vault", Ref: "r1"},
+				},
+			}},
+			wantCount: 1,
+			wantSubstrs: []string{
+				`vars[0] from literal value`,
+				`vars[1] from source "vault"`,
+			},
+		},
+		{
+			name: "two identical literal values are a duplicate",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "X", Value: "same"},
+					{Name: "X", Value: "same"},
+				},
+			}},
+			wantCount:     1,
+			wantDuplicate: true,
+		},
+		{
+			name: "collision counts are per-mapping, not cross-mapping",
+			mappings: []Mapping{
+				{
+					Path: "/bin/a",
+					Vars: []VarRef{{Name: "X", Source: "vault", Ref: "r1"}},
+				},
+				{
+					Path: "/bin/b",
+					Vars: []VarRef{{Name: "X", Source: "aws", Ref: "r2"}},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "triple collision yields two warnings against first slot",
+			mappings: []Mapping{{
+				Path: "/bin/x",
+				Vars: []VarRef{
+					{Name: "X", Source: "a", Ref: "r1"},
+					{Name: "X", Source: "b", Ref: "r2"},
+					{Name: "X", Source: "c", Ref: "r3"},
+				},
+			}},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{Version: Version, Mappings: tt.mappings}
+			got := c.Warnings()
+			if len(got) != tt.wantCount {
+				t.Fatalf("Warnings() returned %d warnings, want %d: %v", len(got), tt.wantCount, got)
+			}
+			if tt.wantCount == 1 && got[0].Duplicate != tt.wantDuplicate {
+				t.Errorf("Duplicate = %v, want %v", got[0].Duplicate, tt.wantDuplicate)
+			}
+			var joined strings.Builder
+			for _, w := range got {
+				joined.WriteString(w.String())
+				joined.WriteByte('\n')
+			}
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(joined.String(), sub) {
+					t.Errorf("warning output missing %q\ngot:\n%s", sub, joined.String())
+				}
+			}
+		})
+	}
+}
+
+func TestWarningsTripleCollisionTargetsFirstSlot(t *testing.T) {
+	c := &Config{Version: Version, Mappings: []Mapping{{
+		Path: "/bin/x",
+		Vars: []VarRef{
+			{Name: "X", Source: "a", Ref: "r1"},
+			{Name: "X", Source: "b", Ref: "r2"},
+			{Name: "X", Source: "c", Ref: "r3"},
+		},
+	}}}
+	got := c.Warnings()
+	if len(got) != 2 {
+		t.Fatalf("want 2 warnings, got %d", len(got))
+	}
+	for i, w := range got {
+		if w.VarIdxA != 0 {
+			t.Errorf("warning %d: VarIdxA = %d, want 0 (first declaration)", i, w.VarIdxA)
+		}
+	}
+	if got[0].VarIdxB != 1 || got[1].VarIdxB != 2 {
+		t.Errorf("VarIdxB sequence = (%d,%d), want (1,2)", got[0].VarIdxB, got[1].VarIdxB)
+	}
+}

--- a/internal/crypto/passphrase.go
+++ b/internal/crypto/passphrase.go
@@ -4,9 +4,20 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"os"
 
 	"golang.org/x/term"
 )
+
+// HasTerminal reports whether there is a controlling terminal available
+// for an interactive passphrase prompt. Callers that want to OPTIONALLY
+// prompt (e.g. `jitenv config validate`, which must stay CI-friendly
+// without a key) check this first so a non-interactive context skips the
+// prompt entirely rather than blocking on /dev/tty. It probes stdin and
+// stdout; CI runners and piped invocations report false.
+func HasTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) || term.IsTerminal(int(os.Stdout.Fd()))
+}
 
 // zeroPassphrase overwrites the bytes of a passphrase slice in place.
 // Used everywhere PromptPassphrase abandons a buffer (mismatched

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -600,3 +600,110 @@ func TestRunRejectsStaleInjectedMarker(t *testing.T) {
 		t.Errorf("expected agent-down warning (stale marker should NOT bypass); stderr=%q", stderr.String())
 	}
 }
+
+// TestRunCollisionConfigStillRuns is the #251 advisory-only regression:
+// a mapping that sets the SAME env var name from two different sources
+// must still RUN end-to-end (collision detection is a warning, never a
+// behavioral block). It also pins the documented last-wins semantics —
+// the later var in declaration order wins at fetch time — so the warning
+// message ("vars[1] wins at fetch time") matches what actually happens.
+func TestRunCollisionConfigStillRuns(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf 'DB=%s\\n' \"$DATABASE_URL\"\n"), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-collision")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+
+	// Two distinct sources both offer a DATABASE_URL; the mapping wires
+	// both into the same env var name. This is the collision #251 warns
+	// about. The later var (from "second") must win.
+	cfg.Sources = map[string]config.SourceConfig{
+		"first":  {Type: "noop", Params: map[string]any{"db": "postgres://FIRST"}},
+		"second": {Type: "noop", Params: map[string]any{"db": "postgres://SECOND"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: scriptPath, Vars: []config.VarRef{
+			{Name: "DATABASE_URL", Source: "first", Ref: "db"},
+			{Name: "DATABASE_URL", Source: "second", Ref: "db"},
+		}},
+	}
+
+	// Sanity: the decrypted config reports exactly one collision warning,
+	// and it survives validation (advisory only).
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("collision config failed validation (must be advisory): %v", err)
+	}
+	if n := len(cfg.Warnings()); n != 1 {
+		t.Fatalf("Warnings() = %d, want 1", n)
+	}
+
+	if err := config.EncryptInPlace(cfg, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := config.AtomicSave(cfgPath, cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	runtimeDir := shortRuntimeDir(t)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	daemon.Stdout = os.Stdout
+	daemon.Stderr = os.Stderr
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon start: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	deadline := time.Now().Add(3 * time.Second)
+	cli := agent.NewClient(paths.Socket)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_CONFIG="+cfgPath,
+	)
+	cmd := exec.Command(bin, "run", scriptPath)
+	cmd.Env = subprocEnv
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v\noutput=%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	if !strings.Contains(got, "DB=postgres://SECOND") {
+		t.Fatalf("last-wins broken; want DATABASE_URL from \"second\", got:\n%s", got)
+	}
+	if strings.Contains(got, "postgres://FIRST") {
+		t.Fatalf("earlier collision var should be shadowed, but FIRST appeared:\n%s", got)
+	}
+}

--- a/internal/tui/bag_bulk_import.go
+++ b/internal/tui/bag_bulk_import.go
@@ -73,6 +73,10 @@ func (s *bagBulkImportScreen) Status() string { return defaultFormStatus }
 
 func (s *bagBulkImportScreen) Init() tea.Cmd { return textarea.Blink }
 
+// capturesText opts out of the root's global 'w' shortcut while the
+// bulk-import textarea is focused (#251).
+func (s *bagBulkImportScreen) capturesText() bool { return true }
+
 func (s *bagBulkImportScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if s.phase == phasePreview {
 		return s.updatePreview(msg)

--- a/internal/tui/file_picker_screen.go
+++ b/internal/tui/file_picker_screen.go
@@ -86,6 +86,11 @@ func (s *filePickerScreen) Status() string { return defaultFormStatus }
 
 func (s *filePickerScreen) Init() tea.Cmd { return s.fp.Init() }
 
+// capturesText opts out of the root's global 'w' shortcut so a keypress
+// reaches the picker (which may filter) rather than opening warnings
+// (#251).
+func (s *filePickerScreen) capturesText() bool { return true }
+
 func (s *filePickerScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if k, ok := msg.(tea.KeyMsg); ok {
 		switch k.String() {

--- a/internal/tui/input_screen.go
+++ b/internal/tui/input_screen.go
@@ -91,9 +91,13 @@ func newInputScreen(r *rootModel, opts inputOpts, onCommit func(string) tea.Cmd)
 	}
 }
 
-func (s *inputScreen) Title() string  { return s.title }
-func (s *inputScreen) Status() string { return defaultFormStatus }
-func (s *inputScreen) Init() tea.Cmd  { return nil }
+func (s *inputScreen) Title() string { return s.title }
+
+// capturesText opts this screen out of the root's global 'w' (browse
+// warnings) shortcut while the user is editing a free-text field (#251).
+func (s *inputScreen) capturesText() bool { return true }
+func (s *inputScreen) Status() string     { return defaultFormStatus }
+func (s *inputScreen) Init() tea.Cmd      { return nil }
 
 func (s *inputScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	// pathPickedMsg comes from filePickerScreen via tea.Sequence

--- a/internal/tui/mappings_screen.go
+++ b/internal/tui/mappings_screen.go
@@ -267,6 +267,10 @@ func (s *mappingFormScreen) Title() string {
 func (s *mappingFormScreen) Status() string { return renderHelpStatus() }
 func (s *mappingFormScreen) Init() tea.Cmd  { return nil }
 
+// capturesText opts out of the root's global 'w' shortcut while a
+// mapping form field is focused (#251).
+func (s *mappingFormScreen) capturesText() bool { return true }
+
 func (s *mappingFormScreen) HelpKeys() []helpEntry { return commonNavKeys() }
 func (s *mappingFormScreen) HelpText() string {
 	return `kind:       "path" matches one exact filesystem path.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/gv/jitenv/internal/config"
@@ -30,6 +32,12 @@ type rootModel struct {
 
 	flash    string // transient overlay: temporary message in the title bar
 	flashErr bool
+
+	// lastWarnings holds the advisory collision warnings (#251) from the
+	// most recent save, so the user can press 'w' to browse the detail
+	// behind a "saved (N warning(s))" flash. Empty when the last save was
+	// clean.
+	lastWarnings []config.Warning
 
 	// footerHint is a one-line context label rendered in the
 	// footer when non-empty. Used by RunWithMappingTemplate (#179)
@@ -104,9 +112,27 @@ func (r *rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case savedMsg:
 		r.dirty = false
 		r.savedSinceLastReload = true
-		r.flash = "saved"
+		r.lastWarnings = msg.warnings
+		if n := len(msg.warnings); n > 0 {
+			r.flash = fmt.Sprintf("saved (%d warning%s) — press w to view", n, plural(n))
+		} else {
+			r.flash = "saved"
+		}
 		r.flashErr = false
 		return r, nil
+	}
+
+	// 'w' opens the collision-warnings detail for the most recent save.
+	// Handled here (not per-screen) so it works from any screen, but
+	// suppressed when the top screen captures free-text input (so a
+	// literal 'w' in a field isn't stolen) and only when there are
+	// warnings to show. The warnings screen itself captures text=false,
+	// so pressing 'w' again while viewing is a no-op (already on it).
+	if km, ok := msg.(tea.KeyMsg); ok && km.String() == "w" && len(r.lastWarnings) > 0 && !screenCapturesText(r.top()) {
+		if _, onWarnings := r.top().(*warningsScreen); !onWarnings {
+			r.push(newWarningsScreen(r, r.lastWarnings))
+			return r, r.top().Init()
+		}
 	}
 
 	if len(r.stack) == 0 {
@@ -161,8 +187,33 @@ type popMsg struct{}
 type popUntilMsg struct{ pred func(screen) bool }
 type pushMsg struct{ s screen }
 type dirtyMsg struct{}
-type savedMsg struct{}
+
+// savedMsg signals a successful save. warnings carries the advisory
+// collision diagnostics (#251) computed on the decrypted snapshot so the
+// root can flash "saved (N warning(s))" and let the user browse them.
+type savedMsg struct{ warnings []config.Warning }
 type statusMsg string
 type errorMsg string
 
 func emit(msg tea.Msg) tea.Cmd { return func() tea.Msg { return msg } }
+
+// textCapturingScreen is implemented by screens that own a focused
+// free-text field. They opt in so the root model can suppress its global
+// single-letter shortcut ('w' → warnings) while the user is typing,
+// rather than stealing the keystroke. Screens that only navigate lists
+// don't implement it.
+type textCapturingScreen interface {
+	capturesText() bool
+}
+
+func screenCapturesText(s screen) bool {
+	t, ok := s.(textCapturingScreen)
+	return ok && t.capturesText()
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/tui/save.go
+++ b/internal/tui/save.go
@@ -23,6 +23,11 @@ func saveCmd(r *rootModel) tea.Cmd {
 			if err := out.Validate(); err != nil {
 				return errorMsg(fmt.Sprintf("validate: %v", err))
 			}
+			// Compute advisory collision warnings (#251) on the still-
+			// decrypted clone, BEFORE encryptForSave seals var.name/source
+			// into envelopes that Warnings() couldn't read. Warnings never
+			// block the save.
+			warnings := out.Warnings()
 			if err := encryptForSave(out, r.key); err != nil {
 				return errorMsg(fmt.Sprintf("encrypt: %v", err))
 			}
@@ -34,7 +39,7 @@ func saveCmd(r *rootModel) tea.Cmd {
 			// config so a subsequent rename/save reuses the same IDs
 			// instead of minting new ones (#248 ID stability).
 			r.cfg.IDMap = out.IDMap
-			return savedMsg{}
+			return savedMsg{warnings: warnings}
 		},
 		func() tea.Msg {
 			_ = pingAgentReload()

--- a/internal/tui/secrets_screen.go
+++ b/internal/tui/secrets_screen.go
@@ -458,6 +458,10 @@ func (s *kvEditScreen) Title() string {
 func (s *kvEditScreen) Status() string { return defaultFormStatus }
 func (s *kvEditScreen) Init() tea.Cmd  { return nil }
 
+// capturesText opts out of the root's global 'w' shortcut while editing
+// (#251).
+func (s *kvEditScreen) capturesText() bool { return true }
+
 func (s *kvEditScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if k, ok := msg.(tea.KeyMsg); ok {
 		switch k.String() {

--- a/internal/tui/sources_screen.go
+++ b/internal/tui/sources_screen.go
@@ -408,6 +408,10 @@ func (s *sourceParamsScreen) Status() string { return defaultFormStatus }
 
 func (s *sourceParamsScreen) Init() tea.Cmd { return nil }
 
+// capturesText opts out of the root's global 'w' shortcut while a source
+// params form field is focused (#251).
+func (s *sourceParamsScreen) capturesText() bool { return true }
+
 func (s *sourceParamsScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 	if k, ok := msg.(tea.KeyMsg); ok {
 		switch k.String() {

--- a/internal/tui/warnings_save_test.go
+++ b/internal/tui/warnings_save_test.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+)
+
+// TestSaveWithCollisionFlashesWarnings drives saveCmd against a config
+// whose single mapping sets DATABASE_URL twice from different sources.
+// The save must succeed (advisory only) and the resulting savedMsg must
+// carry the warning so the root flashes "saved (1 warning)".
+func TestSaveWithCollisionFlashesWarnings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+	if err := config.DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	c.Sources = map[string]config.SourceConfig{
+		"vault": {Type: "local"},
+		"aws":   {Type: "local"},
+	}
+	c.Secrets = map[string]map[string]string{
+		"vault": {"DATABASE_URL": "postgres://v"},
+		"aws":   {"DATABASE_URL": "postgres://a"},
+	}
+	c.Mappings = []config.Mapping{
+		{
+			Path: "/usr/bin/myapp",
+			Vars: []config.VarRef{
+				{Name: "DATABASE_URL", Source: "vault", Ref: "vault", Key: "DATABASE_URL"},
+				{Name: "OK", Source: "aws", Ref: "aws", Key: "DATABASE_URL"},
+				{Name: "Z", Source: "aws", Ref: "aws", Key: "DATABASE_URL"},
+				{Name: "DATABASE_URL", Source: "aws", Ref: "aws", Key: "DATABASE_URL"},
+			},
+		},
+	}
+
+	r := newRootModel(path, c, key)
+
+	// Run the save pipeline and collect the terminal messages.
+	msgs := drainCmd(saveCmd(r))
+	var saved *savedMsg
+	for i := range msgs {
+		if sm, ok := msgs[i].(savedMsg); ok {
+			saved = &sm
+		}
+		if em, ok := msgs[i].(errorMsg); ok {
+			t.Fatalf("save errored (should be advisory only): %s", string(em))
+		}
+	}
+	if saved == nil {
+		t.Fatalf("no savedMsg produced; got %#v", msgs)
+	}
+	if len(saved.warnings) != 1 {
+		t.Fatalf("savedMsg carried %d warnings, want 1: %v", len(saved.warnings), saved.warnings)
+	}
+
+	// Feed the savedMsg through the root to set the flash + lastWarnings.
+	if _, _ = r.Update(*saved); r.flash != "saved (1 warning) — press w to view" {
+		t.Errorf("flash = %q, want %q", r.flash, "saved (1 warning) — press w to view")
+	}
+	if r.flashErr {
+		t.Errorf("flashErr = true, want false (warnings are advisory)")
+	}
+
+	// The documented wording must be present in the warning detail.
+	detail := saved.warnings[0].String()
+	for _, sub := range []string{
+		`mapping[0]`,
+		`env var "DATABASE_URL" is set twice`,
+		`vars[0] from source "vault"`,
+		`vars[3] from source "aws"`,
+		`vars[3] wins at fetch time`,
+	} {
+		if !strings.Contains(detail, sub) {
+			t.Errorf("warning detail missing %q\ngot: %s", sub, detail)
+		}
+	}
+
+	// Pressing 'w' from a non-text screen opens the warnings screen.
+	depth := len(r.stack)
+	_, _ = r.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
+	if len(r.stack) != depth+1 {
+		t.Fatalf("pressing w did not push a screen (stack %d → %d)", depth, len(r.stack))
+	}
+	if _, ok := r.top().(*warningsScreen); !ok {
+		t.Fatalf("top screen after 'w' = %T, want *warningsScreen", r.top())
+	}
+	if body := r.top().View(); !strings.Contains(body, "DATABASE_URL") {
+		t.Errorf("warnings screen body missing collision detail:\n%s", body)
+	}
+
+	// Reloading the saved file proves the collision config still loads
+	// and validates (advisory, never blocks the save).
+	reloaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := config.DecryptInPlace(reloaded, key); err != nil {
+		t.Fatalf("decrypt reload: %v", err)
+	}
+	if err := reloaded.Validate(); err != nil {
+		t.Fatalf("reloaded config failed validation (collision must be advisory): %v", err)
+	}
+	if n := len(reloaded.Warnings()); n != 1 {
+		t.Errorf("reloaded Warnings() = %d, want 1", n)
+	}
+}

--- a/internal/tui/warnings_screen.go
+++ b/internal/tui/warnings_screen.go
@@ -1,0 +1,50 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// warningsScreen is a read-only detail view for the advisory collision
+// warnings (#251) produced by the most recent save. It's pushed when the
+// user presses 'w' after a "saved (N warning(s))" flash. Any key pops it.
+type warningsScreen struct {
+	root     *rootModel
+	warnings []config.Warning
+}
+
+func newWarningsScreen(r *rootModel, w []config.Warning) *warningsScreen {
+	return &warningsScreen{root: r, warnings: w}
+}
+
+func (s *warningsScreen) Title() string {
+	return fmt.Sprintf("save warnings (%d)", len(s.warnings))
+}
+
+func (s *warningsScreen) Status() string {
+	return renderHelpKeys([2]string{"any key", "back"})
+}
+
+func (s *warningsScreen) Init() tea.Cmd { return nil }
+
+func (s *warningsScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	if _, ok := msg.(tea.KeyMsg); ok {
+		return s, emit(popMsg{})
+	}
+	return s, nil
+}
+
+func (s *warningsScreen) View() string {
+	var b strings.Builder
+	b.WriteString(warnStyle.Render("These vars collide within a mapping — the save still succeeded, but the later var wins at fetch time:") + "\n\n")
+	for _, w := range s.warnings {
+		b.WriteString("  • " + w.String() + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(dimText("Same-name vars across different sources are allowed (a fallback chain), so this is a warning, not an error. If unintended, remove or rename one var.") + "\n")
+	return b.String()
+}


### PR DESCRIPTION
## What

Detects intra-mapping env-var-name collisions and surfaces them as **advisory warnings** (never blocking a save). Today, a mapping can declare two `vars` with the same `Name` pointing at different sources; the agent resolver merges into a `map[string]string` keyed by env var name, so the later one silently wins by declaration order. This is almost always a config mistake (mid-migration leftovers, source rename/replace, copy-paste).

Closes #251

## API

New `config.Warnings() []Warning` (separate from `Validate` — does **not** change its signature). It operates on the **decrypted, ID→name-translated** in-memory `Config`, so it runs in the same places `ValidatePost` does (after `DecryptInPlace`) — never on the encrypted form (`var.Name`/`Source` are sealed envelopes per #235/#248).

**Collision predicate** (O(n) per mapping via a name→first-slot map):
- Same non-empty `Name` + distinct `(Source, Ref, Key, Value)` → warn ("later wins at fetch time").
- Same non-empty `Name` + identical origin → warn (redundant duplicate; suggest delete).
- Empty `Name` (expand-whole-bag) skipped (can't statically resolve — out-of-scope follow-up).
- Literal `Value` treated as a source.

Message wording, e.g.:
```
mapping[0]: env var "DATABASE_URL" is set twice (vars[0] from source "vault", vars[3] from source "aws") — vars[3] wins at fetch time
```

## Surfaces

1. **TUI save** (`internal/tui/save.go`, `model.go`): after a successful save, flashes `saved (N warning(s)) — press w to view`; `w` pushes a read-only warnings screen. Never blocks the save. Text-input screens opt out of the global `w` via a `capturesText()` interface so a literal `w` is never stolen.
2. **`jitenv config validate`** (`internal/cli/config.go`): structural check stays no-key/CI-friendly and unprompted. Collision warnings need the decrypted view, so they are only computed when a passphrase is available on a TTY (Enter to skip). New `--strict` escalates warnings → non-zero exit; default exit stays 0. Behavior documented in `--help`.
3. **`unlock` / agent first-load / `clone`**: one stderr (unlock/clone) or slog (agent, → `agent.log`) line per collision, emitted once at load time post-decrypt — not per request.

## Tests

- `internal/config/warnings_test.go` — table-driven truth table for the predicate (same/different source, duplicate, empty-name skip, literal-vs-sourced, per-mapping scoping, triple collision).
- `internal/cli/warnings_test.go` — `reportConfigWarnings` exits 0 by default, non-zero under `--strict`, clean config emits nothing.
- `internal/tui/warnings_save_test.go` — a collision save emits `saved (1 warning)`, lists the documented wording, `w` opens the screen, and the saved file still loads + validates.
- `internal/run/run_e2e_test.go::TestRunCollisionConfigStillRuns` — e2e proves a collision config still RUNS end-to-end with documented last-wins semantics (advisory only, no behavioral regression).

## Out of scope (per issue)

Cross-mapping (exact+glob overlap) collisions; bag-expansion collisions; auto-fix; a global disable knob.

## Verification

`go test ./...`, `go vet ./...`, and `golangci-lint run ./...` all pass.
