### PR TITLE
feat(tui,cli): discover cwd_glob commands by scanning a folder for project markers

### DIFF
--- a/internal/cli/cwd_discover.go
+++ b/internal/cli/cwd_discover.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gv/jitenv/internal/discover"
+)
+
+// newCwdCmd aggregates the `jitenv cwd <subcommand>` group. Today it
+// hosts only `discover` (#252); future cwd_glob-scoped helpers can hang
+// off the same noun.
+func newCwdCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "cwd",
+		Short: "Helpers for cwd_glob mappings.",
+		Long:  `Operate on cwd_glob mappings — directory-scoped command wrappers that inject env vars when you cd into a matching folder.`,
+	}
+	c.AddCommand(newCwdDiscoverCmd())
+	return c
+}
+
+// newCwdDiscoverCmd scans a folder for project marker files and prints
+// the suggested commands, one per line. It reuses internal/discover.Scan
+// — the same registry the TUI's "Discover from folder…" flow uses — so
+// the CLI and TUI never diverge on what a given folder suggests.
+//
+// Output is newline-separated bare command names with no extra chrome,
+// so it composes with shell pipelines (e.g.
+// `jitenv cwd discover ./svc | xargs -n1 …`). Folders with no known
+// markers print nothing and exit 0.
+func newCwdDiscoverCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "discover <folder>",
+		Short: "Suggest commands to wrap by scanning a folder for project markers.",
+		Long: `Scan <folder> (non-recursively) for well-known project marker files
+(package.json → npm/node/npx, Dockerfile → docker, go.mod → go, *.tf →
+terraform/tofu, …) and print the suggested commands, one per line.
+
+This is the command-line companion to the TUI's "Discover from folder…"
+flow; both share the same marker registry.`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmds := discover.Commands(args[0])
+			out := cmd.OutOrStdout()
+			for _, c := range cmds {
+				fmt.Fprintln(out, c)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/cwd_discover_test.go
+++ b/internal/cli/cwd_discover_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCwdDiscover_Golden writes a fixture folder with a couple of marker
+// files and asserts `jitenv cwd discover <folder>` prints the expected
+// newline-separated command list in registry order.
+func TestCwdDiscover_Golden(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"package.json", "Dockerfile"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+
+	cmd := newCwdCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"discover", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	want := "npm\nnode\nnpx\ndocker\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+// TestCwdDiscover_EmptyFolder prints nothing (and exits 0) for a folder
+// with no recognised markers.
+func TestCwdDiscover_EmptyFolder(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cmd := newCwdCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"discover", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("expected empty output, got %q", got)
+	}
+}
+
+// TestCwdDiscover_MissingFolder still exits 0 with no output (discovery
+// is best-effort; a missing folder simply yields no suggestions).
+func TestCwdDiscover_MissingFolder(t *testing.T) {
+	cmd := newCwdCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"discover", filepath.Join(t.TempDir(), "nope")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("expected empty output, got %q", got)
+	}
+}

--- a/internal/cli/subcommands.go
+++ b/internal/cli/subcommands.go
@@ -22,6 +22,7 @@ func subcommands() []*cobra.Command {
 		newVersionNoticeInternalCmd(),
 		newCloneCmd(),
 		newBagCmd(),
+		newCwdCmd(),
 		newSyncCmd(),
 		newGitAskpassInternalCmd(),
 	}

--- a/internal/discover/markers.go
+++ b/internal/discover/markers.go
@@ -1,0 +1,179 @@
+// Package discover scans a folder for well-known project marker files
+// (package.json, Dockerfile, go.mod, …) and suggests the commands that
+// typically operate inside such a project. It is a pure data table plus
+// a single Scan function over os.ReadDir — no TUI or config dependencies
+// — so both the TUI ("Discover from folder…") and an optional CLI
+// surface can reuse it.
+//
+// Scope is deliberately shallow: Scan inspects ONLY the entries of the
+// chosen folder, never descending into subdirectories. It also does not
+// parse any file contents (no package.json scripts, no Makefile targets);
+// presence of the marker is the only signal.
+package discover
+
+import (
+	"os"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// marker is one row in the registry: when any of Files is present (or any
+// of Globs matches a folder entry), Commands are suggested.
+type marker struct {
+	Files    []string // exact filenames (any one present is a hit)
+	Globs    []string // doublestar globs against folder entry names (e.g. "*.tf")
+	Commands []string // commands to suggest when this marker is present
+}
+
+// registry is the flat marker table. Order here is the order suggestions
+// are first encountered; the final result is de-duplicated while keeping
+// first-seen order so the output is stable.
+var registry = []marker{
+	{Files: []string{"package.json"}, Commands: []string{"npm", "node", "npx"}},
+	{Files: []string{"Dockerfile"}, Commands: []string{"docker"}},
+	{Files: []string{"docker-compose.yml", "compose.yml", "compose.yaml"}, Commands: []string{"docker", "docker-compose"}},
+	{Files: []string{"Cargo.toml"}, Commands: []string{"cargo", "rustc"}},
+	{Files: []string{"go.mod"}, Commands: []string{"go"}},
+	{Files: []string{"pyproject.toml", "requirements.txt", "Pipfile"}, Commands: []string{"python", "python3", "pip"}},
+	{Files: []string{"Gemfile"}, Commands: []string{"bundle", "ruby", "rake"}},
+	{Files: []string{"Makefile", "makefile"}, Commands: []string{"make"}},
+	{Files: []string{"flake.nix", "default.nix"}, Commands: []string{"nix"}},
+	{Globs: []string{"*.tf"}, Commands: []string{"terraform", "tofu"}},
+	{Files: []string{"kustomization.yaml", "Chart.yaml"}, Commands: []string{"kubectl", "helm"}},
+}
+
+// Suggestion is a single suggested command, paired with the marker file
+// (or glob) that triggered it so a UI can show "why".
+type Suggestion struct {
+	Command string // e.g. "npm"
+	Reason  string // the filename or glob that triggered it, e.g. "package.json"
+}
+
+// Scan inspects folder (non-recursively) and returns the union of
+// suggested commands for every marker present, de-duplicated by command
+// name (first reason wins) and returned in registry order. Lockfile-aware
+// swaps refine the JS / Python suggestions (pnpm/yarn/bun, poetry).
+//
+// A folder that can't be read (missing, not a dir, permission denied)
+// yields a nil slice rather than an error: discovery is best-effort.
+func Scan(folder string) []Suggestion {
+	entries, err := os.ReadDir(folder)
+	if err != nil {
+		return nil
+	}
+
+	// Build the entry-name list (for glob matching) plus a lower-cased
+	// presence set. The table lists case variants explicitly where it
+	// matters (Makefile AND makefile) so case-sensitive platforms work,
+	// and the lower-cased lookup makes the common case forgiving on
+	// case-insensitive filesystems (macOS, Windows).
+	names := make([]string, 0, len(entries))
+	lower := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		n := e.Name()
+		names = append(names, n)
+		lower[strings.ToLower(n)] = true
+	}
+
+	var out []Suggestion
+	seen := make(map[string]bool)
+
+	add := func(cmd, reason string) {
+		if seen[cmd] {
+			return
+		}
+		seen[cmd] = true
+		out = append(out, Suggestion{Command: cmd, Reason: reason})
+	}
+
+	for _, m := range registry {
+		reason, hit := markerHit(m, names, lower)
+		if !hit {
+			continue
+		}
+		for _, cmd := range m.Commands {
+			add(cmd, reason)
+		}
+	}
+
+	out = applyLockfileSwaps(out, lower)
+	return out
+}
+
+// markerHit reports whether marker m is satisfied by the folder contents
+// and returns the triggering reason (the matched filename or glob).
+func markerHit(m marker, names []string, lower map[string]bool) (string, bool) {
+	for _, f := range m.Files {
+		if lower[strings.ToLower(f)] {
+			return f, true
+		}
+	}
+	for _, g := range m.Globs {
+		for _, n := range names {
+			if ok, _ := doublestar.Match(g, n); ok {
+				return g, true
+			}
+		}
+	}
+	return "", false
+}
+
+// applyLockfileSwaps refines package-manager suggestions based on which
+// lockfile is present:
+//   - pnpm-lock.yaml → use pnpm instead of npm
+//   - yarn.lock      → use yarn instead of npm
+//   - bun.lockb      → use bun instead of npm
+//   - poetry.lock    → add poetry to the Python suggestions
+//
+// The swaps only apply when the base command they replace/extend is
+// present, so a stray lockfile without package.json (or pyproject.toml)
+// won't conjure suggestions out of nowhere.
+func applyLockfileSwaps(in []Suggestion, lower map[string]bool) []Suggestion {
+	// JS package-manager swap: replace npm with the lockfile's manager.
+	jsSwap, jsReason := "", ""
+	switch {
+	case lower["pnpm-lock.yaml"]:
+		jsSwap, jsReason = "pnpm", "pnpm-lock.yaml"
+	case lower["yarn.lock"]:
+		jsSwap, jsReason = "yarn", "yarn.lock"
+	case lower["bun.lockb"]:
+		jsSwap, jsReason = "bun", "bun.lockb"
+	}
+	if jsSwap != "" {
+		for i := range in {
+			if in[i].Command == "npm" {
+				in[i] = Suggestion{Command: jsSwap, Reason: jsReason}
+			}
+		}
+	}
+
+	// Python: poetry.lock adds poetry (alongside the base python tools).
+	if lower["poetry.lock"] {
+		hasPython, hasPoetry := false, false
+		for _, s := range in {
+			switch s.Command {
+			case "python", "python3", "pip":
+				hasPython = true
+			case "poetry":
+				hasPoetry = true
+			}
+		}
+		if hasPython && !hasPoetry {
+			in = append(in, Suggestion{Command: "poetry", Reason: "poetry.lock"})
+		}
+	}
+
+	return in
+}
+
+// Commands is a convenience helper returning just the command names from
+// Scan, in suggestion order.
+func Commands(folder string) []string {
+	sugs := Scan(folder)
+	out := make([]string, 0, len(sugs))
+	for _, s := range sugs {
+		out = append(out, s.Command)
+	}
+	return out
+}

--- a/internal/discover/markers.go
+++ b/internal/discover/markers.go
@@ -123,7 +123,7 @@ func markerHit(m marker, names []string, lower map[string]bool) (string, bool) {
 // lockfile is present:
 //   - pnpm-lock.yaml → use pnpm instead of npm
 //   - yarn.lock      → use yarn instead of npm
-//   - bun.lockb      → use bun instead of npm
+//   - bun.lock / bun.lockb → use bun instead of npm
 //   - poetry.lock    → add poetry to the Python suggestions
 //
 // The swaps only apply when the base command they replace/extend is
@@ -137,6 +137,8 @@ func applyLockfileSwaps(in []Suggestion, lower map[string]bool) []Suggestion {
 		jsSwap, jsReason = "pnpm", "pnpm-lock.yaml"
 	case lower["yarn.lock"]:
 		jsSwap, jsReason = "yarn", "yarn.lock"
+	case lower["bun.lock"]:
+		jsSwap, jsReason = "bun", "bun.lock"
 	case lower["bun.lockb"]:
 		jsSwap, jsReason = "bun", "bun.lockb"
 	}

--- a/internal/discover/markers_test.go
+++ b/internal/discover/markers_test.go
@@ -109,6 +109,16 @@ func TestScan_LockfileSwap_YarnAndBun(t *testing.T) {
 	if !sortedEqual(bun, []string{"bun", "node", "npx"}) {
 		t.Errorf("bun case: got %v", bun)
 	}
+	// Bun 1.2+ defaults to the text-format bun.lock; it must swap npm→bun too.
+	bunText := scanCommands(t, writeFiles(t, "package.json", "bun.lock"))
+	if !sortedEqual(bunText, []string{"bun", "node", "npx"}) {
+		t.Errorf("bun.lock case: got %v", bunText)
+	}
+	for _, c := range bunText {
+		if c == "npm" {
+			t.Errorf("bun.lock case: npm should have been swapped out, got %v", bunText)
+		}
+	}
 }
 
 func TestScan_LockfileSwap_NoBaseNoSuggestion(t *testing.T) {

--- a/internal/discover/markers_test.go
+++ b/internal/discover/markers_test.go
@@ -1,0 +1,203 @@
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// writeFiles creates a temp dir populated with the given (empty) files
+// and returns its path.
+func writeFiles(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	return dir
+}
+
+// scanCommands returns just the suggested command names for folder.
+func scanCommands(t *testing.T, dir string) []string {
+	t.Helper()
+	return Commands(dir)
+}
+
+// sortedEqual compares two string slices ignoring order.
+func sortedEqual(a, b []string) bool {
+	a = append([]string(nil), a...)
+	b = append([]string(nil), b...)
+	sort.Strings(a)
+	sort.Strings(b)
+	return reflect.DeepEqual(a, b)
+}
+
+func TestScan_PerEcosystem(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+		want  []string
+	}{
+		{"npm", []string{"package.json"}, []string{"npm", "node", "npx"}},
+		{"dockerfile", []string{"Dockerfile"}, []string{"docker"}},
+		{"compose-yml", []string{"docker-compose.yml"}, []string{"docker", "docker-compose"}},
+		{"compose-yaml", []string{"compose.yaml"}, []string{"docker", "docker-compose"}},
+		{"cargo", []string{"Cargo.toml"}, []string{"cargo", "rustc"}},
+		{"go", []string{"go.mod"}, []string{"go"}},
+		{"pyproject", []string{"pyproject.toml"}, []string{"python", "python3", "pip"}},
+		{"requirements", []string{"requirements.txt"}, []string{"python", "python3", "pip"}},
+		{"pipfile", []string{"Pipfile"}, []string{"python", "python3", "pip"}},
+		{"gemfile", []string{"Gemfile"}, []string{"bundle", "ruby", "rake"}},
+		{"makefile-upper", []string{"Makefile"}, []string{"make"}},
+		{"flake", []string{"flake.nix"}, []string{"nix"}},
+		{"default-nix", []string{"default.nix"}, []string{"nix"}},
+		{"kustomize", []string{"kustomization.yaml"}, []string{"kubectl", "helm"}},
+		{"helm-chart", []string{"Chart.yaml"}, []string{"kubectl", "helm"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := writeFiles(t, tc.files...)
+			got := scanCommands(t, dir)
+			if !sortedEqual(got, tc.want) {
+				t.Errorf("Scan(%v) = %v, want %v", tc.files, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScan_TerraformGlob(t *testing.T) {
+	dir := writeFiles(t, "main.tf", "variables.tf", "README.md")
+	got := scanCommands(t, dir)
+	if !sortedEqual(got, []string{"terraform", "tofu"}) {
+		t.Fatalf("got %v, want [terraform tofu]", got)
+	}
+
+	// A folder with no .tf files should not suggest terraform.
+	dir2 := writeFiles(t, "README.md")
+	if got := scanCommands(t, dir2); len(got) != 0 {
+		t.Fatalf("expected no suggestions, got %v", got)
+	}
+}
+
+func TestScan_LockfileSwap_Pnpm(t *testing.T) {
+	dir := writeFiles(t, "package.json", "pnpm-lock.yaml")
+	got := scanCommands(t, dir)
+	for _, c := range got {
+		if c == "npm" {
+			t.Fatalf("npm should be swapped for pnpm: %v", got)
+		}
+	}
+	if !contains(got, "pnpm") {
+		t.Fatalf("expected pnpm in %v", got)
+	}
+	// node/npx remain alongside pnpm.
+	if !sortedEqual(got, []string{"pnpm", "node", "npx"}) {
+		t.Fatalf("got %v, want [pnpm node npx]", got)
+	}
+}
+
+func TestScan_LockfileSwap_YarnAndBun(t *testing.T) {
+	yarn := scanCommands(t, writeFiles(t, "package.json", "yarn.lock"))
+	if !sortedEqual(yarn, []string{"yarn", "node", "npx"}) {
+		t.Errorf("yarn case: got %v", yarn)
+	}
+	bun := scanCommands(t, writeFiles(t, "package.json", "bun.lockb"))
+	if !sortedEqual(bun, []string{"bun", "node", "npx"}) {
+		t.Errorf("bun case: got %v", bun)
+	}
+}
+
+func TestScan_LockfileSwap_NoBaseNoSuggestion(t *testing.T) {
+	// pnpm-lock.yaml without package.json yields nothing — the swap
+	// only rewrites an existing npm suggestion.
+	dir := writeFiles(t, "pnpm-lock.yaml")
+	if got := scanCommands(t, dir); len(got) != 0 {
+		t.Fatalf("expected no suggestions, got %v", got)
+	}
+}
+
+func TestScan_PoetryAdds(t *testing.T) {
+	dir := writeFiles(t, "pyproject.toml", "poetry.lock")
+	got := scanCommands(t, dir)
+	if !sortedEqual(got, []string{"python", "python3", "pip", "poetry"}) {
+		t.Fatalf("got %v, want python tools + poetry", got)
+	}
+
+	// poetry.lock alone (no python marker) adds nothing.
+	if got := scanCommands(t, writeFiles(t, "poetry.lock")); len(got) != 0 {
+		t.Fatalf("poetry.lock alone should suggest nothing, got %v", got)
+	}
+}
+
+// TestScan_CaseSensitivity verifies both Makefile and makefile resolve
+// to make, exercising the explicit-case-variant handling that keeps
+// case-sensitive Linux working.
+func TestScan_CaseSensitivity(t *testing.T) {
+	upper := scanCommands(t, writeFiles(t, "Makefile"))
+	if !sortedEqual(upper, []string{"make"}) {
+		t.Errorf("Makefile: got %v", upper)
+	}
+	lowerD := scanCommands(t, writeFiles(t, "makefile"))
+	if !sortedEqual(lowerD, []string{"make"}) {
+		t.Errorf("makefile: got %v", lowerD)
+	}
+}
+
+// TestScan_UnionDedup checks that a folder with multiple markers returns
+// the de-duplicated union (docker appears once even though two markers
+// emit it).
+func TestScan_UnionDedup(t *testing.T) {
+	dir := writeFiles(t, "package.json", "Dockerfile", "docker-compose.yml")
+	got := scanCommands(t, dir)
+	want := []string{"npm", "node", "npx", "docker", "docker-compose"}
+	if !sortedEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	// docker must appear exactly once.
+	count := 0
+	for _, c := range got {
+		if c == "docker" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("docker appeared %d times, want 1: %v", count, got)
+	}
+}
+
+func TestScan_OrderIsRegistryOrder(t *testing.T) {
+	dir := writeFiles(t, "Dockerfile", "package.json")
+	got := scanCommands(t, dir)
+	// package.json is registered before Dockerfile, so its commands lead.
+	want := []string{"npm", "node", "npx", "docker"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestScan_MissingFolder(t *testing.T) {
+	if got := Scan(filepath.Join(t.TempDir(), "does-not-exist")); got != nil {
+		t.Fatalf("missing folder should yield nil, got %v", got)
+	}
+}
+
+func TestScan_ReasonPopulated(t *testing.T) {
+	dir := writeFiles(t, "go.mod")
+	sugs := Scan(dir)
+	if len(sugs) != 1 || sugs[0].Command != "go" || sugs[0].Reason != "go.mod" {
+		t.Fatalf("unexpected suggestions: %#v", sugs)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/commands_list_screen.go
+++ b/internal/tui/commands_list_screen.go
@@ -7,14 +7,26 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/discover"
 )
+
+// Two top sentinels precede the command entries:
+//
+//	cursor 0 → "< Discover from folder… >"
+//	cursor 1 → "< Add command >"
+//	cursor 2..n+1 → existing commands (entry index = cursor-2)
+//
+// numSentinels keeps the off-by-two cursor math honest in one place.
+const numSentinels = 2
 
 // commandsListScreen edits the per-mapping cwd_glob commands list.
 //
 // Storage: cfg.Mappings[idx].Commands is a []string of bare command
-// names. UX mirrors arnListScreen: a "< Add command >" sentinel at the
-// top, existing commands underneath; Enter on an existing row opens an
-// Edit/Delete popup.
+// names. UX mirrors arnListScreen: two sentinels at the top
+// ("< Discover from folder… >" then "< Add command >"), existing
+// commands underneath; Enter on an existing row opens an Edit/Delete
+// popup. Discover scans a chosen folder for project markers and offers
+// the matched commands as a pre-checked checkbox list.
 type commandsListScreen struct {
 	root   *rootModel
 	idx    int
@@ -36,7 +48,7 @@ func (s *commandsListScreen) refresh() {
 		s.cursor = 0
 		return
 	}
-	if max := len(mp.Commands); s.cursor > max {
+	if max := len(mp.Commands) + numSentinels - 1; s.cursor > max {
 		s.cursor = max
 	}
 }
@@ -68,7 +80,12 @@ directory, so running e.g. "npm" from the cwd routes through
 Pick "< Add command >" to append a new entry; selecting an existing
 row opens Edit / Delete. Empty names are rejected and duplicates
 are flagged. The list must be non-empty for a cwd_glob mapping —
-saving an empty list will fail validation.`
+saving an empty list will fail validation.
+
+Pick "< Discover from folder… >" to choose a folder and let jitenv
+scan it for project markers (package.json → npm, Dockerfile →
+docker, …). Matched commands are offered pre-checked; confirming
+appends them, skipping any already in the list.`
 }
 
 func (s *commandsListScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
@@ -76,12 +93,18 @@ func (s *commandsListScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 		s.refresh()
 		return s, nil
 	}
+	// pathPickedMsg arrives from the folder picker launched by
+	// openDiscoverFolder; it carries the folder to scan. The picker has
+	// already popped itself, so this screen is back on top of the stack.
+	if pm, ok := msg.(pathPickedMsg); ok {
+		return s, s.openDiscoverList(pm.path)
+	}
 	mp := s.mp()
 	if mp == nil {
 		return s, nil
 	}
 	if k, ok := msg.(tea.KeyMsg); ok {
-		total := len(mp.Commands) + 1 // sentinel + entries
+		total := len(mp.Commands) + numSentinels // sentinels + entries
 		switch k.String() {
 		case "up", "k":
 			if s.cursor > 0 {
@@ -92,7 +115,10 @@ func (s *commandsListScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 				s.cursor++
 			}
 		case "enter":
-			if s.cursor == 0 {
+			switch s.cursor {
+			case 0:
+				return s, s.openDiscoverFolder()
+			case 1:
 				return s, s.openAddInput()
 			}
 			return s, s.openEntryMenu()
@@ -101,6 +127,46 @@ func (s *commandsListScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
 		}
 	}
 	return s, nil
+}
+
+// openDiscoverFolder pushes the file browser in folder-select mode. On
+// commit it emits a pathPickedMsg that this screen's Update routes to
+// openDiscoverList.
+func (s *commandsListScreen) openDiscoverFolder() tea.Cmd {
+	return emit(pushMsg{s: newFilePickerScreen(s.root, pickDir, pickerStartDir(""))})
+}
+
+// openDiscoverList scans folder for project markers and pushes the
+// pre-checked checkbox screen. When nothing matches it still pushes the
+// screen (which renders an explanatory empty state) so the user gets
+// feedback rather than a silent no-op.
+func (s *commandsListScreen) openDiscoverList(folder string) tea.Cmd {
+	sugs := discover.Scan(folder)
+	return emit(pushMsg{s: newDiscoverCommandsScreen(s.root, s, folder, sugs)})
+}
+
+// appendDiscovered appends each command in cmds that isn't already
+// present (via hasCommand) and returns how many were actually added.
+// This is the SAME dedup path the manual add flow uses, so discover can
+// never introduce duplicates.
+func (s *commandsListScreen) appendDiscovered(cmds []string) int {
+	mp := s.mp()
+	if mp == nil {
+		return 0
+	}
+	added := 0
+	for _, c := range cmds {
+		c = strings.TrimSpace(c)
+		if c == "" || hasCommand(mp.Commands, c) {
+			continue
+		}
+		mp.Commands = append(mp.Commands, c)
+		added++
+	}
+	if added > 0 {
+		s.refresh()
+	}
+	return added
 }
 
 func (s *commandsListScreen) openAddInput() tea.Cmd {
@@ -133,7 +199,7 @@ func (s *commandsListScreen) openEntryMenu() tea.Cmd {
 	if mp == nil {
 		return nil
 	}
-	idx := s.cursor - 1
+	idx := s.cursor - numSentinels
 	if idx < 0 || idx >= len(mp.Commands) {
 		return nil
 	}
@@ -209,15 +275,17 @@ func (s *commandsListScreen) View() string {
 	}
 	b.WriteString(labelStyle.Render(heading) + "\n\n")
 
-	sentinel := "< Add command >"
-	if s.cursor == 0 {
-		b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(sentinel) + "\n")
-	} else {
-		b.WriteString("   " + listItemStyle.Render(sentinel) + "\n")
+	// Two top sentinels: discover (cursor 0) then add (cursor 1).
+	for i, sentinel := range []string{"< Discover from folder… >", "< Add command >"} {
+		if s.cursor == i {
+			b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(sentinel) + "\n")
+		} else {
+			b.WriteString("   " + listItemStyle.Render(sentinel) + "\n")
+		}
 	}
 
 	if len(mp.Commands) == 0 {
-		b.WriteString("\n" + dimText("No commands yet. Pick the row above to add one.") + "\n")
+		b.WriteString("\n" + dimText("No commands yet. Add one, or discover them from a folder above.") + "\n")
 		b.WriteString(dimText("Each command is wrapped by a per-shell symlink while you're") + "\n")
 		b.WriteString(dimText("inside the matching cwd; running it routes through jitenv run.") + "\n")
 		return b.String()
@@ -225,7 +293,7 @@ func (s *commandsListScreen) View() string {
 
 	for i, c := range mp.Commands {
 		row := truncate(c, 60)
-		if i+1 == s.cursor {
+		if i+numSentinels == s.cursor {
 			b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(row) + "\n")
 		} else {
 			b.WriteString("   " + listItemStyle.Render(row) + "\n")

--- a/internal/tui/commands_list_screen_test.go
+++ b/internal/tui/commands_list_screen_test.go
@@ -125,12 +125,16 @@ func TestCommandsList_Add(t *testing.T) {
 	r := makeRoot(commandsFixture())
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
 
-	// Sentinel row is selected by default.
+	// Discover sentinel is selected by default; move to the Add row.
 	if scr.cursor != 0 {
 		t.Fatalf("expected cursor 0, got %d", scr.cursor)
 	}
+	scr.Update(tea.KeyMsg{Type: tea.KeyDown}) // → "< Add command >"
+	if scr.cursor != 1 {
+		t.Fatalf("expected cursor 1 on Add sentinel, got %d", scr.cursor)
+	}
 
-	// Enter on the sentinel pushes an inputScreen for "add command".
+	// Enter on the Add sentinel pushes an inputScreen for "add command".
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	is := findInputScreen(drainCmd(cmd))
 	if is == nil {
@@ -163,6 +167,7 @@ func TestCommandsList_Add_RejectsEmpty(t *testing.T) {
 	r := makeRoot(commandsFixture())
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
 
+	scr.cursor = 1 // "< Add command >"
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	is := findInputScreen(drainCmd(cmd))
 	if is == nil {
@@ -209,6 +214,7 @@ func TestCommandsList_Add_RejectsDuplicate(t *testing.T) {
 	r := makeRoot(commandsFixture())
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
 
+	scr.cursor = 1 // "< Add command >"
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	is := findInputScreen(drainCmd(cmd))
 	if is == nil {
@@ -230,11 +236,13 @@ func TestCommandsList_Edit(t *testing.T) {
 	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
 
-	// Move cursor onto the second entry (yarn).
+	// Move cursor onto the second entry (yarn): 2 sentinels + 2 entries,
+	// yarn is the last row at index numSentinels+1 = 3.
 	scr.Update(tea.KeyMsg{Type: tea.KeyDown})
 	scr.Update(tea.KeyMsg{Type: tea.KeyDown})
-	if scr.cursor != 2 {
-		t.Fatalf("cursor: %d, want 2", scr.cursor)
+	scr.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if scr.cursor != 3 {
+		t.Fatalf("cursor: %d, want 3", scr.cursor)
 	}
 
 	// Enter opens the popup menu.
@@ -270,7 +278,7 @@ func TestCommandsList_Edit_RejectsDuplicate(t *testing.T) {
 	r := makeRoot(commandsFixture())
 	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
-	scr.cursor = 2 // yarn
+	scr.cursor = 3 // yarn (2 sentinels + entry index 1)
 
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	pm := findPopupMenu(drainCmd(cmd))
@@ -296,7 +304,7 @@ func TestCommandsList_Delete(t *testing.T) {
 	r := makeRoot(commandsFixture())
 	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
-	scr.cursor = 1 // npm
+	scr.cursor = 2 // npm (first entry after 2 sentinels)
 
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	pm := findPopupMenu(drainCmd(cmd))
@@ -323,7 +331,7 @@ func TestCommandsList_Delete_NoConfirmKeepsList(t *testing.T) {
 	r := makeRoot(commandsFixture())
 	r.cfg.Mappings[0].Commands = []string{"npm", "yarn"}
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
-	scr.cursor = 1
+	scr.cursor = 2 // npm (first entry after 2 sentinels)
 
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	pm := findPopupMenu(drainCmd(cmd))
@@ -374,7 +382,8 @@ func TestCommandsList_TomlRoundTrip(t *testing.T) {
 	r := makeRoot(c)
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
 
-	// Add: yarn.
+	// Add: yarn (cursor 1 is the "< Add command >" sentinel).
+	scr.cursor = 1
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	is := findInputScreen(drainCmd(cmd))
 	if is == nil {
@@ -384,7 +393,7 @@ func TestCommandsList_TomlRoundTrip(t *testing.T) {
 	drainCmd(is.commit())
 
 	// Add: python3.
-	scr.cursor = 0
+	scr.cursor = 1
 	_, cmd = scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	is = findInputScreen(drainCmd(cmd))
 	is.input.SetValue("python3")
@@ -394,16 +403,17 @@ func TestCommandsList_TomlRoundTrip(t *testing.T) {
 		t.Fatalf("after add: %v", got)
 	}
 
-	// Edit "yarn" → "pnpm".
-	scr.cursor = 2
+	// Edit "yarn" → "pnpm" (entries start at cursor numSentinels=2, so
+	// yarn is at cursor 3).
+	scr.cursor = 3
 	_, cmd = scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	pm := findPopupMenu(drainCmd(cmd))
 	is = findInputScreen(drainCmd(pm.onChoose("Edit")))
 	is.input.SetValue("pnpm")
 	drainCmd(is.commit())
 
-	// Delete "npm".
-	scr.cursor = 1
+	// Delete "npm" (first entry, cursor 2).
+	scr.cursor = 2
 	_, cmd = scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	pm = findPopupMenu(drainCmd(cmd))
 	cs := findConfirm(drainCmd(pm.onChoose("Delete")))
@@ -451,7 +461,7 @@ func TestCommandsList_EmptyListStillRejectedByValidate(t *testing.T) {
 	c.Version = config.Version
 	r := makeRoot(c)
 	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
-	scr.cursor = 1 // the only entry
+	scr.cursor = 2 // the only entry (after 2 sentinels)
 
 	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	pm := findPopupMenu(drainCmd(cmd))

--- a/internal/tui/discover_commands_screen.go
+++ b/internal/tui/discover_commands_screen.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/discover"
+)
+
+// discoverCommandsScreen presents the commands suggested by
+// discover.Scan for a chosen folder as a pre-checked checkbox list. The
+// user toggles rows with space/enter and confirms with a focused
+// "< Confirm >" row; on confirm every still-checked command is appended
+// to the owning mapping via the SAME hasCommand dedup path the manual
+// add flow uses (commandsListScreen.appendDiscovered).
+//
+// Layout (cursor index space):
+//
+//	0..n-1  suggestion rows (checkboxes)
+//	n       "< Confirm >"
+//
+// The screen is purely additive: it never removes existing commands and
+// silently skips suggestions already present in the list.
+type discoverCommandsScreen struct {
+	root    *rootModel
+	owner   *commandsListScreen
+	folder  string
+	sugs    []discover.Suggestion
+	checked []bool
+	cursor  int
+}
+
+func newDiscoverCommandsScreen(r *rootModel, owner *commandsListScreen, folder string, sugs []discover.Suggestion) *discoverCommandsScreen {
+	checked := make([]bool, len(sugs))
+	for i := range checked {
+		checked[i] = true // pre-checked
+	}
+	return &discoverCommandsScreen{
+		root:    r,
+		owner:   owner,
+		folder:  folder,
+		sugs:    sugs,
+		checked: checked,
+	}
+}
+
+func (s *discoverCommandsScreen) Title() string  { return "discover commands" }
+func (s *discoverCommandsScreen) Status() string { return renderHelpStatus() }
+func (s *discoverCommandsScreen) Init() tea.Cmd  { return nil }
+
+func (s *discoverCommandsScreen) HelpKeys() []helpEntry { return commonNavKeys() }
+func (s *discoverCommandsScreen) HelpText() string {
+	return `These commands were suggested by scanning the chosen folder for
+project marker files (package.json → npm/node/npx, Dockerfile →
+docker, *.tf → terraform/tofu, …). The scan looks only at the
+folder itself — it does not descend into subdirectories or parse
+file contents.
+
+Every suggestion starts checked. Toggle a row with Space/Enter,
+then pick "< Confirm >" to append the checked commands. Commands
+already in the list are skipped, so confirming is always safe.`
+}
+
+// confirmIdx is the cursor index of the "< Confirm >" row.
+func (s *discoverCommandsScreen) confirmIdx() int { return len(s.sugs) }
+
+func (s *discoverCommandsScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	k, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return s, nil
+	}
+	total := len(s.sugs) + 1 // suggestions + confirm row
+	switch k.String() {
+	case "up", "k":
+		if s.cursor > 0 {
+			s.cursor--
+		}
+	case "down", "j":
+		if s.cursor < total-1 {
+			s.cursor++
+		}
+	case " ", "space":
+		// Space toggles a suggestion row (no-op on the confirm row).
+		if s.cursor < len(s.sugs) {
+			s.checked[s.cursor] = !s.checked[s.cursor]
+		}
+	case "enter":
+		if s.cursor == s.confirmIdx() {
+			return s, s.confirm()
+		}
+		// Enter on a suggestion toggles it (mirrors var_tree_screen).
+		s.checked[s.cursor] = !s.checked[s.cursor]
+	case "esc":
+		return s, emit(popMsg{})
+	}
+	return s, nil
+}
+
+// confirm appends every checked command to the owning mapping via the
+// shared dedup append, then pops back to the commands list.
+func (s *discoverCommandsScreen) confirm() tea.Cmd {
+	var picked []string
+	for i, sug := range s.sugs {
+		if s.checked[i] {
+			picked = append(picked, sug.Command)
+		}
+	}
+	added := s.owner.appendDiscovered(picked)
+	msgs := []tea.Cmd{emit(popMsg{})}
+	if added > 0 {
+		msgs = append(msgs,
+			emit(dirtyMsg{}),
+			emit(commandsChangedMsg{}),
+			emit(statusMsg(fmt.Sprintf("added %d command(s)", added))),
+		)
+	} else {
+		msgs = append(msgs, emit(statusMsg("nothing to add (all already present)")))
+	}
+	return tea.Sequence(msgs...)
+}
+
+func (s *discoverCommandsScreen) View() string {
+	var b strings.Builder
+	b.WriteString(labelStyle.Render("Suggested commands") + "\n")
+	b.WriteString(dimText("from "+truncate(s.folder, 56)) + "\n\n")
+
+	if len(s.sugs) == 0 {
+		b.WriteString(dimText("No known project markers found in that folder.") + "\n")
+		b.WriteString(dimText("Pick a folder containing e.g. package.json, go.mod, a Dockerfile, …") + "\n\n")
+	}
+
+	for i, sug := range s.sugs {
+		box := "[ ]"
+		if s.checked[i] {
+			box = okStyle.Render("[✓]")
+		}
+		line := fmt.Sprintf("%s  %-16s %s", box, sug.Command, dimText("("+sug.Reason+")"))
+		if i == s.cursor {
+			b.WriteString(" " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(line) + "\n")
+		} else {
+			b.WriteString("   " + listItemStyle.Render(line) + "\n")
+		}
+	}
+
+	confirm := "< Confirm >"
+	if s.cursor == s.confirmIdx() {
+		b.WriteString("\n " + labelStyle.Render("▶ ") + listItemFocusedStyle.Render(confirm) + "\n")
+	} else {
+		b.WriteString("\n   " + listItemStyle.Render(confirm) + "\n")
+	}
+	b.WriteString("\n" + dimText("Space/Enter toggle · already-listed commands are skipped on confirm.") + "\n")
+	return b.String()
+}

--- a/internal/tui/discover_commands_screen_test.go
+++ b/internal/tui/discover_commands_screen_test.go
@@ -1,0 +1,204 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+)
+
+// findDiscoverScreen pulls the most recently pushed
+// discoverCommandsScreen out of a drained command stream.
+func findDiscoverScreen(msgs []tea.Msg) *discoverCommandsScreen {
+	for _, m := range msgs {
+		if pm, ok := m.(pushMsg); ok {
+			if ds, ok := pm.s.(*discoverCommandsScreen); ok {
+				return ds
+			}
+		}
+	}
+	return nil
+}
+
+// markerDir writes a temp folder containing the given marker files.
+func markerDir(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	return dir
+}
+
+// TestCommandsList_DiscoverSentinelOpensPicker checks that the top
+// sentinel (cursor 0) opens the folder picker.
+func TestCommandsList_DiscoverSentinelOpensPicker(t *testing.T) {
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	// Cursor 0 is the discover sentinel by default.
+	_, cmd := scr.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	fp := findFilePicker(drainCmd(cmd))
+	if fp == nil {
+		t.Fatal("Enter on discover sentinel should push a filePickerScreen")
+	}
+	if fp.mode != pickDir {
+		t.Errorf("picker mode = %v, want pickDir (folder select)", fp.mode)
+	}
+}
+
+// TestCommandsList_DiscoverFlow drives the full discover path: a
+// pathPickedMsg from the picker opens the suggestion list pre-checked,
+// and confirming appends the checked commands via the dedup path.
+func TestCommandsList_DiscoverFlow(t *testing.T) {
+	dir := markerDir(t, "package.json", "Dockerfile")
+
+	r := makeRoot(commandsFixture()) // existing Commands == ["npm"]
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	// Simulate the picker returning the chosen folder.
+	_, cmd := scr.Update(pathPickedMsg{path: dir})
+	ds := findDiscoverScreen(drainCmd(cmd))
+	if ds == nil {
+		t.Fatal("pathPickedMsg should push a discoverCommandsScreen")
+	}
+
+	// Suggestions for package.json + Dockerfile: npm, node, npx, docker.
+	wantCmds := []string{"npm", "node", "npx", "docker"}
+	gotCmds := make([]string, len(ds.sugs))
+	for i, s := range ds.sugs {
+		gotCmds[i] = s.Command
+	}
+	if !reflect.DeepEqual(gotCmds, wantCmds) {
+		t.Fatalf("suggestions = %v, want %v", gotCmds, wantCmds)
+	}
+
+	// Every suggestion must start pre-checked.
+	for i, c := range ds.checked {
+		if !c {
+			t.Errorf("suggestion %d (%s) not pre-checked", i, ds.sugs[i].Command)
+		}
+	}
+
+	// Move to the confirm row and confirm.
+	ds.cursor = ds.confirmIdx()
+	confirmMsgs := drainCmd(ds.confirm())
+
+	// "npm" already present → deduped; node, npx, docker appended.
+	want := []string{"npm", "node", "npx", "docker"}
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Commands = %v, want %v", got, want)
+	}
+	if !hasMsgType(confirmMsgs, dirtyMsg{}) {
+		t.Errorf("expected dirtyMsg after confirm: %#v", confirmMsgs)
+	}
+	if !hasMsgType(confirmMsgs, commandsChangedMsg{}) {
+		t.Errorf("expected commandsChangedMsg after confirm: %#v", confirmMsgs)
+	}
+}
+
+// TestDiscoverScreen_TogglePreventsAppend verifies unchecking a row
+// excludes it from the confirmed append.
+func TestDiscoverScreen_TogglePreventsAppend(t *testing.T) {
+	dir := markerDir(t, "go.mod", "Dockerfile")
+	r := makeRoot(commandsFixture())
+	r.cfg.Mappings[0].Commands = nil // start empty
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	_, cmd := scr.Update(pathPickedMsg{path: dir})
+	ds := findDiscoverScreen(drainCmd(cmd))
+	if ds == nil {
+		t.Fatal("expected discover screen")
+	}
+	// Suggestions in registry order: docker (Dockerfile), then go (go.mod).
+	if len(ds.sugs) != 2 || ds.sugs[0].Command != "docker" || ds.sugs[1].Command != "go" {
+		t.Fatalf("unexpected suggestions: %#v", ds.sugs)
+	}
+
+	// Uncheck "docker" via space on cursor 0, then confirm.
+	ds.cursor = 0
+	ds.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if ds.checked[0] {
+		t.Fatal("space should have unchecked row 0")
+	}
+	ds.cursor = ds.confirmIdx()
+	drainCmd(ds.confirm())
+
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"go"}) {
+		t.Fatalf("Commands = %v, want [go] (docker was unchecked)", got)
+	}
+}
+
+// TestDiscoverScreen_AllDuplicatesNoOp confirms a folder whose entire
+// suggestion set is already present makes no change and reports it.
+func TestDiscoverScreen_AllDuplicatesNoOp(t *testing.T) {
+	dir := markerDir(t, "go.mod")
+	r := makeRoot(commandsFixture())
+	r.cfg.Mappings[0].Commands = []string{"go"} // already has the only suggestion
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	_, cmd := scr.Update(pathPickedMsg{path: dir})
+	ds := findDiscoverScreen(drainCmd(cmd))
+	if ds == nil {
+		t.Fatal("expected discover screen")
+	}
+	ds.cursor = ds.confirmIdx()
+	msgs := drainCmd(ds.confirm())
+
+	if got := r.cfg.Mappings[0].Commands; !reflect.DeepEqual(got, []string{"go"}) {
+		t.Fatalf("Commands mutated: %v", got)
+	}
+	// No dirtyMsg since nothing changed.
+	if hasMsgType(msgs, dirtyMsg{}) {
+		t.Errorf("dirtyMsg should not fire when nothing was added: %#v", msgs)
+	}
+}
+
+// TestDiscoverScreen_EmptyFolderRendersGuidance checks the empty-state
+// path: a folder with no markers still pushes a screen (not a silent
+// no-op) so the user sees feedback.
+func TestDiscoverScreen_EmptyFolderRendersGuidance(t *testing.T) {
+	dir := markerDir(t, "README.md")
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	_, cmd := scr.Update(pathPickedMsg{path: dir})
+	ds := findDiscoverScreen(drainCmd(cmd))
+	if ds == nil {
+		t.Fatal("empty-marker folder should still push a discover screen")
+	}
+	if len(ds.sugs) != 0 {
+		t.Fatalf("expected no suggestions, got %#v", ds.sugs)
+	}
+	if got := ds.View(); got == "" {
+		t.Error("expected guidance text in empty-state view")
+	}
+}
+
+// TestDiscoverScreen_PreCheckedRender asserts the pre-checked checkbox
+// glyph renders for suggestions.
+func TestDiscoverScreen_PreCheckedRender(t *testing.T) {
+	dir := markerDir(t, "go.mod")
+	r := makeRoot(commandsFixture())
+	scr := newCommandsListScreen(r, 0).(*commandsListScreen)
+
+	_, cmd := scr.Update(pathPickedMsg{path: dir})
+	ds := findDiscoverScreen(drainCmd(cmd))
+	if ds == nil {
+		t.Fatal("expected discover screen")
+	}
+	view := ds.View()
+	if want := "[✓]"; !strings.Contains(view, want) {
+		t.Errorf("view missing pre-checked glyph %q:\n%s", want, view)
+	}
+	if !strings.Contains(view, "go") {
+		t.Errorf("view missing suggested command:\n%s", view)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #252: a "Discover from folder…" flow for cwd_glob mappings that scans a chosen folder for project marker files and offers the matched commands as a pre-checked checkbox list.

Closes #252

## What's here

**`internal/discover` (new, pure — no TUI/config deps)**
- Flat marker registry + `Scan(folder) []Suggestion` over `os.ReadDir`. Non-recursive (stops at the chosen folder); no file-content parsing.
- Markers: package.json→npm/node/npx, Dockerfile→docker, compose→docker/docker-compose, Cargo.toml→cargo/rustc, go.mod→go, pyproject/requirements/Pipfile→python/python3/pip, Gemfile→bundle/ruby/rake, Makefile|makefile→make, flake.nix|default.nix→nix, `*.tf`→terraform/tofu, kustomization.yaml|Chart.yaml→kubectl/helm.
- Lockfile-aware swaps: pnpm-lock.yaml→pnpm, yarn.lock→yarn, bun.lockb→bun (replacing npm); poetry.lock adds poetry. Swaps only apply when the base suggestion is present.
- Case handling: explicit case variants (Makefile/makefile) so case-sensitive Linux works, plus case-insensitive lookup for forgiving matching elsewhere.
- Union de-dup in registry order.

**TUI wiring (`internal/tui`)**
- `commands_list_screen.go`: second top sentinel `< Discover from folder… >` above `< Add command >`. Cursor math centralised via `numSentinels = 2`.
- `openDiscoverFolder()` opens the existing file picker in folder-select mode (`pickDir`, reused — not duplicated). The returned `pathPickedMsg` is routed to a new `discoverCommandsScreen`.
- `discover_commands_screen.go` (new): pre-checked checkbox list, Space/Enter toggle, `< Confirm >` row. Confirm appends each checked command via `commandsListScreen.appendDiscovered`, which goes through the SAME `hasCommand` dedup as the manual add flow (no bypass, no auto-add).

**CLI (`internal/cli`)**
- `jitenv cwd discover <folder>` prints suggested commands newline-separated, reusing `internal/discover`. Low-cost, so included rather than deferred.

## Tests
- `internal/discover/markers_test.go`: per-ecosystem fixtures, lockfile swaps (pnpm substitution, poetry add), `*.tf` glob, Makefile/makefile case-sensitivity, multi-marker union de-dup, missing folder, reason population.
- `internal/tui/discover_commands_screen_test.go`: sentinel opens folder picker in `pickDir` mode; full flow renders suggestions pre-checked and confirm updates `mp.Commands` with dedup; toggle-off excludes a row; all-duplicates is a no-op (no dirtyMsg); empty-marker folder still renders guidance.
- Existing `commands_list_screen_test.go` updated for the two-sentinel cursor layout.
- `internal/cli/cwd_discover_test.go`: golden output, empty folder, missing folder.

## Out of scope (per issue)
Parsing project files for finer suggestions, auto-running discover, recursive/cross-folder scan, user-defined markers, auto-wiring vars.

## Verification
- `go test ./...` — all pass
- `go vet ./...` — clean
- `golangci-lint run` — clean