### PR TITLE
docs(website): refresh jitenv.com + release-triggered version-pin renderer (#253)

### DIFF
--- a/.github/workflows/website-update.yml
+++ b/.github/workflows/website-update.yml
@@ -32,8 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     # Stable-only. A workflow_dispatch run is always allowed (the caller
     # supplies the tag); a release-triggered run is skipped for
-    # prereleases / RC tags.
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    # prereleases / RC tags. Gate on BOTH the prerelease flag AND the
+    # tag-name pattern: a stable tag accidentally published with
+    # prerelease:true is still recognized by name, and a '-' in a SemVer
+    # tag (e.g. -rc.1) marks a prerelease regardless of the flag. The Go
+    # step's IsStableTag remains the final authority (defense in depth).
+    if: ${{ github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !contains(github.event.release.tag_name, '-')) }}
     env:
       # For a release event the tag comes from the payload; for a manual
       # run it comes from the dispatch input.

--- a/.github/workflows/website-update.yml
+++ b/.github/workflows/website-update.yml
@@ -1,0 +1,81 @@
+name: website-update
+
+# Refreshes the version-pinned spans in the static site under docs/ on
+# each STABLE release (#253). It substitutes ONLY the marker-bounded
+# spans (see internal/rendocs) — hand-written narrative is never touched
+# — then commits + pushes the result directly to main with a
+# `[skip ci]` message so it doesn't loop back through CI.
+#
+# Stable-only: prereleases / RC tags are skipped (same gate the
+# chocolatey / macos-release workflows use). Manual re-runs are possible
+# via workflow_dispatch with an explicit tag.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to render (e.g. v0.14.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: website-update
+  cancel-in-progress: false
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    # Stable-only. A workflow_dispatch run is always allowed (the caller
+    # supplies the tag); a release-triggered run is skipped for
+    # prereleases / RC tags.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    env:
+      # For a release event the tag comes from the payload; for a manual
+      # run it comes from the dispatch input.
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      # Check out main with the same fine-grained PAT release-please.yml
+      # uses, so the push below is authored by a user/PAT (and can land
+      # on main) rather than the recursion-guarded GITHUB_TOKEN.
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Render version-pinned docs spans
+        run: |
+          echo "Rendering docs for tag: ${TAG}"
+          go run ./cmd/render-docs -tag "${TAG}" -docs docs
+
+      - name: Summarize diff
+        id: diff
+        run: |
+          if git diff --quiet -- docs; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No docs changes for ${TAG} — nothing to commit."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "----- docs diff -----"
+            git --no-pager diff --stat -- docs
+            git --no-pager diff -- docs
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs
+          git commit -m "docs(website): refresh version pins for ${TAG} [skip ci]"
+          git push origin HEAD:main
+          echo "Pushed website version-pin refresh for ${TAG} to main."

--- a/cmd/render-docs/main.go
+++ b/cmd/render-docs/main.go
@@ -1,0 +1,47 @@
+// Command render-docs performs marker-bounded version-pin substitution
+// on the static site under docs/. It is invoked by the website-update
+// release workflow (#253). See package internal/rendocs for the marker
+// contract and the >50% safety bail.
+//
+// Usage:
+//
+//	render-docs [-docs DIR] [-tag vX.Y.Z] [-dry-run]
+//
+// With no -tag it resolves the tag from GITHUB_REF / GITHUB_REF_NAME,
+// then `gh release view`. Exit status is non-zero on any error (an RC
+// tag, a runaway-diff bail, an IO failure) so the workflow fails loud.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/gv/jitenv/internal/rendocs"
+)
+
+func main() {
+	docs := flag.String("docs", "docs", "path to the docs directory to render")
+	tag := flag.String("tag", "", "release tag to substitute (default: resolve from env / gh)")
+	dryRun := flag.Bool("dry-run", false, "compute and print changes without writing files")
+	flag.Parse()
+
+	res, err := rendocs.Run(context.Background(), rendocs.Options{
+		DocsDir: *docs,
+		Tag:     *tag,
+		DryRun:  *dryRun,
+		Out:     os.Stdout,
+		Err:     os.Stderr,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "render-docs:", err)
+		os.Exit(1)
+	}
+	if len(res.Changed) == 0 {
+		// Exit 0 with no changes — the workflow's no-op diff check
+		// handles whether to commit.
+		return
+	}
+	fmt.Printf("render-docs: rewrote %d file(s) for %s\n", len(res.Changed), res.Tag)
+}

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,8 +9,9 @@ Four nouns:
 
 - **Source** — a backend that yields secret material. The first-party
   source is `local` (encrypted bags inside `config.toml`); `aws` (AWS
-  Secrets Manager) is also compiled in. New sources plug into
-  `pkg/source` — see [source-plugins.md](source-plugins.md).
+  Secrets Manager) and `vault` (HashiCorp Vault KV v1/v2) are also
+  compiled in. New sources plug into `pkg/source` — see
+  [source-plugins.md](source-plugins.md).
 - **Bag** — for the `local` source only, a named group of `KEY = value`
   pairs. Bags are how you organize related secrets ("stripe", "db",
   "ci"). They live under `[secrets.<bagname>]` in `config.toml` and
@@ -22,6 +23,11 @@ Four nouns:
 - **VarRef** — one entry inside a mapping's `vars` array, naming an
   env var to inject and where to fetch it from.
 
+This is the *logical* shape, with names shown for readability. On
+disk the names are stored as opaque IDs in a sealed `name_map` and the
+sensitive values are `enc:v2:` envelopes — see
+[security.md](security.md) for the real on-disk form.
+
 ```toml
 # Sources are declared once.
 [sources.local]
@@ -32,12 +38,12 @@ type = "aws"
 [sources.prod_aws.params]
 region          = "us-east-1"
 access_key_id   = "AKIA…"
-secret_access_key = "enc:v1:…"   # encrypted at rest
+secret_access_key = "enc:v2:…"   # encrypted at rest
 
 # Bags hold local secret values.
 [secrets.stripe]
-STRIPE_PK = "enc:v1:…"
-STRIPE_SK = "enc:v1:…"
+STRIPE_PK = "enc:v2:…"
+STRIPE_SK = "enc:v2:…"
 
 # Mappings tie a file (or glob) to env vars.
 [[mappings]]

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,18 +35,47 @@ echo "$DATABASE_URL"       # empty in your shell &mdash; it never saw the value<
 
     <h3>Features</h3>
     <ul class="features">
-      <li>Per-file env injection via shell hooks (bash + zsh).</li>
-      <li>Encrypted at rest with XChaCha20-Poly1305 + Argon2id.</li>
+      <li>Per-file env injection via shell hooks (bash + zsh + PowerShell&nbsp;7).</li>
+      <li>Encrypted at rest with XChaCha20-Poly1305 + Argon2id; even the
+        source, bag, and key <em>names</em> are sealed on disk.</li>
       <li>Long-lived per-user agent; secrets stay out of the parent shell.</li>
-      <li>Pluggable source backends: <code>local</code> (encrypted bags) and AWS Secrets Manager.</li>
-      <li>Exact-path and glob mappings, with whole-bag expansion.</li>
-      <li>TUI for managing config without hand-editing TOML.</li>
-      <li>Linux and macOS support.</li>
+      <li>Pluggable source backends: <code>local</code> (encrypted bags),
+        <code>aws</code> (AWS Secrets Manager), and <code>vault</code>
+        (HashiCorp Vault KV v1/v2).</li>
+      <li>Exact-path, <code>glob</code>, and directory-scoped
+        <code>cwd_glob</code> mappings, with whole-bag expansion.</li>
+      <li>TUI for managing config without hand-editing TOML &mdash; with a
+        built-in file browser for picking mapping targets.</li>
+      <li>Linux, macOS, and Windows support.</li>
+    </ul>
+
+    <h3>Highlights</h3>
+    <ul class="features">
+      <li><strong><code>jitenv clone</code></strong> &mdash; clone a private
+        HTTPS repo, capture its PAT once, store it encrypted, and wire a
+        <code>cwd_glob</code> mapping so <code>git</code> inside the tree
+        sees the token via <code>GIT_ASKPASS</code> &mdash; never written to
+        <code>.git/config</code> or <code>~/.netrc</code>.</li>
+      <li><strong><code>cwd_glob</code> mappings</strong> &mdash; scope
+        secrets to a directory. Inside a matched tree, a per-shell wrapper
+        injects env vars into the listed <code>commands</code>
+        (e.g. <code>npm</code>, <code>git</code>) at exec time.</li>
+      <li><strong><code>jitenv sync</code></strong> &mdash; push/pull the
+        encrypted config to a pluggable remote (SSH, file) with
+        last-writer-wins and a divergence fence. The remote only ever sees
+        one opaque AEAD blob &mdash; never plaintext.</li>
     </ul>
   </section>
 
   <section id="downloads">
     <h2>Download</h2>
+
+    <p>
+      Stable release:
+      <strong><!-- VERSION:start -->v0.13.0<!-- VERSION:end --></strong>.
+      Pre-built, cosign-signed binaries are published on every tag by
+      goreleaser.
+    </p>
 
     <h3>Pre-built binaries</h3>
     <p>
@@ -55,15 +84,30 @@ echo "$DATABASE_URL"       # empty in your shell &mdash; it never saw the value<
       for:
     </p>
     <ul>
-      <li><code>linux/amd64</code> &mdash; <code>.tar.gz</code>, <code>.deb</code>, <code>.rpm</code></li>
-      <li><code>linux/arm64</code> &mdash; <code>.tar.gz</code>, <code>.deb</code>, <code>.rpm</code></li>
+      <li><code>linux/amd64</code> &amp; <code>linux/arm64</code> &mdash; <code>.tar.gz</code>, <code>.deb</code>, <code>.rpm</code></li>
+      <li><code>darwin/amd64</code> &amp; <code>darwin/arm64</code> &mdash; <code>.tar.gz</code> (Developer&nbsp;ID code-signed + notarized)</li>
+      <li><code>windows/amd64</code> &amp; <code>windows/arm64</code> &mdash; <code>.zip</code></li>
     </ul>
+
+    <h3>macOS &mdash; Homebrew</h3>
+    <pre><code>brew install Galvill/jitenv/jitenv</code></pre>
     <p>
-      macOS (darwin/amd64 and darwin/arm64) is supported in code; binary
-      releases are not yet published, so install via <code>go install</code>
-      or build from source (below). After installing, activate the shell
-      hook once:
+      A Homebrew cask that downloads the notarized tarball for your arch.
+      It ships from a separate post-publish workflow (Apple's notarization
+      latency never blocks the Linux/Windows artifacts), so it typically
+      lands within ~30&nbsp;minutes of a new release.
     </p>
+
+    <h3>Windows &mdash; Chocolatey</h3>
+    <pre><code>choco install jitenv</code></pre>
+    <p>
+      Fetches the official <code>windows_amd64</code> release zip,
+      SHA256-verifies it, and shims both <code>jitenv.exe</code> and
+      <code>jitenv-tui.exe</code> onto <code>%PATH%</code>. PowerShell&nbsp;7+
+      is required for the hook.
+    </p>
+
+    <h3>Activate the shell hook (once)</h3>
     <pre><code>jitenv hook install
 exec $SHELL</code></pre>
 
@@ -98,6 +142,9 @@ make install</code></pre>
       <a href="https://github.com/Galvill/jitenv/blob/main/LICENSE">MIT licensed</a>.
       Source for this site lives in
       <a href="https://github.com/Galvill/jitenv/tree/main/docs"><code>/docs</code></a>.
+    </p>
+    <p class="version-footer">
+      Docs current as of <!-- VERSION:asof:start -->v0.13.0<!-- VERSION:asof:end -->.
     </p>
   </div>
 </footer>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,17 +2,54 @@
 
 From zero to "my deploy script has its env vars" in about a minute.
 
+Current stable release:
+<!-- VERSION:start -->v0.13.0<!-- VERSION:end -->.
+
 ## 1. Install
 
-Pick one. The release artifact path is the simplest if you're on Linux:
+Pick the path for your platform. Pre-built, cosign-signed binaries
+ship on every tag via goreleaser.
+
+### Linux — release artifact
 
 ```sh
-# Debian / Ubuntu (replace with the real version + arch)
-curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_X.Y.Z_linux_amd64.deb
-sudo dpkg -i jitenv_X.Y.Z_linux_amd64.deb
+# Debian / Ubuntu
+curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.13.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
+sudo dpkg -i jitenv_<!-- ARTIFACT_VERSION:start -->0.13.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
 
-# Or build from source
+# Fedora / RHEL / openSUSE
+curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.13.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.rpm
+sudo rpm -i jitenv_<!-- ARTIFACT_VERSION:start -->0.13.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.rpm
+```
+
+`amd64` and `arm64` are both published; swap the arch in the filename.
+
+### macOS — Homebrew
+
+```sh
+brew install Galvill/jitenv/jitenv
+```
+
+A Homebrew cask that downloads the notarized tarball for your arch.
+macOS binaries are Apple Developer ID code-signed and notarized, so
+Gatekeeper accepts them without a quarantine override.
+
+### Windows — Chocolatey
+
+```powershell
+choco install jitenv
+```
+
+Fetches the official `windows_amd64` release zip, SHA256-verifies it,
+and shims both `jitenv.exe` and `jitenv-tui.exe` onto `%PATH%`.
+PowerShell 7+ is required for the hook.
+
+### From source
+
+```sh
 go install github.com/gv/jitenv/cmd/jitenv@latest
+# or
+git clone https://github.com/Galvill/jitenv && cd jitenv && make install
 ```
 
 ## 2. Wire up the shell hook (once per machine)
@@ -22,9 +59,17 @@ jitenv hook install      # appends one line to ~/.bashrc or ~/.zshrc
 exec $SHELL              # or open a new terminal
 ```
 
+On Windows, run the same in PowerShell 7+:
+
+```powershell
+jitenv hook install      # adds the activation line to your $PROFILE
+```
+
 Idempotent — re-running it does nothing if the line is already
-there. See [shell-hook.md](shell-hook.md) for what's actually being
-installed.
+there. For bash the installer also wires the login chain
+(`.bash_profile` → `.bash_login` → `.profile`) so login shells still
+source `~/.bashrc`. See [shell-hook.md](shell-hook.md) for what's
+actually being installed.
 
 ## 3. Create a config and add a secret
 
@@ -43,14 +88,23 @@ In the TUI:
 
 Back in the main menu, **Mappings** → `< Create New Mapping >`:
 
-- **kind** → `path`
-- **target** → e.g. `/home/me/scripts/deploy.sh` (or pick `glob`
-  and use `~/work/**/*.sh`)
+- **kind** → `path`, `glob`, or `cwd_glob`.
+- **target** → e.g. `/home/me/scripts/deploy.sh` (the **target**
+  row opens a file browser so you can pick the file instead of
+  typing it), or pick `glob` and use `~/work/**/*.sh`, or `cwd_glob`
+  and scope a directory.
 - **variables** → tick the keys you want injected. Tick the **bag**
   itself to inject every key in it under its own name (the
   "expand the whole bag" mode).
 
-Save (Ctrl+S, or whatever the footer hints). Quit the TUI.
+Save (Ctrl+S, or whatever the footer hints). Quit the TUI. Saving
+auto-reloads a running agent — no relock needed.
+
+Prefer the shell? `jitenv clone <https-url>` clones a private repo,
+captures its PAT once, stores it encrypted, and wires a `cwd_glob`
+mapping so `git` inside the tree authenticates without the token
+landing in `.git/config`. See [concepts.md](concepts.md) for the
+`cwd_glob` model.
 
 ## 5. Unlock the agent and run
 
@@ -61,12 +115,15 @@ echo "$STRIPE_SK"        # empty in your shell — it never had the var
 ```
 
 That's it. The agent stays up until you `jitenv lock` or the idle
-timeout expires; you don't re-enter the passphrase per command.
+timeout expires; you don't re-enter the passphrase per command. If
+you run a mapped command while the agent is locked, the hook offers
+an inline `[u]`-to-unlock prompt so you can unlock and inject without
+leaving the command.
 
 ## What's next
 
 - [concepts.md](concepts.md) — the model. Read this before doing anything
-  fancy with globs or whole-bag expansion.
+  fancy with globs, `cwd_glob`, or whole-bag expansion.
 - [shell-hook.md](shell-hook.md) — exit-code contract, login-shell wiring,
   debug flags.
 - [security.md](security.md) — what jitenv protects against and what it
@@ -75,3 +132,5 @@ timeout expires; you don't re-enter the passphrase per command.
   the agent won't start, etc.
 - [tui.md](tui.md) — full TUI walkthrough.
 - [source-plugins.md](source-plugins.md) — adding a new secret backend.
+
+<!-- VERSION:asof:start -->_Docs current as of v0.13.0._<!-- VERSION:asof:end -->

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,13 +20,49 @@ exec'd child's `/proc/<pid>/environ`.
   `config.toml` `_meta.salt`. Re-deriving the key from the same
   passphrase + salt always produces the same 32-byte key.
 - **AEAD.** XChaCha20-Poly1305 from `golang.org/x/crypto/chacha20poly1305`.
-  Sensitive values are stored as `enc:v1:<base64(nonce ‖ ciphertext)>`
+  Sensitive values are stored as `enc:v2:<base64(nonce ‖ ciphertext)>`
   envelopes in `config.toml`. The 24-byte nonce is freshly randomized
-  per encrypt — never reused across saves.
+  per encrypt — never reused across saves. Legacy `enc:v1:` envelopes
+  (pre-AAD) are still accepted on read and rewritten to `enc:v2:` on
+  the next save, so older configs keep working.
+- **Associated data (AAD) binding.** Every `enc:v2:` envelope is sealed
+  with a canonical associated-data string derived from *where* the
+  value lives in the config — e.g. `src.<id>.secret_access_key`,
+  `secret.<bagID>.<keyID>`, `mapping[i].vars[j].name`. The AEAD tag
+  check fails if a ciphertext is transplanted from one slot to another,
+  so an attacker who can write to `config.toml` can't move a sealed
+  value into a different field and have the agent hand the wrong
+  plaintext to the wrong consumer. See `crypto.AAD` /
+  `crypto.EncryptField` (#110).
 - **Passphrase verification.** `_meta.verify` is a fixed sentinel
   encrypted under the master key during `jitenv config init`. Each
   `jitenv unlock` re-derives the key and decrypts it; failure means
   the wrong passphrase.
+
+## What gets sealed (not just the secret values)
+
+jitenv encrypts more than the obvious secret material:
+
+- **Source params and bag values** — the original case: anything
+  marked sensitive in a source's params block, and every value under
+  `[secrets.<bag>]`.
+- **Variable-reference fields (#235).** Each `VarRef`'s scalar fields —
+  the env var `name`, `source`, `ref`, `key`, inline `value`, plus any
+  `extra` map entries — are sealed individually. The mapping's
+  *shape* (which file/glob, how many vars) is visible on disk, but the
+  env-var names and the keys they pull are not leaked in plaintext.
+- **Source / bag / key NAMES (#248).** The human-facing names live only
+  inside a sealed `[_meta].name_map`. On disk the TOML is rekeyed by
+  random opaque IDs (`s_…` for sources, `b_…` for bags, `k_…` for
+  keys); the AADs above are built from those IDs, not the names. So a
+  config left on disk reveals neither your secret values nor the names
+  you gave your sources, bags, and keys. The IDs are stable across
+  no-op saves (the prior `name_map` is reused) so re-saving an
+  unchanged config produces no spurious diff.
+
+`config.EncryptInPlace` / `DecryptInPlace` own this translation; an
+older (pre-#248) jitenv binary cannot read an opaque-ID config, so the
+migration writes a backup of the original before rekeying.
 
 ## Key handling
 
@@ -62,7 +98,9 @@ the fallback is `/tmp/jitenv-<uid>/`, also mode 0700.
 
 ## What the on-disk file looks like
 
-`config.toml` (mode 0600) contains:
+`config.toml` (mode 0600). Note that names are opaque IDs and every
+sensitive field — including the `vars[*]` scalars — is a sealed
+`enc:v2:` envelope:
 
 ```toml
 version = 1
@@ -72,24 +110,30 @@ kdf = "argon2id"
 argon_time       = 3
 argon_memory_kib = 65536
 argon_threads    = 4
-salt   = "base64-of-16-bytes"
-verify = "enc:v1:base64-of-nonce-and-ciphertext"
+salt     = "base64-of-16-bytes"
+verify   = "enc:v2:base64-of-nonce-and-ciphertext"
+name_map = "enc:v2:…"   # sealed source/bag/key ID↔name dictionary (#248)
 
-[sources.local]
+[sources.s_7f3a]          # ID, not "local"
 type = "local"
 
-[secrets.stripe]
-STRIPE_PK = "enc:v1:…"
-STRIPE_SK = "enc:v1:…"
+[secrets.b_91c2]          # ID, not "stripe"
+k_4d10 = "enc:v2:…"       # key ID → sealed value
+k_8e22 = "enc:v2:…"
 
 [[mappings]]
-path = "/home/me/scripts/deploy.sh"
+path = "/home/me/scripts/deploy.sh"   # path/glob shape stays visible
 [[mappings.vars]]
-name   = "STRIPE_SK"
-source = "local"
-ref    = "stripe"
-key    = "STRIPE_SK"
+name   = "enc:v2:…"       # env var name, sealed (#235)
+source = "enc:v2:…"
+ref    = "enc:v2:…"
+key    = "enc:v2:…"
 ```
+
+The mapping *target* (the file path or glob) is intentionally left in
+plaintext — the resolver matches against it on every command and it
+isn't itself secret material. Everything that identifies *what secret
+goes where* is sealed.
 
 Atomic save via `config.AtomicSave` (sibling tempfile + rename, mode
 0600) so the file is never half-written.

--- a/docs/shell-hook.md
+++ b/docs/shell-hook.md
@@ -63,11 +63,21 @@ bug:
 
 `jitenv is-mapped` reads the config file directly and never contacts
 the agent, so an exit code 2 always means the on-disk config is
-missing or malformed. The agent-unreachable UX (red countdown, **Press
-Enter to skip, Ctrl+C to abort**) lives inside `jitenv run` and the
-cwd_glob shim — see `internal/agentwarn/agentwarn.go`. It only fires
-*after* `is-mapped` returned 0 and `jitenv run` then failed to reach
-the agent.
+missing or malformed. The agent-unreachable UX (a red countdown with
+**Press [u] to unlock and inject, [Enter] to continue without env,
+[Ctrl+C] to abort**) lives inside `jitenv run` and the cwd_glob shim —
+see `internal/agentwarn/agentwarn.go`. It only fires *after*
+`is-mapped` returned 0 and `jitenv run` then failed to reach the
+agent.
+
+If you press **`u`**, jitenv runs the unlock flow inline: it prompts
+for your passphrase, starts the agent in the background, re-fetches
+the env vars, and only then execs your command — so the mapped
+command *is* injected, without you leaving the prompt. **Enter**
+continues the command with no env injection; **Ctrl+C** aborts it.
+The inline-unlock option is offered only on a real TTY; piped or
+non-interactive invocations skip the countdown entirely (the warning
+line still prints once so the failure is visible in logs).
 
 You can see the dispatch in `internal/shell/snippets/bash.sh`. Set
 `JITENV_HOOK_DEBUG=1` in your shell to see which branch the trap

--- a/docs/source-plugins.md
+++ b/docs/source-plugins.md
@@ -32,9 +32,9 @@ type Constructor func(cfg map[string]any) (Source, error)
 ```
 
 `cfg` is the contents of `[sources.<name>.params]` after envelope
-decryption — sensitive params arrive as plaintext strings, not
-`enc:v1:` envelopes, because `crypto.DecryptStringsInPlace` walks the
-config before construction.
+decryption — params arrive as plaintext strings, not `enc:v2:`
+envelopes, because the config decrypt pass walks the params block
+before construction.
 
 Optionally implement `Schemed`:
 
@@ -83,23 +83,76 @@ source whose params need to feel polished in the UI.
    so a single line here makes the source available everywhere.
 
 4. **Implement `Schema()` if you want a polished UI.** Mark sensitive
-   fields with `Sensitive: true` so the TUI masks them and the saver
-   wraps them in `enc:v1:` envelopes on disk.
+   fields with `Sensitive: true` so the TUI masks them. Note that
+   *every* param is encrypted on disk regardless — `Sensitive` only
+   drives UI masking, not whether the value is sealed (see below).
 
 5. **Write tests.** The existing `local` source has the simplest
-   shape; `aws` shows how to mock the SDK for unit tests.
+   shape; `aws` and `vault` show how to mock the backend for unit
+   tests.
 
 ## Sensitive fields and encryption
 
-Mark a `ParamField` `Sensitive: true` to:
+**Encrypt-by-default (#112).** On save, the config encrypter seals
+*every* non-empty, non-envelope string in a source's `params` map —
+whether or not the schema flagged it `Sensitive`. So a source that
+ships no `Schema()` at all (a generic key/value source) still gets all
+of its param values sealed; you never have to remember to mark a field
+to keep it off disk in plaintext. The `Sensitive` bit on a
+`ParamField` only controls **UI masking** in the TUI.
 
-- Mask its value in the TUI.
-- Have the saver re-encrypt it as `enc:v1:` on every save (so the
-  on-disk form stays a fresh ciphertext under the master key).
-
-The agent's `crypto.DecryptStringsInPlace` walks the whole `params`
-map and replaces any `enc:v1:` string with its plaintext before your
+Each sealed value is an `enc:v2:` envelope bound to a per-field
+associated-data string derived from the source's opaque ID and the
+param key (`src.<id>.<param>`), so a ciphertext can't be transplanted
+between fields. The agent's decrypt pass walks the whole `params` map
+and replaces any envelope string with its plaintext before your
 constructor sees it. You don't need per-source crypto code.
+
+## Worked example: the `vault` source
+
+The `vault` source (`internal/sources/vault`) is a good template for a
+network-backed backend with cross-field validation:
+
+```toml
+[sources.prod_vault]
+type = "vault"
+[sources.prod_vault.params]
+address     = "https://vault.example.com:8200"
+auth_method = "approle"
+role_id     = "db_role"
+secret_id   = "enc:v2:…"   # sealed on disk
+mount       = "secret"
+kv_version  = "v2"
+```
+
+Then reference a KV path from a mapping. `ref` is the path under the
+mount; an empty `key` expands the whole secret into one env var per
+field (the same "expand the whole bag" shape the `local` source uses):
+
+```toml
+[[mappings]]
+path = "/home/me/scripts/migrate.sh"
+[[mappings.vars]]
+source = "prod_vault"
+ref    = "myapp/prod"      # reads secret/data/myapp/prod for kv v2
+# name + key omitted → every field of the secret becomes its own env var
+```
+
+What the `vault` package demonstrates for your own source:
+
+- **A `Schema()` with enums and a sensitive field** — `auth_method`
+  is an `Enum: ["token", "approle"]`; `token` and `secret_id` are
+  `Sensitive: true`.
+- **Cross-field validation the per-field `Required` flag can't
+  express** — e.g. "`token` is required when `auth_method=token`".
+  `vault` does this in a `validateStatic()` called from its
+  constructor.
+- **A cheap, side-effect-free `Validate()`** — it authenticates
+  (and caches the client) without reading any secret, which is what
+  `jitenv sources test` invokes.
+- **Defensive `Fetch()`** — it rejects `..` path-traversal refs before
+  hitting the network and stringifies non-string values so the
+  returned map is always `map[string]string`.
 
 ## Special: the `local` source and `bagSink`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,14 +6,23 @@ those answer 80% of "why isn't it working".
 
 ## "Agent unreachable" — red countdown on every command
 
-Your shell hook is installed, but the agent isn't running.
-`jitenv unlock`, type your passphrase, done. If unlock itself fails
+Your shell hook is installed, but the agent isn't running. You have
+three options at the countdown prompt without leaving the command:
+
+- **`u`** — unlock inline. jitenv prompts for your passphrase, starts
+  the agent in the background, re-fetches the env vars, and execs your
+  command *with* them injected. This is the fast path.
+- **Enter** — continue the command now, with no env injection.
+- **Ctrl+C** — abort the command.
+
+Or just run `jitenv unlock` ahead of time. If unlock itself fails
 with "agent did not start within 3s", read the agent log — by
 default it's at `${XDG_RUNTIME_DIR}/jitenv/agent.log`, and at
 `/tmp/jitenv-<uid>/agent.log` if `XDG_RUNTIME_DIR` is unset.
 
 To temporarily silence the warning while you debug, `JITENV_HOOK_DELAY=0`
-in the shell.
+in the shell. The inline `[u]` prompt is only offered on a real TTY;
+piped or non-interactive invocations skip the countdown entirely.
 
 ## Hook installed, but mapped commands aren't intercepted
 
@@ -46,20 +55,41 @@ changes without a relock. Hand-edits skip that ping. Either:
 - `jitenv lock && jitenv unlock`.
 
 Note that hand-editing the config is fragile — sensitive values must
-be wrapped in `enc:v1:` envelopes encrypted under the current master
-key, which the TUI does for you on every save.
+be wrapped in `enc:v2:` envelopes encrypted under the current master
+key, and source/bag/key *names* are stored as opaque IDs resolved
+through a sealed `[_meta].name_map`. The TUI does all of this for you
+on every save, which is why it's the supported edit path.
 
 ## Wrong config file is being loaded
 
-`config.Resolve` checks in this order:
+`config.Resolve` checks in this order (Unix):
 
 1. `$JITENV_CONFIG` if set.
 2. `$XDG_CONFIG_HOME/jitenv/config.toml` if `XDG_CONFIG_HOME` is set.
 3. `~/.config/jitenv/config.toml` otherwise.
 
+On Windows the order is `%JITENV_CONFIG%` →
+`%LOCALAPPDATA%\jitenv\config.toml` →
+`%USERPROFILE%\AppData\Local\jitenv\config.toml`, with the legacy
+roaming `%APPDATA%\jitenv\config.toml` consulted read-only as a
+fallback so older installs upgrade in place.
+
 If you run jitenv with `JITENV_CONFIG=/path/to/foo.toml`, it sticks
 to that file regardless of XDG. Useful for per-project configs
 or for testing — `unset JITENV_CONFIG` to fall back.
+
+## "jitenv keeps telling me a new version is available"
+
+On hook load each shell tab fires a fire-and-forget background fetch
+of the latest GitHub release tag, caches it for 24 hours, and prints
+a one-line stderr notice if a newer release exists. No telemetry is
+sent and only the tag name is read. To turn it off:
+
+- `JITENV_NO_VERSION_CHECK=1` for a single shell session,
+- `[agent] version_check = false` in `config.toml` for the user, or
+- the `CI` env var (auto-skips — matches every mainstream CI).
+
+`dev`/snapshot builds skip the check automatically.
 
 ## Forgot the passphrase
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -32,8 +32,9 @@ and the mappings page.
 
 ## Editing a mapping
 
-Selecting a mapping (or `< Create New Mapping >`) drills into a
-3-row editor:
+Selecting a mapping (or `< Create New Mapping >`) drills into a small
+form. For `path`/`glob` it has three rows; picking `cwd` adds a
+`commands` row:
 
 ```
 kind:      path
@@ -41,10 +42,29 @@ target:    /home/me/scripts/deploy.sh
 variables: 4 selected
 ```
 
+```
+kind:      cwd
+target:    ~/work/acme
+commands:  npm, yarn
+variables: 1 selected
+```
+
 Enter on each row opens its own popup:
 
-- **kind** — choose `path` or `glob`.
-- **target** — type the path or glob.
+- **kind** — choose `path` (one exact file), `glob` (a doublestar
+  pattern against the executed file's path), or `cwd` (match the
+  shell's pwd against a directory pattern; fires only for the listed
+  `commands`). Changing the kind carries the previous target across.
+- **target** — for `path`, the input field offers a **`[ Browse ]`**
+  button (or `Ctrl+O`) that opens an in-TUI **file browser** so you
+  can navigate the filesystem and pick the file instead of typing the
+  path (#223). For `glob`/`cwd` you type the pattern.
+- **commands** (cwd only) — a checkbox list of the command names that
+  get wrapped in the matched directory. You can add names by hand, or
+  point jitenv at a folder and let it **scan for project markers**
+  (`package.json`, `go.mod`, a `.git` dir, …) to suggest the relevant
+  commands as a pre-checked list (#256); the suggestion screen is
+  purely additive and never removes commands you already added.
 - **variables** — opens a bag→key tree with checkboxes.
 
 The variable tree shows every local-secret bag with its keys
@@ -52,6 +72,11 @@ indented beneath. Ticking the bag includes the whole bag (now and
 any future keys); ticking individual keys produces named env vars
 per key. While a bag is in "all" mode, the individual key boxes
 render dimmed.
+
+If you back out of a half-filled form (a target with no variables, a
+`cwd` mapping with no commands, …) the TUI warns that the mapping is
+incomplete and lets you resume editing or discard it rather than
+silently saving a broken entry.
 
 ## Local secrets
 

--- a/internal/rendocs/rendocs.go
+++ b/internal/rendocs/rendocs.go
@@ -94,16 +94,37 @@ func spans() []span {
 func Render(content string, r Release, ext string) (string, error) {
 	out := content
 	for _, s := range spans() {
+		// (?s) lets "." cross newlines so a span survives a human edit
+		// that puts the version string on its own line.
 		re, err := regexp.Compile(
-			regexp.QuoteMeta(s.start) + "(.*?)" + regexp.QuoteMeta(s.end),
+			"(?s)" + regexp.QuoteMeta(s.start) + "(.*?)" + regexp.QuoteMeta(s.end),
 		)
 		if err != nil {
+			return "", err
+		}
+		// Catch malformed edits loudly: a start marker with no matching
+		// end (or vice versa) means a human mangled the markers. Silently
+		// no-op'ing would let stale docs ship with no signal, so fail.
+		if err := checkBalanced(out, s); err != nil {
 			return "", err
 		}
 		repl := s.start + s.replace(r, ext) + s.end
 		out = re.ReplaceAllLiteralString(out, repl)
 	}
 	return out, nil
+}
+
+// checkBalanced reports an error if content has an unequal number of a
+// span's start and end markers — an unbalanced edit the renderer must
+// not silently skip.
+func checkBalanced(content string, s span) error {
+	starts := strings.Count(content, s.start)
+	ends := strings.Count(content, s.end)
+	if starts != ends {
+		return fmt.Errorf("rendocs: unbalanced markers for %q: %d start, %d end",
+			s.start, starts, ends)
+	}
+	return nil
 }
 
 // TooLargeError is returned when a render would change more bytes than

--- a/internal/rendocs/rendocs.go
+++ b/internal/rendocs/rendocs.go
@@ -1,0 +1,208 @@
+// Package rendocs performs mechanical, marker-bounded version-pin
+// substitution on the static docs under docs/. It is driven by the
+// website-update release workflow (#253 Part B).
+//
+// Design constraints (from the issue):
+//
+//   - Marker-based in-place substitution only. No build step, no docs
+//     framework. The renderer touches ONLY the bytes between explicit
+//     start/end markers; all hand-written narrative content is left
+//     byte-for-byte unchanged.
+//   - A safety bail: if rendering a file would change more than half of
+//     its bytes, that's treated as a marker-handling bug and the render
+//     aborts rather than committing garbage.
+//
+// Supported markers (HTML-comment form for .html, identical form works
+// inside .md since GitHub renders raw HTML comments as nothing):
+//
+//	<!-- VERSION:start -->v0.13.0<!-- VERSION:end -->
+//	    → replaced with the full tag, e.g. "v0.14.0".
+//
+//	<!-- ARTIFACT_VERSION:start -->0.13.0<!-- ARTIFACT_VERSION:end -->
+//	    → replaced with the bare version (tag minus a leading "v"),
+//	      matching the goreleaser artifact name template
+//	      jitenv_{{.Version}}_{{.Os}}_{{.Arch}}.
+//
+//	<!-- VERSION:asof:start -->...<!-- VERSION:asof:end -->
+//	    → a per-page "as of" footer. For .md files the inner text becomes
+//	      "_Docs current as of vX.Y.Z._"; for .html it becomes the bare
+//	      tag "vX.Y.Z" (the surrounding markup supplies the prose).
+package rendocs
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// span describes one marker family: the literal start/end delimiters and
+// a function producing the replacement inner text for a given tag.
+type span struct {
+	start   string
+	end     string
+	replace func(r Release, ext string) string
+}
+
+// Release is the resolved release identity the renderer substitutes.
+type Release struct {
+	// Tag is the full git tag, e.g. "v0.14.0".
+	Tag string
+}
+
+// Bare returns the tag without a leading "v": "v0.14.0" → "0.14.0".
+// This matches the version segment in goreleaser artifact filenames.
+func (r Release) Bare() string {
+	return strings.TrimPrefix(r.Tag, "v")
+}
+
+// spans is the ordered list of marker families the renderer understands.
+// VERSION must be processed before nothing in particular, but the regex
+// for each family is anchored to its own delimiters so order is moot.
+func spans() []span {
+	return []span{
+		{
+			start:   "<!-- VERSION:start -->",
+			end:     "<!-- VERSION:end -->",
+			replace: func(r Release, _ string) string { return r.Tag },
+		},
+		{
+			start:   "<!-- ARTIFACT_VERSION:start -->",
+			end:     "<!-- ARTIFACT_VERSION:end -->",
+			replace: func(r Release, _ string) string { return r.Bare() },
+		},
+		{
+			start: "<!-- VERSION:asof:start -->",
+			end:   "<!-- VERSION:asof:end -->",
+			replace: func(r Release, ext string) string {
+				if ext == ".md" {
+					return fmt.Sprintf("_Docs current as of %s._", r.Tag)
+				}
+				return r.Tag
+			},
+		},
+	}
+}
+
+// Render returns the rewritten contents of a single file. ext is the
+// file extension (".html" / ".md") and selects the asof phrasing. It
+// only ever rewrites bytes between known markers; everything else is
+// preserved exactly.
+//
+// Render is deterministic and pure — no IO — so it is trivially
+// golden-testable.
+func Render(content string, r Release, ext string) (string, error) {
+	out := content
+	for _, s := range spans() {
+		re, err := regexp.Compile(
+			regexp.QuoteMeta(s.start) + "(.*?)" + regexp.QuoteMeta(s.end),
+		)
+		if err != nil {
+			return "", err
+		}
+		repl := s.start + s.replace(r, ext) + s.end
+		out = re.ReplaceAllLiteralString(out, repl)
+	}
+	return out, nil
+}
+
+// TooLargeError is returned when a render would change more bytes than
+// the configured ceiling — a signal that marker handling went wrong.
+type TooLargeError struct {
+	Path        string
+	ChangedFrac float64
+}
+
+func (e *TooLargeError) Error() string {
+	return fmt.Sprintf("rendocs: refusing to rewrite %s: %.0f%% of bytes changed (>50%%); likely a marker bug",
+		e.Path, e.ChangedFrac*100)
+}
+
+// RenderFile renders one file's content, applies the >50% safety bail,
+// and reports whether the content changed. path is used only for the
+// extension and for error messages.
+func RenderFile(path, content string, r Release) (rendered string, changed bool, err error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	rendered, err = Render(content, r, ext)
+	if err != nil {
+		return "", false, err
+	}
+	if rendered == content {
+		return content, false, nil
+	}
+	if frac := changedFraction(content, rendered); frac > 0.5 {
+		return "", false, &TooLargeError{Path: path, ChangedFrac: frac}
+	}
+	return rendered, true, nil
+}
+
+// changedFraction estimates how much of a file changed as the byte
+// total of intra-line edits over the original byte total. Marker
+// substitution never adds or removes lines, so a positional line
+// comparison is exact for the intended edits; within each differing
+// line we trim the common prefix/suffix and count only the genuinely
+// changed bytes. This stays small for legitimate version-pin edits
+// (only the inner span text moves) while still ballooning past 50% if a
+// marker bug mangles structure (whole lines diverge or counts change).
+func changedFraction(a, b string) float64 {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return 1
+	}
+	la := strings.Split(a, "\n")
+	lb := strings.Split(b, "\n")
+	changed := 0
+	n := len(la)
+	if len(lb) > n {
+		n = len(lb)
+	}
+	for i := 0; i < n; i++ {
+		var lineA, lineB string
+		if i < len(la) {
+			lineA = la[i]
+		}
+		if i < len(lb) {
+			lineB = lb[i]
+		}
+		if lineA != lineB {
+			changed += lineEditBytes(lineA, lineB)
+		}
+	}
+	return float64(changed) / float64(len(a))
+}
+
+// lineEditBytes returns the number of original-line bytes outside the
+// common prefix/suffix shared with the rewritten line — a tight bound
+// on how much of the original line was rewritten.
+func lineEditBytes(a, b string) int {
+	p := 0
+	for p < len(a) && p < len(b) && a[p] == b[p] {
+		p++
+	}
+	s := 0
+	for s < len(a)-p && s < len(b)-p && a[len(a)-1-s] == b[len(b)-1-s] {
+		s++
+	}
+	if d := len(a) - p - s; d > 0 {
+		return d
+	}
+	return 0
+}
+
+// IsStableTag reports whether tag is a stable release tag (no
+// prerelease / RC suffix). The website-update workflow is stable-only,
+// so RC tags like "v0.14.0-rc.1" must not trigger a docs rewrite. The
+// workflow gates on this too, but the renderer enforces it as a
+// belt-and-suspenders guard.
+func IsStableTag(tag string) bool {
+	t := strings.TrimSpace(tag)
+	if t == "" {
+		return false
+	}
+	// A SemVer prerelease is anything after the first '-' in the
+	// version core. We treat any '-' as prerelease.
+	core := strings.TrimPrefix(t, "v")
+	return !strings.Contains(core, "-")
+}

--- a/internal/rendocs/rendocs_test.go
+++ b/internal/rendocs/rendocs_test.go
@@ -2,6 +2,7 @@ package rendocs
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +50,7 @@ func TestNarrativeUntouched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if !strings.Contains(got, "talks\nabout v0.13.0 in prose") {
+	if !strings.Contains(got, "It talks\nabout v0.13.0 in prose") {
 		t.Errorf("narrative prose mentioning the old version was modified; got:\n%s", got)
 	}
 }
@@ -124,27 +125,73 @@ func TestChangedFraction(t *testing.T) {
 	}
 }
 
-// TestSafetyBailWiring asserts the >50% guard is wired into RenderFile.
-// A normal marker swap never trips it (by design the metric only counts
-// bytes of the ORIGINAL that were rewritten — see lineEditBytes), so we
-// assert the legit path does NOT bail, then assert the threshold + error
-// type directly via the metric the guard consults.
+// TestSafetyBailWiring asserts the >50% guard is actually wired into
+// RenderFile by driving it down the bail branch: a tiny file whose marked
+// span holds a long original inner string is rewritten to the short tag,
+// so the rewritten bytes dominate the file and changedFraction > 0.5.
 func TestSafetyBailWiring(t *testing.T) {
 	// Legit edit: must NOT bail.
 	in := readFixture(t, "quickstart.input.md")
 	if _, _, err := RenderFile("quickstart.md", in, Release{Tag: fixtureTag}); err != nil {
 		t.Fatalf("legit render unexpectedly bailed: %v", err)
 	}
-	// The guard fires when changedFraction > 0.5. Confirm a full rewrite
-	// crosses the threshold the guard checks.
-	full := changedFraction("aaaa\nbbbb\ncccc\n", "zzzz\nwwww\nqqqq\n")
-	if full <= 0.5 {
-		t.Fatalf("full-rewrite fraction %v did not exceed the 0.5 guard", full)
+
+	// Bail path: a marked span whose original inner text is long relative
+	// to the whole file. Replacing it with the short tag rewrites the
+	// majority of the file's bytes, so the guard must fire. This is what a
+	// marker-handling bug looks like in practice.
+	inner := strings.Repeat("Z", 100)
+	content := "<!-- VERSION:start -->" + inner + "<!-- VERSION:end -->\n"
+	rendered, changed, err := RenderFile("docs/x.md", content, Release{Tag: fixtureTag})
+	if err == nil {
+		t.Fatalf("expected RenderFile to bail with TooLargeError, got changed=%v rendered=%q", changed, rendered)
+	}
+	var tle *TooLargeError
+	if !errors.As(err, &tle) {
+		t.Fatalf("expected *TooLargeError, got %T: %v", err, err)
+	}
+	if tle.ChangedFrac <= 0.5 {
+		t.Errorf("TooLargeError.ChangedFrac = %v, want > 0.5", tle.ChangedFrac)
+	}
+	// On bail RenderFile must NOT return the mutated content.
+	if rendered != "" || changed {
+		t.Errorf("bail returned content; rendered=%q changed=%v", rendered, changed)
 	}
 	// And the error type formats sensibly.
-	e := &TooLargeError{Path: "docs/x.md", ChangedFrac: full}
-	if !strings.Contains(e.Error(), "docs/x.md") || !strings.Contains(e.Error(), "%") {
-		t.Errorf("TooLargeError.Error() = %q", e.Error())
+	if !strings.Contains(tle.Error(), "docs/x.md") || !strings.Contains(tle.Error(), "%") {
+		t.Errorf("TooLargeError.Error() = %q", tle.Error())
+	}
+}
+
+// TestRenderMultilineSpan verifies the (?s) flag: a version string that a
+// human has moved onto its own line (markers and content split across
+// newlines) is still updated.
+func TestRenderMultilineSpan(t *testing.T) {
+	content := "intro\n<!-- VERSION:start -->\nv0.13.0\n<!-- VERSION:end -->\noutro\n"
+	got, err := Render(content, Release{Tag: fixtureTag}, ".md")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := "intro\n<!-- VERSION:start -->v0.14.0<!-- VERSION:end -->\noutro\n"
+	if got != want {
+		t.Errorf("multiline span not updated:\n got: %q\nwant: %q", got, want)
+	}
+	if strings.Contains(got, "v0.13.0") {
+		t.Errorf("old version survived in multiline span: %q", got)
+	}
+}
+
+// TestRenderUnbalancedMarkers verifies a start marker with no matching
+// end (a mangled edit) fails loudly instead of silently no-op'ing.
+func TestRenderUnbalancedMarkers(t *testing.T) {
+	content := "intro\n<!-- VERSION:start -->v0.13.0\noutro\n" // no VERSION:end
+	if _, err := Render(content, Release{Tag: fixtureTag}, ".md"); err == nil {
+		t.Fatal("expected Render to reject unbalanced markers, got nil")
+	}
+	// An end with no start is equally malformed.
+	content2 := "intro\nv0.13.0<!-- VERSION:end -->\noutro\n"
+	if _, err := Render(content2, Release{Tag: fixtureTag}, ".md"); err == nil {
+		t.Fatal("expected Render to reject a lone end marker, got nil")
 	}
 }
 

--- a/internal/rendocs/rendocs_test.go
+++ b/internal/rendocs/rendocs_test.go
@@ -1,0 +1,238 @@
+package rendocs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fixtureTag = "v0.14.0"
+
+// TestGolden renders each .input fixture and asserts it matches the
+// matching .golden file byte-for-byte. This is the load-bearing test:
+// it pins both the version substitution AND the "narrative untouched"
+// guarantee (the fixtures embed prose mentioning the old version that
+// must survive verbatim).
+func TestGolden(t *testing.T) {
+	cases := []struct {
+		input  string
+		golden string
+		ext    string
+	}{
+		{"quickstart.input.md", "quickstart.golden.md", ".md"},
+		{"index.input.html", "index.golden.html", ".html"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			in := readFixture(t, tc.input)
+			want := readFixture(t, tc.golden)
+			got, err := Render(in, Release{Tag: fixtureTag}, tc.ext)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if got != want {
+				t.Errorf("rendered output mismatch for %s\n--- got ---\n%s\n--- want ---\n%s",
+					tc.input, got, want)
+			}
+		})
+	}
+}
+
+// TestNarrativeUntouched is an explicit, focused assertion that prose
+// mentioning the old version is preserved (the automation must only
+// touch marked spans).
+func TestNarrativeUntouched(t *testing.T) {
+	in := readFixture(t, "quickstart.input.md")
+	got, err := Render(in, Release{Tag: fixtureTag}, ".md")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(got, "talks\nabout v0.13.0 in prose") {
+		t.Errorf("narrative prose mentioning the old version was modified; got:\n%s", got)
+	}
+}
+
+func TestRenderIdempotent(t *testing.T) {
+	in := readFixture(t, "quickstart.input.md")
+	once, err := Render(in, Release{Tag: fixtureTag}, ".md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	twice, err := Render(once, Release{Tag: fixtureTag}, ".md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if once != twice {
+		t.Error("Render is not idempotent")
+	}
+}
+
+func TestRenderFileNoChange(t *testing.T) {
+	golden := readFixture(t, "quickstart.golden.md")
+	_, changed, err := RenderFile("quickstart.md", golden, Release{Tag: fixtureTag})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("rendering an already-current file reported a change")
+	}
+}
+
+func TestBare(t *testing.T) {
+	if got := (Release{Tag: "v0.14.0"}).Bare(); got != "0.14.0" {
+		t.Errorf("Bare() = %q, want 0.14.0", got)
+	}
+	if got := (Release{Tag: "0.14.0"}).Bare(); got != "0.14.0" {
+		t.Errorf("Bare() on already-bare = %q", got)
+	}
+}
+
+func TestIsStableTag(t *testing.T) {
+	stable := []string{"v0.14.0", "0.14.0", "v1.0.0"}
+	pre := []string{"v0.14.0-rc.1", "v0.14.0-beta", "v1.0.0-alpha.2", ""}
+	for _, s := range stable {
+		if !IsStableTag(s) {
+			t.Errorf("IsStableTag(%q) = false, want true", s)
+		}
+	}
+	for _, s := range pre {
+		if IsStableTag(s) {
+			t.Errorf("IsStableTag(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestChangedFraction pins the metric that drives the safety bail:
+// small intra-line edits stay small; whole-line / structural mangling
+// balloons.
+func TestChangedFraction(t *testing.T) {
+	// Identical → 0.
+	if f := changedFraction("abc\ndef\n", "abc\ndef\n"); f != 0 {
+		t.Errorf("identical changedFraction = %v, want 0", f)
+	}
+	// One short inner edit inside a long line → small fraction.
+	long := strings.Repeat("x", 100) + "v0.13.0" + strings.Repeat("y", 100) + "\n"
+	long2 := strings.Repeat("x", 100) + "v0.14.0" + strings.Repeat("y", 100) + "\n"
+	if f := changedFraction(long, long2); f > 0.5 {
+		t.Errorf("tiny intra-line edit changedFraction = %v, want <=0.5", f)
+	}
+	// Whole file rewritten → ~1.0 (> 0.5, trips the bail).
+	if f := changedFraction("aaaa\nbbbb\ncccc\n", "zzzz\nwwww\nqqqq\n"); f <= 0.5 {
+		t.Errorf("full rewrite changedFraction = %v, want >0.5", f)
+	}
+}
+
+// TestSafetyBailWiring asserts the >50% guard is wired into RenderFile.
+// A normal marker swap never trips it (by design the metric only counts
+// bytes of the ORIGINAL that were rewritten — see lineEditBytes), so we
+// assert the legit path does NOT bail, then assert the threshold + error
+// type directly via the metric the guard consults.
+func TestSafetyBailWiring(t *testing.T) {
+	// Legit edit: must NOT bail.
+	in := readFixture(t, "quickstart.input.md")
+	if _, _, err := RenderFile("quickstart.md", in, Release{Tag: fixtureTag}); err != nil {
+		t.Fatalf("legit render unexpectedly bailed: %v", err)
+	}
+	// The guard fires when changedFraction > 0.5. Confirm a full rewrite
+	// crosses the threshold the guard checks.
+	full := changedFraction("aaaa\nbbbb\ncccc\n", "zzzz\nwwww\nqqqq\n")
+	if full <= 0.5 {
+		t.Fatalf("full-rewrite fraction %v did not exceed the 0.5 guard", full)
+	}
+	// And the error type formats sensibly.
+	e := &TooLargeError{Path: "docs/x.md", ChangedFrac: full}
+	if !strings.Contains(e.Error(), "docs/x.md") || !strings.Contains(e.Error(), "%") {
+		t.Errorf("TooLargeError.Error() = %q", e.Error())
+	}
+}
+
+// TestRunWritesAndIsNoOp exercises the file-walking Run end to end on a
+// temp copy of the docs fixtures, including the no-op second pass.
+func TestRunWritesAndIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "quickstart.md"), readFixture(t, "quickstart.input.md"))
+	writeFile(t, filepath.Join(dir, "index.html"), readFixture(t, "index.input.html"))
+	// A file with no markers must be left untouched and not reported.
+	writeFile(t, filepath.Join(dir, "concepts.md"), "# Concepts\n\nNo markers here.\n")
+
+	res, err := Run(context.Background(), Options{DocsDir: dir, Tag: fixtureTag})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Changed) != 2 {
+		t.Fatalf("expected 2 changed files, got %d: %v", len(res.Changed), res.Changed)
+	}
+	if got := readFile(t, filepath.Join(dir, "quickstart.md")); got != readFixture(t, "quickstart.golden.md") {
+		t.Errorf("quickstart.md not rendered to golden:\n%s", got)
+	}
+
+	// Second pass: nothing should change.
+	res2, err := Run(context.Background(), Options{DocsDir: dir, Tag: fixtureTag})
+	if err != nil {
+		t.Fatalf("Run (2nd): %v", err)
+	}
+	if len(res2.Changed) != 0 {
+		t.Errorf("expected no changes on second pass, got %v", res2.Changed)
+	}
+}
+
+func TestRunRejectsRC(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "quickstart.md"), readFixture(t, "quickstart.input.md"))
+	_, err := Run(context.Background(), Options{DocsDir: dir, Tag: "v0.14.0-rc.1"})
+	if err == nil {
+		t.Fatal("expected Run to reject an RC tag")
+	}
+	if !strings.Contains(err.Error(), "stable-only") {
+		t.Errorf("error did not mention stable-only: %v", err)
+	}
+}
+
+func TestResolveTagFromEnv(t *testing.T) {
+	t.Setenv("GITHUB_REF_NAME", "v0.14.0")
+	t.Setenv("GITHUB_REF", "refs/tags/v0.14.0")
+	tag, err := ResolveTag(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v0.14.0" {
+		t.Errorf("ResolveTag = %q, want v0.14.0", tag)
+	}
+}
+
+func TestResolveTagFromRef(t *testing.T) {
+	t.Setenv("GITHUB_REF_NAME", "")
+	t.Setenv("GITHUB_REF", "refs/tags/v0.15.1")
+	tag, err := ResolveTag(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v0.15.1" {
+		t.Errorf("ResolveTag = %q, want v0.15.1", tag)
+	}
+}
+
+// --- helpers ---
+
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+	return readFile(t, filepath.Join("testdata", name))
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/rendocs/run.go
+++ b/internal/rendocs/run.go
@@ -1,0 +1,149 @@
+package rendocs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Options configures a Run.
+type Options struct {
+	// DocsDir is the directory whose files are scanned + rewritten.
+	DocsDir string
+	// Tag is the release tag to substitute. If empty, ResolveTag is
+	// used to discover it from the environment / gh.
+	Tag string
+	// DryRun, when true, computes the changes and logs them but writes
+	// nothing to disk.
+	DryRun bool
+	// Out / Err receive human-readable progress + the diff summary.
+	Out io.Writer
+	Err io.Writer
+}
+
+// Result reports what a Run did.
+type Result struct {
+	Tag     string
+	Changed []string // relative paths rewritten (or that would be, in DryRun)
+}
+
+// Run resolves the tag, walks DocsDir, rewrites the marked spans in
+// every file, and returns the set of files that changed. It is a no-op
+// (empty Result.Changed) when nothing needs updating, which the
+// workflow uses to avoid empty commits.
+func Run(ctx context.Context, o Options) (*Result, error) {
+	if o.Out == nil {
+		o.Out = io.Discard
+	}
+	if o.Err == nil {
+		o.Err = io.Discard
+	}
+
+	tag := strings.TrimSpace(o.Tag)
+	if tag == "" {
+		var err error
+		tag, err = ResolveTag(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !IsStableTag(tag) {
+		return nil, fmt.Errorf("rendocs: tag %q is a prerelease/RC; website-update is stable-only", tag)
+	}
+
+	rel := Release{Tag: tag}
+	res := &Result{Tag: tag}
+
+	err := filepath.WalkDir(o.DocsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".md" && ext != ".html" {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rendered, changed, err := RenderFile(path, string(raw), rel)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			return nil
+		}
+		relPath, _ := filepath.Rel(o.DocsDir, path)
+		res.Changed = append(res.Changed, relPath)
+		fmt.Fprintf(o.Out, "render: %s\n", relPath)
+		if !o.DryRun {
+			// Preserve the file's existing mode.
+			info, statErr := os.Stat(path)
+			mode := os.FileMode(0o644)
+			if statErr == nil {
+				mode = info.Mode().Perm()
+			}
+			if werr := os.WriteFile(path, []byte(rendered), mode); werr != nil {
+				return werr
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Changed) == 0 {
+		fmt.Fprintln(o.Out, "render: no changes (already at "+tag+")")
+	}
+	return res, nil
+}
+
+// ResolveTag discovers the release tag, preferring the workflow's
+// GITHUB_REF / GITHUB_REF_NAME, then falling back to the gh CLI's view
+// of the latest release. Used when Options.Tag is empty.
+func ResolveTag(ctx context.Context) (string, error) {
+	if name := os.Getenv("GITHUB_REF_NAME"); name != "" && looksLikeTag(name) {
+		return name, nil
+	}
+	if ref := os.Getenv("GITHUB_REF"); ref != "" {
+		if t := strings.TrimPrefix(ref, "refs/tags/"); t != ref {
+			return t, nil
+		}
+	}
+	// Fall back to `gh release view --json tagName`.
+	tag, err := ghLatestTag(ctx)
+	if err != nil {
+		return "", fmt.Errorf("rendocs: no tag in GITHUB_REF/GITHUB_REF_NAME and gh fallback failed: %w", err)
+	}
+	return tag, nil
+}
+
+func looksLikeTag(s string) bool {
+	return strings.HasPrefix(s, "v") && !strings.ContainsAny(s, "/ ")
+}
+
+// ghLatestTag shells out to gh to read the latest release's tag.
+// Indirected through a var so tests can stub it.
+var ghLatestTag = func(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "release", "view", "--json", "tagName", "--jq", ".tagName")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gh release view: %w (%s)", err, strings.TrimSpace(stderr.String()))
+	}
+	tag := strings.TrimSpace(stdout.String())
+	if tag == "" {
+		return "", fmt.Errorf("gh release view returned an empty tagName")
+	}
+	return tag, nil
+}

--- a/internal/rendocs/testdata/index.golden.html
+++ b/internal/rendocs/testdata/index.golden.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+  <p>
+    Stable release:
+    <strong><!-- VERSION:start -->v0.14.0<!-- VERSION:end --></strong>.
+  </p>
+  <p>
+    This prose mentions v0.13.0 and the renderer must leave it alone.
+  </p>
+  <footer>
+    Docs current as of <!-- VERSION:asof:start -->v0.14.0<!-- VERSION:asof:end -->.
+  </footer>
+</body>
+</html>

--- a/internal/rendocs/testdata/index.input.html
+++ b/internal/rendocs/testdata/index.input.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+  <p>
+    Stable release:
+    <strong><!-- VERSION:start -->v0.13.0<!-- VERSION:end --></strong>.
+  </p>
+  <p>
+    This prose mentions v0.13.0 and the renderer must leave it alone.
+  </p>
+  <footer>
+    Docs current as of <!-- VERSION:asof:start -->v0.13.0<!-- VERSION:asof:end -->.
+  </footer>
+</body>
+</html>

--- a/internal/rendocs/testdata/quickstart.golden.md
+++ b/internal/rendocs/testdata/quickstart.golden.md
@@ -1,0 +1,14 @@
+# Quickstart fixture
+
+Current stable release:
+<!-- VERSION:start -->v0.14.0<!-- VERSION:end -->.
+
+```sh
+curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.14.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
+sudo dpkg -i jitenv_<!-- ARTIFACT_VERSION:start -->0.14.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
+```
+
+This narrative paragraph must NOT be touched by the renderer. It talks
+about v0.13.0 in prose and that string stays exactly as written.
+
+<!-- VERSION:asof:start -->_Docs current as of v0.14.0._<!-- VERSION:asof:end -->

--- a/internal/rendocs/testdata/quickstart.input.md
+++ b/internal/rendocs/testdata/quickstart.input.md
@@ -1,0 +1,14 @@
+# Quickstart fixture
+
+Current stable release:
+<!-- VERSION:start -->v0.13.0<!-- VERSION:end -->.
+
+```sh
+curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.13.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
+sudo dpkg -i jitenv_<!-- ARTIFACT_VERSION:start -->0.13.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
+```
+
+This narrative paragraph must NOT be touched by the renderer. It talks
+about v0.13.0 in prose and that string stays exactly as written.
+
+<!-- VERSION:asof:start -->_Docs current as of v0.13.0._<!-- VERSION:asof:end -->


### PR DESCRIPTION
## Summary

Refreshes the static site under `docs/` to the current feature set and adds release-triggered automation that keeps the version-pinned spans current — the two intentionally-bundled halves of #253.

## Part A — one-shot content refresh

All copy verified against the actual code / README / CLAUDE.md before writing (no invented specifics). Docs files refreshed:

- [x] `docs/index.html` — accurate source list (`local` + AWS + **Vault**), `clone` / `cwd_glob` / `sync` highlights, macOS Homebrew + Windows Chocolatey installs, dropped the "releases not yet published" hedge, added VERSION/ARTIFACT_VERSION/asof markers + a stable-version line.
- [x] `docs/quickstart.md` — Vault + Windows (Choco) + macOS (Homebrew cask) install paths, `clone` / `cwd_glob` mention, login-chain note, file-browser target row, inline-unlock note; the old `X.Y.Z` placeholders are now VERSION-marked spans.
- [x] `docs/concepts.md` — Vault added to the source list; note that names are opaque IDs on disk (cwd_glob / expand-the-bag / lookup precedence were already current).
- [x] `docs/shell-hook.md` — documented the agent-locked countdown with the new `[u]`-to-unlock option (#232). (Exit-code table and #237 bare-name PATH matching were already current.)
- [x] `docs/security.md` — var-field encryption (#235), opaque-ID name encryption via `name_map` (#248), the AAD model (#110), `enc:v2` + sealed-name on-disk example, key-handling conventions.
- [x] `docs/tui.md` — post-#223 file browser on the target row, post-#231 form flow, `cwd` commands + folder-scan discovery (#256), incomplete-mapping guard.
- [x] `docs/source-plugins.md` — Vault worked example alongside local + AWS; AWS-style schema + **encrypt-by-default** (#112).
- [x] `docs/troubleshooting.md` — inline `[u]`-unlock prompt, agent-reload-on-save, `JITENV_NO_VERSION_CHECK` opt-out (#136), Windows config-path resolution, `enc:v2` note.

Also surfaced: Windows Chocolatey (#180), macOS Homebrew cask + async-notarize (#226), version-check opt-out (#136), the bash login-chain wiring. Stayed static HTML/MD — no docs framework introduced.

## Part B — release-triggered version-pin renderer

- **`internal/rendocs`** — pure, IO-free, golden-tested marker substitution. Markers: `VERSION` (full tag), `ARTIFACT_VERSION` (bare version, matching the goreleaser `jitenv_{{.Version}}_{{.Os}}_{{.Arch}}` artifact pattern), `VERSION:asof` (per-page footer). Includes a **>50% safety bail**, no-op detection, RC/prerelease rejection, and tag resolution from `GITHUB_REF` / `GITHUB_REF_NAME` / `gh release view`.
- **`cmd/render-docs`** — thin CLI (`-tag`, `-docs`, `-dry-run`).
- **Golden tests** (required) — fixture `quickstart.md` / `index.html` rendered for `v0.14.0` and asserted byte-for-byte against goldens; an explicit test pins that narrative prose mentioning the *old* version is left untouched.
- **`.github/workflows/website-update.yml`** — `on: { release: { types: [published] }, workflow_dispatch }`.

### website-update workflow is: stable-only / push-direct / marker-based

- **stable-only** — skips prereleases/RC tags (`!github.event.release.prerelease`, mirroring chocolatey/macos-release); the renderer also rejects RC tags as a second guard.
- **push-direct** — commits + pushes straight to `main` with a `[skip ci]` message, using the **same `RELEASE_PLEASE_TOKEN` PAT + `github-actions[bot]` identity** the existing workflows use (no new secret introduced).
- **marker-based** — only the marker-bounded spans in `docs/` are rewritten; hand-written narrative is never touched. Empty-diff runs are no-ops.

The new workflow is release/dispatch-triggered, so it does not run in PR CI and does not alter any existing workflow.

## Verification

- `go test ./...` — green (renderer golden tests pass).
- `go vet ./...` + `golangci-lint run` — clean.
- `go run ./cmd/render-docs -tag v0.14.0 -dry-run` against the real docs touches exactly `index.html` + `quickstart.md`; the diff is surgical (version spans only, prose untouched).
- HTML well-formedness + internal-link resolution checked.

Closes #253
