### PR TITLE
fix(shell): stop bash hook forking is-mapped during PROMPT_COMMAND (#258)

### DIFF
--- a/internal/shell/hook_prompt_command_test.go
+++ b/internal/shell/hook_prompt_command_test.go
@@ -1,0 +1,102 @@
+//go:build !windows
+
+package shell_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// TestBashHookSkipsPromptCommandCommands is a regression test for the
+// per-prompt fork storm (issue #258). The bash DEBUG trap runs under
+// `extdebug` (functrace), so it fires for every command bash executes
+// while redrawing the prompt — including a git-prompt's `git rev-parse`
+// / `[[ … ]]` and jitenv's own `jitenv __chpwd`. After issue #237 made
+// the bare-name branch fork `jitenv is-mapped`, those prompt-internal
+// commands each spawned a `jitenv` process on every prompt.
+//
+// The hook brackets PROMPT_COMMAND with a latch (__jitenv_prompt_begin /
+// __jitenv_prompt_end) so the trap skips prompt-internal commands while
+// still intercepting interactively-typed ones. This test asserts both
+// halves: a bare command run *inside* PROMPT_COMMAND must NOT reach the
+// is-mapped dispatch (no "candidate" debug line), while the same command
+// typed interactively MUST.
+func TestBashHookSkipsPromptCommandCommands(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	binDir := filepath.Dir(bin)
+
+	dir := t.TempDir()
+
+	// A real on-PATH executable standing in for a prompt-internal tool
+	// (e.g. the `git` a git-prompt runs). Unique name so the debug log is
+	// unambiguous to grep.
+	toolDir := filepath.Join(dir, "tools")
+	if err := os.MkdirAll(toolDir, 0o755); err != nil {
+		t.Fatalf("mkdir tools: %v", err)
+	}
+	tool := filepath.Join(toolDir, "promptprobe")
+	if err := os.WriteFile(tool, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write tool: %v", err)
+	}
+
+	// A valid (empty-mapping) config so is-mapped resolves cleanly; the
+	// tool is unmapped, so the interactive invocation logs a candidate
+	// and then runs normally.
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := config.InitNew(cfgPath, []byte("hunter2-prompt")); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	// The git-prompt is already in PROMPT_COMMAND when the hook loads, so
+	// jitenv's prepend wraps it inside the latch — the realistic ordering.
+	script := fmt.Sprintf(`
+PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
+export JITENV_HOOK_DEBUG=1
+PROMPT_COMMAND="promptprobe"
+eval "$(jitenv hook bash)"
+printf '__PROMPT_REDRAW__\n' >&2
+eval "$PROMPT_COMMAND"
+printf '__INTERACTIVE__\n' >&2
+promptprobe
+printf '__DONE__\n' >&2
+`, binDir, toolDir, cfgPath)
+
+	cmd := exec.Command("bash", "--norc", "-c", script)
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+
+	redrawIdx := strings.Index(got, "__PROMPT_REDRAW__")
+	interactiveIdx := strings.Index(got, "__INTERACTIVE__")
+	doneIdx := strings.Index(got, "__DONE__")
+	if redrawIdx < 0 || interactiveIdx < 0 || doneIdx < 0 {
+		t.Fatalf("missing phase markers in output:\n%s", got)
+	}
+
+	const candidate = "candidate cmd=[promptprobe]"
+	redrawPhase := got[redrawIdx:interactiveIdx]
+	interactivePhase := got[interactiveIdx:doneIdx]
+
+	if strings.Contains(redrawPhase, candidate) {
+		t.Errorf("prompt-internal command reached is-mapped dispatch (per-prompt fork storm, issue #258).\nredraw phase:\n%s", redrawPhase)
+	}
+	if !strings.Contains(interactivePhase, candidate) {
+		t.Errorf("interactively-typed command was NOT dispatched — the latch over-suppressed.\ninteractive phase:\n%s", interactivePhase)
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -99,10 +99,28 @@ __jitenv_chpwd() {
     [[ $rc -eq 10 ]] && hash -r 2>/dev/null
     __JITENV_LAST_PWD="$PWD"
 }
+# Prompt latch. The DEBUG trap below fires for EVERY simple command
+# under `extdebug` (which turns on functrace) — including the commands
+# bash runs *inside* PROMPT_COMMAND while redrawing the prompt (a
+# git-prompt's `git rev-parse …` / `[[ … ]]`, our own `jitenv __chpwd`,
+# etc.). Those aren't commands the user typed, so routing them through
+# `jitenv is-mapped` is wrong — and since the bare-name PATH branch
+# (issue #237) forks `jitenv is-mapped` per command, it turned every
+# prompt redraw into a fork storm (one `jitenv` spawn per prompt-internal
+# command, every prompt). A marker prepended to PROMPT_COMMAND sets the
+# latch and one appended clears it, so the trap skips everything
+# bracketed by them while still intercepting interactively-typed
+# commands. (issue #258)
+__jitenv_prompt_begin() { __JITENV_IN_PROMPT=1; }
+__jitenv_prompt_end()   { __JITENV_IN_PROMPT=; }
+
 # Run once at hook-load time so the wrapper dir is populated before
-# the first command in this shell.
+# the first command in this shell. Bracketed by the latch so the
+# chpwd reconcile's own internal commands don't trip the trap.
+__jitenv_prompt_begin
 __jitenv_chpwd
-PROMPT_COMMAND="__jitenv_chpwd${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+__jitenv_prompt_end
+PROMPT_COMMAND="__jitenv_prompt_begin;__jitenv_chpwd${PROMPT_COMMAND:+;$PROMPT_COMMAND};__jitenv_prompt_end"
 
 # Version-check (#136): fire-and-forget background HTTP fetch
 # refreshes a 24h-cached sidecar at $XDG_CACHE_HOME/jitenv/
@@ -136,6 +154,15 @@ __jitenv_log() {
 
 __jitenv_debug_trap() {
     [[ -n "${__JITENV_REENTRY:-}" ]] && return 0
+
+    # Skip every command bash runs while redrawing the prompt:
+    # PROMPT_COMMAND itself plus the user's git-prompt / precmd machinery,
+    # which `extdebug`'s functrace makes the DEBUG trap fire on. The latch
+    # is set by __jitenv_prompt_begin / cleared by __jitenv_prompt_end,
+    # which bracket PROMPT_COMMAND. Without it the trap forks
+    # `jitenv is-mapped` for every prompt-internal command on every
+    # prompt (issue #258).
+    [[ -n "${__JITENV_IN_PROMPT:-}" ]] && return 0
 
     # Skip while bash is running a programmable-completion function —
     # the DEBUG trap fires on commands inside compfuncs too, and we


### PR DESCRIPTION
## Problem

A long delay was added to **every prompt** after #237 (PR #242). The bash hook's `DEBUG` trap runs under `shopt -s extdebug` (functrace), so it fires for every command bash runs *inside* `PROMPT_COMMAND` while redrawing the prompt — the user's git-prompt (`git rev-parse …`, `[[ … ]]`) and jitenv's own `jitenv __chpwd`.\n\nPre-#237 those bare names short-circuited with no subprocess. #237 added the bare-name `type -P` branch that **forks `jitenv is-mapped`** for every PATH-resolvable command, so every prompt redraw became a fork storm — one `jitenv` spawn + full TOML parse (larger post-#248) per prompt-internal command, every prompt.\n\nObserved (`JITENV_HOOK_DEBUG=1`): `jitenv __chpwd`, `[[ … ]]`, `git rev-parse …` each emit `candidate cmd=… → is-mapped` on every prompt.\n\nzsh is **not** affected (its `zle accept-line` widget only fires on interactive Enter).\n\n## Fix\n\nLatch the DEBUG trap off for the duration of `PROMPT_COMMAND` (the bash-preexec pattern): `__jitenv_prompt_begin` (prepended) sets `__JITENV_IN_PROMPT`, `__jitenv_prompt_end` (appended) clears it, and the trap early-returns while it's set. The existing chpwd entry is bracketed too. Interactively-typed commands are still intercepted (the latch is clear when the user's line runs).\n\nBaked PROMPT_COMMAND becomes: `__jitenv_prompt_begin;__jitenv_chpwd;<existing>;__jitenv_prompt_end`.\n\n## Verification\n\n- New regression test `TestBashHookSkipsPromptCommandCommands`: a bare command run inside PROMPT_COMMAND produces **no** `is-mapped` dispatch; the same command typed interactively **does**.\n- Manual repro (before): prompt redraw forks `is-mapped` for the prompt tool. After: zero forks during redraw, interactive interception preserved.\n- `go test ./...` green; `go vet ./...` clean; full `internal/shell` + `internal/run` e2e suites pass.\n\n## Follow-up (separate)\n\nEven with the latch, an interactively-typed bare-name command forks `is-mapped` once. #237's deferred mitigation (gate the bare-name branch on whether any `path`/`glob` mapping exists, cached from `__chpwd`) would zero that out for cwd_glob-only users — worth a separate PR.\n\nCloses #258