### PR TITLE
fix(rendocs): pin testdata fixtures to LF so Windows CI passes

### DIFF
--- a/internal/rendocs/rendocs_test.go
+++ b/internal/rendocs/rendocs_test.go
@@ -50,7 +50,11 @@ func TestNarrativeUntouched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if !strings.Contains(got, "It talks\nabout v0.13.0 in prose") {
+	// Normalize CRLF so the assertion holds regardless of how the
+	// fixture was checked out (a Windows checkout would be CRLF absent
+	// the testdata .gitattributes; this keeps the test robust either way).
+	gotLF := strings.ReplaceAll(got, "\r\n", "\n")
+	if !strings.Contains(gotLF, "It talks\nabout v0.13.0 in prose") {
 		t.Errorf("narrative prose mentioning the old version was modified; got:\n%s", got)
 	}
 }

--- a/internal/rendocs/testdata/.gitattributes
+++ b/internal/rendocs/testdata/.gitattributes
@@ -1,0 +1,7 @@
+# Golden-file fixtures must stay LF on every platform so the renderer
+# tests (line/byte comparisons + the hardcoded "\n" narrative assertion
+# in TestNarrativeUntouched) are deterministic. Without this, Windows
+# checks these out as CRLF and the test fails on "\n" vs "\r\n". The
+# failure was latent because PR #257 (the #253 renderer) never ran
+# Windows CI; it surfaced the first time a later PR did.
+* text eol=lf


### PR DESCRIPTION
## Problem

`main` is currently **red on Windows**: `internal/rendocs.TestNarrativeUntouched` fails because it asserts `strings.Contains(got, "It talks\nabout v0.13.0 in prose")` against a fixture read from disk, and Windows checks the `.md` fixture out as **CRLF** — so the embedded `\n` never matches.

This was **latent**: PR #257 (the #253 website renderer) never ran Windows CI — GitHub wouldn't spawn workflow runs for that head commit because the push token lacked `workflows` permission (the new `.github/workflows/website-update.yml` file) — so the failure only surfaced when a later PR first exercised the Windows job. Every PR branched from `main` now fails the Windows check on this test.\n\n## Fix\n\n- Add `internal/rendocs/testdata/.gitattributes` with `* text eol=lf` so the golden fixtures stay LF on every platform's checkout (the proper fix for golden-file tests).\n- Normalize CRLF in the `TestNarrativeUntouched` assertion as defense-in-depth.\n\n## Verification\n\nRan the `internal/rendocs` suite against both the normal LF fixtures **and** a CRLF-converted fixture (simulating a Windows checkout) — both pass. `go test ./internal/rendocs/...` green.\n\nUnblocks the Windows job for all open PRs (including #259).