### PR TITLE
fix(shell): in-shell anchor pre-filter — stop forking is-mapped per command (#260)

### DIFF
--- a/.goreleaser.darwin.yaml
+++ b/.goreleaser.darwin.yaml
@@ -49,6 +49,30 @@ builds:
         - cmd: ./packaging/macos/sign-submit.sh "{{ .Path }}" "{{ .Os }}"
           output: true
 
+  # Lightweight hot-path binary (see .goreleaser.yaml). Signed +
+  # notarized like the others via the per-binary post hook.
+  - id: jitenv-hook
+    main: ./cmd/jitenv-hook
+    binary: jitenv-hook
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
+      - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+    hooks:
+      post:
+        - cmd: ./packaging/macos/sign-submit.sh "{{ .Path }}" "{{ .Os }}"
+          output: true
+
   - id: jitenv-tui
     main: ./cmd/jitenv-tui
     binary: jitenv-tui
@@ -79,6 +103,7 @@ archives:
     formats: [tar.gz]
     ids:
       - jitenv
+      - jitenv-hook
       - jitenv-tui
     name_template: "jitenv_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,31 @@ builds:
       - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
       - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
 
+  # The lightweight hot-path binary the shell hook spawns on every
+  # prompt (__chpwd / is-mapped / run / shim). It imports none of the
+  # AWS SDK / net-http / source / sync / TUI graph the full binary
+  # links, so it starts in ~1.5ms vs ~50ms — the per-prompt cost that
+  # made interactive shells laggy. Same internal packages, identical
+  # behaviour; the hook falls back to `jitenv` when it's absent.
+  - id: jitenv-hook
+    main: ./cmd/jitenv-hook
+    binary: jitenv-hook
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/gv/jitenv/internal/version.Version={{.Version}}
+      - -X github.com/gv/jitenv/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/gv/jitenv/internal/version.Date={{.Date}}
+
   # The interactive TUI lives in a separate binary so the main
   # jitenv binary's import graph stays free of Bubble Tea / Lip
   # Gloss / termenv. Those libs send OSC 11 (background color) +
@@ -68,11 +93,12 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
-    # Both binaries ship in the same archive so a brew/dpkg/manual
-    # install gets the pair atomically. `ids:` is the v2-spelling
+    # All binaries ship in the same archive so a brew/dpkg/manual
+    # install gets them atomically. `ids:` is the v2-spelling
     # of the build allowlist.
     ids:
       - jitenv
+      - jitenv-hook
       - jitenv-tui
     name_template: "jitenv_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
@@ -90,6 +116,7 @@ nfpms:
     package_name: jitenv
     ids:
       - jitenv
+      - jitenv-hook
       - jitenv-tui
     vendor: Galvill
     homepage: https://github.com/Galvill/jitenv

--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,22 @@ LDFLAGS := -s -w \
 
 build:
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN) ./cmd/jitenv
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-hook ./cmd/jitenv-hook
 	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-tui ./cmd/jitenv-tui
 
 # Cross-compile the Windows binaries. The TUI ships as a separate
 # binary (#182 bug B): the main jitenv binary stays free of
 # Bubble Tea / Lip Gloss imports so it doesn't query the terminal
-# on every invocation.
+# on every invocation. jitenv-hook is the lightweight hot-path binary
+# (no AWS SDK / net-http) the shell hook spawns per prompt.
 build-windows:
 	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN).exe ./cmd/jitenv
+	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-hook.exe ./cmd/jitenv-hook
 	GOOS=windows GOARCH=amd64 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o bin/$(BIN)-tui.exe ./cmd/jitenv-tui
 
 install: build
 	install -Dm0755 bin/$(BIN) $(PREFIX)/bin/$(BIN)
+	install -Dm0755 bin/$(BIN)-hook $(PREFIX)/bin/$(BIN)-hook
 	install -Dm0755 bin/$(BIN)-tui $(PREFIX)/bin/$(BIN)-tui
 
 test:

--- a/cmd/jitenv-hook/main.go
+++ b/cmd/jitenv-hook/main.go
@@ -1,0 +1,103 @@
+// Command jitenv-hook is the lightweight companion to the main `jitenv`
+// binary. It implements ONLY the hot-path operations the shell hook and
+// the cwd_glob wrapper shims invoke on every prompt / mapped command:
+// `__chpwd`, `is-mapped`, `run`, and the argv[0] shim dispatch.
+//
+// Why a second binary: the full `jitenv` links the AWS SDK v2, net/http,
+// and the rest of the source/sync/TUI graph (~70 of those packages,
+// 29 MB), so spawning it costs ~50 ms of startup on every prompt even
+// though the chpwd/is-mapped work itself is ~0. jitenv-hook deliberately
+// imports none of that — only internal/config, internal/chpwd,
+// internal/run, internal/shim and the agent *client* — so it starts in
+// ~1.5 ms (≈3.6 MB). The shell hook prefers it (see internal/shell/
+// render.go) and falls back to `jitenv` when it isn't installed.
+//
+// It shares the exact same internal packages as `jitenv`, so behaviour is
+// identical by construction; this is purely a startup-cost optimisation.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gv/jitenv/internal/chpwd"
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/run"
+	"github.com/gv/jitenv/internal/shim"
+)
+
+// exitWrapperSetChanged mirrors internal/cli/chpwd_internal.go: __chpwd
+// exits 10 when it added/removed a wrapper so the shell clears its
+// command-hash table. Kept in sync by hand (both are load-bearing for
+// the bash/zsh `hash -r` / `rehash` dispatch).
+const exitWrapperSetChanged = 10
+
+func main() {
+	// Wrapper-symlink dispatch: when invoked under any name other than
+	// "jitenv-hook" we are a cwd_glob wrapper (e.g. …/shells/<pid>/bin/npm
+	// → jitenv-hook) and route to the shim, exactly like cmd/jitenv does
+	// for the "jitenv" name. Strip .exe for the Windows comparison.
+	base := filepath.Base(os.Args[0])
+	if name := strings.TrimSuffix(base, ".exe"); name != "" {
+		base = name
+	}
+	if base != "jitenv-hook" && base != "" {
+		shim.Main(base, os.Args[1:])
+		return
+	}
+
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "jitenv-hook: expected one of: __chpwd, is-mapped, run")
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "__chpwd":
+		// jitenv-hook __chpwd <shell-pid> <oldpwd> <newpwd>
+		changed, err := chpwd.Run(os.Args[2:])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		if changed {
+			os.Exit(exitWrapperSetChanged)
+		}
+	case "is-mapped":
+		// jitenv-hook is-mapped <path> — exit 0 mapped, 1 not, 2 unreadable.
+		if len(os.Args) < 3 {
+			os.Exit(2)
+		}
+		abs, err := filepath.Abs(os.Args[2])
+		if err != nil {
+			os.Exit(2)
+		}
+		cfgPath, err := config.Resolve(os.Getenv("JITENV_CONFIG"))
+		if err != nil {
+			os.Exit(2)
+		}
+		cfg, err := config.Load(cfgPath)
+		if err != nil {
+			os.Exit(2)
+		}
+		if config.NewIndex(cfg.Mappings).Mapped(abs) {
+			return
+		}
+		os.Exit(1)
+	case "run":
+		// jitenv-hook run <file> [args...] — fetch env + exec the file.
+		if len(os.Args) < 3 {
+			fmt.Fprintln(os.Stderr, "usage: jitenv-hook run <file> [args...]")
+			os.Exit(2)
+		}
+		if err := run.Run(context.Background(), os.Args[2], os.Args[3:]); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "jitenv-hook: unknown command %q\n", os.Args[1])
+		os.Exit(2)
+	}
+}

--- a/e2e/scenarios/zsh-hook-injects-env.yaml
+++ b/e2e/scenarios/zsh-hook-injects-env.yaml
@@ -77,8 +77,11 @@ steps:
     # it contains no shell-special characters, and zsh-quoted when it
     # does. A bare /home/jitenv/... path qualifies for the unquoted
     # form, so the rewritten BUFFER lacks the double-quotes the
-    # original eval-style snippet always emitted.
-    assert_stdout_contains: 'BUFFER=jitenv run /home/jitenv/scripts/showz.sh'
+    # original eval-style snippet always emitted. The leading binary is
+    # the lightweight `jitenv-hook` when installed (its absolute path) or
+    # bare `jitenv` otherwise (#263), so assert only the binary-agnostic
+    # tail.
+    assert_stdout_contains: 'run /home/jitenv/scripts/showz.sh'
 
   # End-to-end via the rewritten BUFFER: run it through eval inside
   # zsh and inspect the script's stdout for the injected bag values.

--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -43,6 +43,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/gv/jitenv/internal/agent"
 	"github.com/gv/jitenv/internal/config"
@@ -117,7 +118,7 @@ func Run(args []string) (bool, error) {
 		return false, nil
 	}
 
-	wanted, err := desiredCommandsFor(cfgPath, cfgErr, newPwd)
+	wanted, idx, err := desiredCommandsFor(cfgPath, cfgErr, newPwd)
 	if err != nil {
 		debugLog("desiredCommands error: %v", err)
 		// Config missing or malformed: leave the wrapper dir alone
@@ -126,6 +127,13 @@ func Run(args []string) (bool, error) {
 		return false, nil
 	}
 	debugLog("config reports wanted=%v", wanted)
+
+	// Refresh the per-shell match-anchors sidecar the bash/zsh hooks read
+	// to decide, without forking `jitenv is-mapped`, whether a typed
+	// command could match a path/glob mapping. Only the reconcile path
+	// reaches here (config mtime or pwd changed), so it tracks config
+	// edits; the short-circuit above leaves a valid sidecar untouched.
+	writeAnchors(anchorsPath(paths, pid), idx)
 	changed, err := reconcile(wrapDir, wanted)
 	if err != nil {
 		debugLog("reconcile error: %v", err)
@@ -186,18 +194,59 @@ func writeLastMtime(path string, mtime int64) error {
 // No agent contact, no decryption — the cwd_glob and commands fields
 // are plaintext TOML. cfgErr is the pre-resolved Resolve error so the
 // caller doesn't pay a second config.Resolve cost.
-func desiredCommandsFor(cfgPath string, cfgErr error, pwd string) ([]string, error) {
+func desiredCommandsFor(cfgPath string, cfgErr error, pwd string) ([]string, *config.Index, error) {
 	if cfgErr != nil {
-		return nil, cfgErr
+		return nil, nil, cfgErr
 	}
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(cfg.Mappings) == 0 {
-		return nil, nil
+		// Build an (empty) index anyway so the caller writes an empty
+		// anchors sidecar — a config that just lost its last path/glob
+		// mapping must stop the hook from forking is-mapped.
+		return nil, config.NewIndex(cfg.Mappings), nil
 	}
-	return config.NewIndex(cfg.Mappings).CwdCommands(pwd), nil
+	idx := config.NewIndex(cfg.Mappings)
+	return idx.CwdCommands(pwd), idx, nil
+}
+
+// anchorsPath is the per-shell sidecar listing the path/glob match
+// anchors (see config.Index.Anchors). Lives alongside the wrapper bin
+// dir + last-mtime so agent.GcOrphanShells reaps it with the shell.
+func anchorsPath(paths agent.Paths, pid int) string {
+	return filepath.Join(filepath.Dir(paths.ShellWrapDir(pid)), "match-anchors")
+}
+
+// writeAnchors (re)writes the match-anchors sidecar from idx. Format is
+// one tab-separated record per line: `E\t<abs-path>` for an exact path
+// mapping, `P\t<literal-prefix>` for a glob. An empty idx (no path/glob
+// mappings) yields an empty file, which tells the hook to never fork
+// is-mapped. Best-effort: a write failure just means the hook keeps its
+// previous (possibly stale) view until the next reconcile.
+func writeAnchors(path string, idx *config.Index) {
+	var b strings.Builder
+	if idx != nil {
+		exact, prefixes := idx.Anchors()
+		for _, e := range exact {
+			b.WriteString("E\t")
+			b.WriteString(e)
+			b.WriteByte('\n')
+		}
+		for _, p := range prefixes {
+			b.WriteString("P\t")
+			b.WriteString(p)
+			b.WriteByte('\n')
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		debugLog("writeAnchors mkdir: %v", err)
+		return
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		debugLog("writeAnchors: %v", err)
+	}
 }
 
 // reconcile makes the wrapper dir contain exactly one wrapper per

--- a/internal/config/anchors_test.go
+++ b/internal/config/anchors_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLiteralPrefix(t *testing.T) {
+	cases := map[string]string{
+		"/usr/local/bin/*":      "/usr/local/bin/",
+		"/usr/local/bin/kube-*": "/usr/local/bin/kube-",
+		"/usr/{local,opt}/bin":  "/usr/",
+		"/opt/foo":              "/opt/foo", // no wildcard → whole pattern
+		"/a/[xy]/z":             "/a/",
+		"/a/b?c":                "/a/b",
+		`/a/b\*c/*`:             "/a/b*c/", // escaped star is literal
+		"*foo":                  "",        // opens with a wildcard
+		"/**/x":                 "/",
+	}
+	for in, want := range cases {
+		if got := literalPrefix(in); got != want {
+			t.Errorf("literalPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIndexAnchors(t *testing.T) {
+	exactA, _ := filepath.Abs("/usr/local/bin/terraform")
+	exactB, _ := filepath.Abs("/opt/homebrew/bin/aws")
+
+	idx := NewIndex([]Mapping{
+		{Path: "/usr/local/bin/terraform"},
+		{Path: "/opt/homebrew/bin/aws"},
+		{Glob: "/usr/local/bin/kubectl-*"},
+		{Glob: "/srv/*/bin/*"},
+		{CwdGlob: "~/work/**", Commands: []string{"npm"}}, // excluded from anchors
+	})
+
+	exact, prefixes := idx.Anchors()
+
+	wantExact := []string{exactA, exactB}
+	// Anchors sorts; sort our expectation the same way via the function's
+	// contract (sorted ascending).
+	if exactA > exactB {
+		wantExact = []string{exactB, exactA}
+	}
+	if !reflect.DeepEqual(exact, wantExact) {
+		t.Errorf("exact = %v, want %v", exact, wantExact)
+	}
+
+	wantPrefixes := []string{"/srv/", "/usr/local/bin/kubectl-"}
+	if !reflect.DeepEqual(prefixes, wantPrefixes) {
+		t.Errorf("prefixes = %v, want %v", prefixes, wantPrefixes)
+	}
+}
+
+func TestIndexAnchorsEmpty(t *testing.T) {
+	idx := NewIndex(nil)
+	exact, prefixes := idx.Anchors()
+	if len(exact) != 0 || len(prefixes) != 0 {
+		t.Errorf("empty config should yield no anchors; got exact=%v prefixes=%v", exact, prefixes)
+	}
+	// cwd_glob-only must also yield zero anchors (served by PATH wrappers).
+	idx = NewIndex([]Mapping{{CwdGlob: "~/work", Commands: []string{"npm"}}})
+	exact, prefixes = idx.Anchors()
+	if len(exact) != 0 || len(prefixes) != 0 {
+		t.Errorf("cwd_glob-only should yield no anchors; got exact=%v prefixes=%v", exact, prefixes)
+	}
+}

--- a/internal/config/mapping.go
+++ b/internal/config/mapping.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -215,4 +216,60 @@ func containsString(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// Anchors returns the minimal information a shell hook needs to decide,
+// *without* spawning `jitenv is-mapped`, whether a resolved command path
+// could possibly match a `path`/`glob` mapping:
+//
+//   - exact: the absolute `path` mapping targets (an O(1) exact-match set).
+//   - prefixes: the literal directory prefix of every `glob` mapping —
+//     the run of characters before the first wildcard. A path can match a
+//     doublestar glob only if it starts with this prefix, so HasPrefix is a
+//     necessary (conservative) condition: the hook can safely skip the
+//     is-mapped fork for any resolved path that is neither an exact target
+//     nor under a prefix, and `is-mapped` remains the source of truth for
+//     the (rare) candidates that pass the filter. Both slices are sorted
+//     for a stable on-disk sidecar. cwd_glob mappings are intentionally
+//     excluded — those are intercepted by the PATH wrapper shims, not the
+//     DEBUG-trap / accept-line path. (issue #260)
+func (idx *Index) Anchors() (exact, prefixes []string) {
+	for k := range idx.exact {
+		exact = append(exact, k)
+	}
+	seen := map[string]struct{}{}
+	for _, g := range idx.globs {
+		p := literalPrefix(g.pattern)
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		prefixes = append(prefixes, p)
+	}
+	sort.Strings(exact)
+	sort.Strings(prefixes)
+	return exact, prefixes
+}
+
+// literalPrefix returns the leading run of pattern that contains no
+// doublestar wildcard — i.e. everything before the first unescaped
+// `*`, `?`, `[`, or `{`. A `\`-escaped metacharacter contributes its
+// literal self to the prefix (doublestar treats `\` as an escape on the
+// forward-slash-normalised patterns the Index stores). A pattern with no
+// wildcard yields itself; a pattern that opens with a wildcard yields "".
+func literalPrefix(pattern string) string {
+	var b strings.Builder
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c == '\\' && i+1 < len(pattern) {
+			b.WriteByte(pattern[i+1])
+			i++
+			continue
+		}
+		if c == '*' || c == '?' || c == '[' || c == '{' {
+			break
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
 }

--- a/internal/shell/hook_anchor_prefilter_test.go
+++ b/internal/shell/hook_anchor_prefilter_test.go
@@ -1,0 +1,168 @@
+//go:build !windows
+
+package shell_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// writeConfigWithMappings builds an encrypted config at cfgPath with the
+// given mappings (path/glob/cwd_glob fields are plaintext, so is-mapped /
+// __chpwd read them without the key). Mirrors the setup in hook_e2e_test.go.
+func writeConfigWithMappings(t *testing.T, dir string, mappings []config.Mapping) string {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := config.InitNew(cfgPath, []byte("hunter2-anchor")); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	cfg.Mappings = mappings
+	tmp, err := os.CreateTemp(dir, "save-*.toml")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	return cfgPath
+}
+
+func mkexec(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// runHookDebug sources the bash hook (so __chpwd writes + the hook loads
+// the match-anchors sidecar) and runs the given command lines, returning
+// combined output with JITENV_HOOK_DEBUG on. The DEBUG trap logs
+// "candidate cmd=[…]" immediately before each `jitenv is-mapped` fork, so
+// the presence/absence of that line per command is a direct probe of the
+// anchor pre-filter.
+func runHookDebug(t *testing.T, bin, cfgPath, runtimeDir, lines string) string {
+	t.Helper()
+	binDir := filepath.Dir(bin)
+	script := fmt.Sprintf(`
+PATH=%q:$PATH
+export JITENV_CONFIG=%q
+export JITENV_HOOK_DEBUG=1
+eval "$(jitenv hook bash)"
+%s
+`, binDir, cfgPath, lines)
+	cmd := exec.Command("bash", "--norc", "-c", script)
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	return string(out)
+}
+
+// TestHookAnchorPrefilter_NoPathGlob_NoForks asserts that with only a
+// cwd_glob mapping (no path/glob), the DEBUG trap never forks is-mapped —
+// not even for a command run during prompt redraw. This is the fix for
+// the per-prompt fork storm (issue #260): cwd_glob is served by the PATH
+// wrappers, so the trap has nothing to route and short-circuits.
+func TestHookAnchorPrefilter_NoPathGlob_NoForks(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	probe := filepath.Join(dir, "tools", "probe")
+	mkexec(t, probe)
+
+	cfgPath := writeConfigWithMappings(t, dir, []config.Mapping{
+		{CwdGlob: filepath.Join(dir, "work") + "/**", Commands: []string{"npm"}},
+	})
+
+	out := runHookDebug(t, bin, cfgPath, runtimeDir, fmt.Sprintf(`
+PROMPT_COMMAND=%q
+printf '__REDRAW__\n' >&2
+eval "$PROMPT_COMMAND"
+printf '__INTERACTIVE__\n' >&2
+%q
+printf '__DONE__\n' >&2
+`, probe, probe))
+
+	if strings.Contains(out, "candidate cmd=") {
+		t.Errorf("trap forked is-mapped with no path/glob mappings (issue #260):\n%s", out)
+	}
+}
+
+// TestHookAnchorPrefilter_PathGlob_OnlyForksOnPlausibleMatch asserts the
+// precise filter: a command that can't match any anchor produces no
+// is-mapped fork, while a command under a glob's literal prefix does
+// (is-mapped then remains the source of truth — here it declines, so the
+// command just runs, no agent needed).
+func TestHookAnchorPrefilter_PathGlob_OnlyForksOnPlausibleMatch(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	// glob /…/root/sub/* → literal prefix /…/root/sub/
+	root := filepath.Join(dir, "root")
+	// under the prefix but NOT matched by the single-segment glob (the
+	// doublestar `*` doesn't cross `/`), so is-mapped returns "not mapped"
+	// → reaches the fork but doesn't route.
+	underPrefix := filepath.Join(root, "sub", "deep", "tool")
+	mkexec(t, underPrefix)
+	// outside the prefix → must be filtered out before any fork.
+	outside := filepath.Join(root, "other", "tool")
+	mkexec(t, outside)
+
+	cfgPath := writeConfigWithMappings(t, dir, []config.Mapping{
+		{Glob: filepath.Join(root, "sub") + "/*", Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}}},
+	})
+
+	out := runHookDebug(t, bin, cfgPath, runtimeDir, fmt.Sprintf(`
+printf '__OUTSIDE__\n' >&2
+%q
+printf '__UNDER__\n' >&2
+%q
+printf '__DONE__\n' >&2
+`, outside, underPrefix))
+
+	outsideIdx := strings.Index(out, "__OUTSIDE__")
+	underIdx := strings.Index(out, "__UNDER__")
+	doneIdx := strings.Index(out, "__DONE__")
+	if outsideIdx < 0 || underIdx < 0 || doneIdx < 0 {
+		t.Fatalf("missing phase markers:\n%s", out)
+	}
+	outsidePhase := out[outsideIdx:underIdx]
+	underPhase := out[underIdx:doneIdx]
+
+	if strings.Contains(outsidePhase, "candidate cmd=") {
+		t.Errorf("command outside every anchor prefix still forked is-mapped:\n%s", outsidePhase)
+	}
+	if !strings.Contains(underPhase, "candidate cmd=") {
+		t.Errorf("command under a glob's literal prefix was filtered out (should fork is-mapped to confirm):\n%s", underPhase)
+	}
+}

--- a/internal/shell/hook_barename_gate_test.go
+++ b/internal/shell/hook_barename_gate_test.go
@@ -90,3 +90,62 @@ func TestHookBarenameGate(t *testing.T) {
 		t.Errorf("Case B: expected BARENAME_ACTIVE=1 (mapping dir on PATH); got:\n%s", outB)
 	}
 }
+
+// TestHookRelativePathCapturedWhenGateOff is the regression for invoking a
+// mapped file by a relative path with a slash (e.g. `test/run.sh`). Such a
+// token is a pathname, not a $PATH lookup, so it must be resolved and
+// matched even when __JITENV_BARENAME_ACTIVE is 0 (mappings not on $PATH).
+// Before the fix it fell into the gated bare-name branch and was dropped,
+// while `./test/run.sh` still worked.
+func TestHookRelativePathCapturedWhenGateOff(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	binDir := filepath.Dir(bin)
+	buildHookBinary(t, binDir)
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	// Mapping at dir/proj/run.sh — dir/proj is NOT on $PATH → gate off.
+	scriptMap := filepath.Join(dir, "proj", "run.sh")
+	mkexec(t, scriptMap)
+	cfgPath := writeConfigWithMappings(t, dir, []config.Mapping{
+		{Path: scriptMap, Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}}},
+	})
+
+	// cd into dir, then invoke the mapping by a relative path with a slash.
+	// JITENV_HOOK_DELAY=0 avoids the agent-down countdown on the route.
+	script := fmt.Sprintf(`
+PATH=%q:$PATH
+export JITENV_CONFIG=%q
+export JITENV_HOOK_DEBUG=1
+export JITENV_HOOK_DELAY=0
+eval "$(jitenv hook bash)"
+cd %q
+printf 'BARENAME_ACTIVE=%%s\n' "${__JITENV_BARENAME_ACTIVE:-unset}"
+printf '__RUN__\n' >&2
+proj/run.sh
+printf '__DONE__\n' >&2
+`, binDir, cfgPath, dir)
+	cmd := exec.Command("bash", "--norc", "-c", script)
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\n%s", err, out)
+	}
+	got := string(out)
+	if !strings.Contains(got, "BARENAME_ACTIVE=0") {
+		t.Fatalf("expected gate off (mapping not on PATH); got:\n%s", got)
+	}
+	runPhase := got[strings.Index(got, "__RUN__"):]
+	// The relative-with-slash path must reach is-mapped (resolved as a
+	// pathname), i.e. NOT be dropped by the bare-name gate.
+	if !strings.Contains(runPhase, "candidate cmd=[proj/run.sh]") {
+		t.Errorf("relative path `proj/run.sh` was not captured by the hook (gate dropped it):\n%s", runPhase)
+	}
+	if !strings.Contains(runPhase, "branch=case0") {
+		t.Errorf("relative path `proj/run.sh` resolved but was not routed as mapped (case0):\n%s", runPhase)
+	}
+}

--- a/internal/shell/hook_barename_gate_test.go
+++ b/internal/shell/hook_barename_gate_test.go
@@ -1,0 +1,92 @@
+//go:build !windows
+
+package shell_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// sourceAndProbe sources the rendered bash hook with the given PATH and
+// JITENV_CONFIG, then prints __JITENV_BARENAME_ACTIVE and runs `probeCmd`
+// (a bare command) with JITENV_HOOK_DEBUG on. Returns combined output.
+func sourceAndProbe(t *testing.T, bin, cfgPath, runtimeDir, extraPath, probeCmd string) string {
+	t.Helper()
+	binDir := filepath.Dir(bin)
+	script := fmt.Sprintf(`
+PATH=%q:%q:$PATH
+export JITENV_CONFIG=%q
+export JITENV_HOOK_DEBUG=1
+eval "$(jitenv hook bash)"
+printf 'BARENAME_ACTIVE=%%s\n' "${__JITENV_BARENAME_ACTIVE:-unset}"
+printf '__PROBE__\n' >&2
+%s
+printf '__DONE__\n' >&2
+`, binDir, extraPath, cfgPath, probeCmd)
+	cmd := exec.Command("bash", "--norc", "-c", script)
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+// TestHookBarenameGate verifies #263 (a): the trap's bare-name resolve is
+// gated on whether an anchor is actually reachable via $PATH. For a
+// path/glob mapping that points at a project script NOT on $PATH (the
+// common case — and the one that made WSL2 prompts hang, since the trap
+// would `type -P` every git-prompt command over the /mnt/* 9P dirs),
+// __JITENV_BARENAME_ACTIVE is 0 and the bare-name branch never resolves.
+func TestHookBarenameGate(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	buildHookBinary(t, filepath.Dir(bin))
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	// A bare command on $PATH that stands in for a git-prompt command.
+	toolsDir := filepath.Join(dir, "tools")
+	probe := filepath.Join(toolsDir, "probe")
+	mkexec(t, probe)
+
+	// Case A: path mapping points at a project script whose dir is NOT on
+	// $PATH → no bare command can match → gate off, branch skipped.
+	dirA := filepath.Join(dir, "cfgA")
+	_ = os.MkdirAll(dirA, 0o755)
+	scriptMap := filepath.Join(dir, "proj", "run.sh")
+	mkexec(t, scriptMap)
+	cfgA := writeConfigWithMappings(t, dirA, []config.Mapping{
+		{Path: scriptMap, Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}}},
+	})
+	outA := sourceAndProbe(t, bin, cfgA, runtimeDir, toolsDir, "probe")
+	if !strings.Contains(outA, "BARENAME_ACTIVE=0") {
+		t.Errorf("Case A: expected BARENAME_ACTIVE=0 (mapping dir not on PATH); got:\n%s", outA)
+	}
+	probePhaseA := outA[strings.Index(outA, "__PROBE__"):]
+	if strings.Contains(probePhaseA, "candidate cmd=[probe]") {
+		t.Errorf("Case A: bare command resolved despite no PATH-reachable anchor (the WSL2 hang path):\n%s", probePhaseA)
+	}
+
+	// Case B: path mapping points at a tool INSIDE an on-$PATH dir → a
+	// bare command there can match → gate on.
+	dirB := filepath.Join(dir, "cfgB")
+	_ = os.MkdirAll(dirB, 0o755)
+	binMap := filepath.Join(toolsDir, "probe") // same dir we put on PATH
+	cfgB := writeConfigWithMappings(t, dirB, []config.Mapping{
+		{Path: binMap, Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}}},
+	})
+	outB := sourceAndProbe(t, bin, cfgB, runtimeDir, toolsDir, "true")
+	if !strings.Contains(outB, "BARENAME_ACTIVE=1") {
+		t.Errorf("Case B: expected BARENAME_ACTIVE=1 (mapping dir on PATH); got:\n%s", outB)
+	}
+}

--- a/internal/shell/hook_light_binary_test.go
+++ b/internal/shell/hook_light_binary_test.go
@@ -1,0 +1,138 @@
+//go:build !windows
+
+package shell_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/gv/jitenv/internal/agent"
+	"github.com/gv/jitenv/internal/config"
+)
+
+// buildHookBinary builds cmd/jitenv-hook into dir as "jitenv-hook" so the
+// rendered hook resolves the lightweight binary alongside "jitenv".
+func buildHookBinary(t *testing.T, dir string) string {
+	t.Helper()
+	out := filepath.Join(dir, "jitenv-hook")
+	cmd := exec.Command("go", "build", "-o", out, "../../cmd/jitenv-hook")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build jitenv-hook: %v", err)
+	}
+	return out
+}
+
+// TestLightHookBinaryEndToEnd verifies Approach 1: when jitenv-hook is
+// installed alongside jitenv, the rendered hook bakes its path, and the
+// full intercept path (chpwd + is-mapped + run) flows through the
+// lightweight binary while still fetching injected env from the agent
+// (the heavy binary). Identical behaviour, just the fast spawn.
+func TestLightHookBinaryEndToEnd(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t) // <dir>/jitenv
+	binDir := filepath.Dir(bin)
+	hookBin := buildHookBinary(t, binDir) // <dir>/jitenv-hook
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf 'FOO=%s\\n' \"$FOO\"\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-light")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	key, _ := config.DeriveKeyFromMeta(cfg, pw)
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"my-secret": "from-noop"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: scriptPath, Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "my-secret"}}},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	paths, _ := agent.DefaultPaths()
+
+	// Agent is the heavy binary (it needs the sources).
+	pr, pw2, _ := os.Pipe()
+	daemon := exec.Command(bin, "__agent", "--key-fd=3", "--config="+cfgPath, "--idle=10s")
+	daemon.ExtraFiles = []*os.File{pr}
+	daemon.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	if err := daemon.Start(); err != nil {
+		t.Fatalf("daemon: %v", err)
+	}
+	pr.Close()
+	if _, err := pw2.Write(key); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	pw2.Close()
+	defer func() { _ = daemon.Process.Kill() }()
+
+	cli := agent.NewClient(paths.Socket)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := cli.Status(context.Background()); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Sanity: the rendered hook must bake the jitenv-hook path.
+	snippet, err := exec.Command(bin, "hook", "bash").Output()
+	if err != nil {
+		t.Fatalf("hook bash: %v", err)
+	}
+	if !strings.Contains(string(snippet), hookBin) {
+		t.Fatalf("rendered hook does not reference jitenv-hook %q; snippet:\n%s", hookBin, snippet)
+	}
+
+	// jitenv-hook answers is-mapped directly (no agent needed).
+	ism := exec.Command(hookBin, "is-mapped", scriptPath)
+	ism.Env = append(os.Environ(), "JITENV_CONFIG="+cfgPath)
+	if err := ism.Run(); err != nil {
+		t.Fatalf("jitenv-hook is-mapped on a mapped path should exit 0, got: %v", err)
+	}
+
+	// Full path: source the hook (which uses jitenv-hook) and run the
+	// mapped script by absolute path; the trap routes through
+	// `jitenv-hook run`, which fetches FOO from the agent and execs.
+	cmd := exec.Command("bash", "-c", fmt.Sprintf(
+		`PATH=%q:$PATH
+export JITENV_CONFIG=%q
+eval "$(jitenv hook bash)"
+%q
+`, binDir, cfgPath, scriptPath))
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	if !strings.Contains(string(out), "FOO=from-noop") {
+		t.Fatalf("expected light-binary hook to inject FOO; output:\n%s", out)
+	}
+}

--- a/internal/shell/hook_shortcircuit_test.go
+++ b/internal/shell/hook_shortcircuit_test.go
@@ -1,0 +1,80 @@
+//go:build !windows
+
+package shell_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// TestHookChpwdShortCircuitsInShell verifies #263 part 3: once the
+// per-shell reconcile stamp exists, repeated prompts in the same dir with
+// an unchanged config do NOT spawn `jitenv-hook __chpwd` at all — the
+// short-circuit happens in the shell with builtins. A `cd` (pwd change)
+// must still reconcile. The Go side prints a "jitenv-chpwd:" debug line
+// only when it actually runs, so counting those lines counts forks.
+func TestHookChpwdShortCircuitsInShell(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	binDir := filepath.Dir(bin)
+	buildHookBinary(t, binDir) // jitenv-hook alongside jitenv
+
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	cfgPath := writeConfigWithMappings(t, dir, []config.Mapping{
+		{Path: filepath.Join(dir, "tool"), Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}}},
+	})
+
+	// Source the hook (one load-time reconcile), then drive __jitenv_chpwd
+	// directly several times in the same dir, then after a cd.
+	script := fmt.Sprintf(`
+PATH=%q:$PATH
+export JITENV_CONFIG=%q
+export JITENV_HOOK_DEBUG=1
+eval "$(jitenv hook bash)"
+printf '__AFTER_LOAD__\n' >&2
+__jitenv_chpwd
+__jitenv_chpwd
+__jitenv_chpwd
+printf '__AFTER_SAMEDIR__\n' >&2
+mkdir -p %q/sub && cd %q/sub
+__jitenv_chpwd
+printf '__AFTER_CD__\n' >&2
+`, binDir, cfgPath, dir, dir)
+
+	cmd := exec.Command("bash", "--norc", "-c", script)
+	cmd.Env = append(os.Environ(), "XDG_RUNTIME_DIR="+runtimeDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash run: %v\noutput=%s", err, out)
+	}
+	got := string(out)
+
+	loadIdx := strings.Index(got, "__AFTER_LOAD__")
+	sameIdx := strings.Index(got, "__AFTER_SAMEDIR__")
+	cdIdx := strings.Index(got, "__AFTER_CD__")
+	if loadIdx < 0 || sameIdx < 0 || cdIdx < 0 {
+		t.Fatalf("missing phase markers:\n%s", got)
+	}
+
+	const reconcile = "jitenv-chpwd:"    // Go-side line — printed only on a real fork
+	sameDirPhase := got[loadIdx:sameIdx] // the 3 same-dir calls
+	cdPhase := got[sameIdx:cdIdx]        // the cd + 1 call
+
+	if n := strings.Count(sameDirPhase, reconcile); n != 0 {
+		t.Errorf("same-dir prompts forked __chpwd %d time(s); expected 0 (in-shell short-circuit):\n%s", n, sameDirPhase)
+	}
+	if strings.Count(cdPhase, reconcile) == 0 {
+		t.Errorf("a cd did not reconcile (no __chpwd fork) — the short-circuit is too aggressive:\n%s", cdPhase)
+	}
+}

--- a/internal/shell/render.go
+++ b/internal/shell/render.go
@@ -2,6 +2,9 @@ package shell
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/gv/jitenv/internal/agent"
@@ -47,8 +50,32 @@ func Render(shell string) (string, error) {
 	r := strings.NewReplacer(
 		"{{RuntimeDir}}", quote(paths.Dir),
 		"{{ConfigPath}}", quote(cfgPath),
+		"{{HookBin}}", quote(hookBin()),
 	)
 	return r.Replace(tmpl), nil
+}
+
+// hookBin resolves the binary the shell hook should invoke for the
+// hot-path commands (__chpwd / is-mapped / run). It prefers the
+// lightweight `jitenv-hook` installed alongside the running binary —
+// spawning it costs ~1.5ms vs ~50ms for the full `jitenv` (which links
+// the AWS SDK / net-http graph). When jitenv-hook isn't present (partial
+// install, `go install` of only cmd/jitenv) it falls back to bare
+// `jitenv`, preserving the previous behaviour. A re-`eval` of the hook
+// picks up jitenv-hook once it's installed.
+func hookBin() string {
+	self, err := os.Executable()
+	if err == nil {
+		name := "jitenv-hook"
+		if runtime.GOOS == "windows" {
+			name = "jitenv-hook.exe"
+		}
+		cand := filepath.Join(filepath.Dir(self), name)
+		if st, err := os.Stat(cand); err == nil && !st.IsDir() {
+			return cand
+		}
+	}
+	return "jitenv"
 }
 
 // shellQuote single-quotes a path for safe inclusion in a POSIX shell

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -68,6 +68,30 @@ __jitenv_cfg_path() {
         printf '%s' "$__JITENV_CFG_PATH"
     fi
 }
+# Path/glob match anchors (issue #260). `jitenv __chpwd` writes these to
+# a per-shell sidecar whenever the config changes; the DEBUG trap reads
+# them to decide — with ZERO subprocess forks — whether a resolved
+# command could possibly match a `path`/`glob` mapping. Without this the
+# trap forks `jitenv is-mapped` for every command, e.g. every git-prompt
+# command on every prompt. cwd_glob mappings are NOT anchors — those are
+# served by the wrapper shims in $__JITENV_WRAP_DIR, not this path.
+__JITENV_ANCHORS_FILE="${__JITENV_WRAP_DIR%/bin}/match-anchors"
+declare -A __JITENV_EXACT 2>/dev/null
+declare -a __JITENV_PREFIX 2>/dev/null
+__jitenv_load_anchors() {
+    __JITENV_EXACT=()
+    __JITENV_PREFIX=()
+    [[ -r "$__JITENV_ANCHORS_FILE" ]] || return 0
+    local kind val
+    # IFS=tab so values (absolute paths / prefixes) keep any spaces.
+    while IFS=$'\t' read -r kind val; do
+        case "$kind" in
+            E) __JITENV_EXACT["$val"]=1 ;;
+            P) __JITENV_PREFIX+=("$val") ;;
+        esac
+    done < "$__JITENV_ANCHORS_FILE"
+}
+
 # chpwd hook: bash has no native chpwd, so we drive `jitenv __chpwd`
 # from PROMPT_COMMAND. The Go side compares pwd and the config-file
 # mtime against per-shell sidecar state ($__JITENV_RUNTIME_DIR/shells/
@@ -97,6 +121,9 @@ __jitenv_chpwd() {
     # we don't leak a non-zero status into the user's prompt.
     local rc=$?
     [[ $rc -eq 10 ]] && hash -r 2>/dev/null
+    # Refresh the in-shell anchor cache (cheap: a builtin read of a tiny
+    # file, no fork) so the trap's pre-filter tracks config edits.
+    __jitenv_load_anchors
     __JITENV_LAST_PWD="$PWD"
 }
 # Run once at hook-load time so the wrapper dir is populated before
@@ -155,6 +182,14 @@ __jitenv_debug_trap() {
         *" command_not_found_handle "*|*" command_not_found_handler "*) return 0 ;;
     esac
 
+    # Fast path: with no `path`/`glob` mappings the trap can never route
+    # anything (cwd_glob is handled by the PATH wrappers), so skip all
+    # resolution outright — not even a `type -P`. This is what keeps the
+    # prompt cheap for cwd_glob-only / unmapped configs, where the DEBUG
+    # trap otherwise fired a `jitenv is-mapped` fork for every command
+    # bash runs while drawing the prompt. (issue #260)
+    [[ ${#__JITENV_EXACT[@]} -eq 0 && ${#__JITENV_PREFIX[@]} -eq 0 ]] && return 0
+
     local cmd="$BASH_COMMAND"
     local first_raw; first_raw="${cmd%% *}"
     [[ -z "$first_raw" ]] && return 0
@@ -183,6 +218,24 @@ __jitenv_debug_trap() {
         [[ "$resolved" == "$__JITENV_WRAP_DIR/"* ]] && return 0
     fi
     [[ ! -f "$resolved" ]] && return 0
+
+    # Pre-filter: only spawn `jitenv is-mapped` when this resolved path
+    # could actually match a path/glob mapping — an exact `path` target,
+    # or under some `glob`'s literal prefix. Everything else (the bulk of
+    # what runs, including a git-prompt's /usr/bin commands) returns here
+    # with no fork. `is-mapped` stays the source of truth for whatever
+    # passes; the prefix test is conservative (necessary condition for a
+    # doublestar match), so it can only ever cause an extra fork that
+    # is-mapped then rejects — never a missed injection. (issue #260)
+    if [[ -z "${__JITENV_EXACT[$resolved]:-}" ]]; then
+        local _maybe= _pfx
+        if (( ${#__JITENV_PREFIX[@]} )); then
+            for _pfx in "${__JITENV_PREFIX[@]}"; do
+                [[ "$resolved" == "$_pfx"* ]] && { _maybe=1; break; }
+            done
+        fi
+        [[ -z "$_maybe" ]] && return 0
+    fi
 
     __jitenv_log "candidate cmd=[$cmd] resolved=[$resolved]"
     jitenv is-mapped "$resolved" >/dev/null 2>&1

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -83,9 +83,28 @@ __jitenv_cfg_path() {
 __JITENV_ANCHORS_FILE="${__JITENV_WRAP_DIR%/bin}/match-anchors"
 declare -A __JITENV_EXACT 2>/dev/null
 declare -a __JITENV_PREFIX 2>/dev/null
+# Whether a BARE command could ever resolve (via $PATH) to a mapped file.
+# Recomputed by __jitenv_load_anchors; gates the trap's bare-name branch
+# so it doesn't `type -P` (walk $PATH) when nothing could match. (#263)
+__JITENV_BARENAME_ACTIVE=0
+
+# __jitenv_native_path sets __JITENV_NATIVE_PATH to $PATH with the WSL2
+# Windows mounts (/mnt/*) stripped, so `type -P` in the trap never stats
+# the slow 9P filesystem. path/glob mappings are native-fs files, so a
+# bare command that maps can always still be found. No fork. (#263)
+__jitenv_native_path() {
+    local d IFS=:
+    __JITENV_NATIVE_PATH=
+    for d in $PATH; do
+        case "$d" in /mnt/*) continue ;; esac
+        __JITENV_NATIVE_PATH="${__JITENV_NATIVE_PATH:+$__JITENV_NATIVE_PATH:}$d"
+    done
+}
+
 __jitenv_load_anchors() {
     __JITENV_EXACT=()
     __JITENV_PREFIX=()
+    __JITENV_BARENAME_ACTIVE=0
     [[ -r "$__JITENV_ANCHORS_FILE" ]] || return 0
     local kind val
     # IFS=tab so values (absolute paths / prefixes) keep any spaces.
@@ -95,6 +114,29 @@ __jitenv_load_anchors() {
             P) __JITENV_PREFIX+=("$val") ;;
         esac
     done < "$__JITENV_ANCHORS_FILE"
+
+    # A bare command resolves to <pathdir>/<name>, so it can only match an
+    # exact anchor whose dir is on $PATH, or a glob whose literal prefix
+    # overlaps a $PATH dir. If none do, the trap can skip the bare-name
+    # resolve entirely — that's what keeps a git-prompt cheap on WSL2,
+    # where each `type -P` would otherwise stat ~25 slow /mnt/* (9P) dirs.
+    # /mnt/* entries are ignored here too (mappings are native files). (#263)
+    local d pd p
+    local -A _pd=()
+    local IFS=:
+    for d in $PATH; do
+        case "$d" in /mnt/*) continue ;; esac
+        _pd["$d"]=1
+    done
+    IFS=$' \t\n'
+    for pd in "${!__JITENV_EXACT[@]}"; do
+        [[ -n "${_pd["${pd%/*}"]:-}" ]] && { __JITENV_BARENAME_ACTIVE=1; return 0; }
+    done
+    for p in "${__JITENV_PREFIX[@]}"; do
+        for d in "${!_pd[@]}"; do
+            [[ "$d/" == "$p"* || "$p" == "$d/"* ]] && { __JITENV_BARENAME_ACTIVE=1; return 0; }
+        done
+    done
 }
 
 # chpwd hook: bash has no native chpwd, so we drive `jitenv __chpwd`
@@ -237,10 +279,22 @@ __jitenv_debug_trap() {
     else
         # Bare name → resolve through $PATH so `path`/`glob` mappings fire
         # on PATH-invoked commands too, not just explicit-path ones.
+        # (issue #237)
+        #
+        # Skip entirely unless an anchor is actually reachable via $PATH
+        # (see __jitenv_load_anchors). A bare command can only resolve to a
+        # mapped file whose dir is on $PATH; when none is, resolving here is
+        # pure waste — and on WSL2 `type -P` would stat every /mnt/* (9P)
+        # $PATH entry for each keyword/command a git-prompt runs, which is
+        # what made prompts hang for tens of seconds. (issue #263)
+        [[ ${__JITENV_BARENAME_ACTIVE:-0} -eq 1 ]] || return 0
+        # Resolve through $PATH minus the WSL2 /mnt/* (9P) mounts so even
+        # the active case never stats the slow Windows filesystem.
         # `type -P` only reports a real executable file (skips builtins,
         # aliases, functions, and typos, which yield an empty result →
-        # run normally). (issue #237)
-        resolved="$(builtin type -P -- "$first" 2>/dev/null)"
+        # run normally).
+        __jitenv_native_path
+        resolved="$(PATH="$__JITENV_NATIVE_PATH" builtin type -P -- "$first" 2>/dev/null)"
         [[ -z "$resolved" ]] && return 0
         # If the name resolved to a cwd_glob wrapper, the wrapper shim
         # already calls is-mapped itself — routing it through here too

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -274,7 +274,11 @@ __jitenv_debug_trap() {
     local resolved
     if [[ "$first" = /* ]]; then
         resolved="$first"
-    elif [[ "$first" = ./* || "$first" = ../* ]]; then
+    elif [[ "$first" = */* ]]; then
+        # Any token containing a slash is a pathname (./x, ../x, dir/x,
+        # a/b/c), not a $PATH lookup — resolve it relative to the cwd. This
+        # is NOT gated by the bare-name PATH check below: a relative path
+        # can match a path/glob mapping regardless of $PATH. (issue #237/#263)
         resolved="$(cd "$(dirname "$first")" 2>/dev/null && pwd)/$(basename "$first")"
     else
         # Bare name → resolve through $PATH so `path`/`glob` mappings fire

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -26,6 +26,11 @@ export __JITENV_SESSION_NONCE
 
 __JITENV_RUNTIME_DIR={{RuntimeDir}}
 __JITENV_CFG_PATH={{ConfigPath}}
+# Hot-path binary: the lightweight `jitenv-hook` when installed (≈1.5ms
+# startup), else bare `jitenv` (≈50ms — it links the AWS SDK / net-http
+# graph). Baked by `jitenv hook bash`; __chpwd / is-mapped / run go
+# through it, the once-per-load version check stays on full `jitenv`.
+__JITENV_BIN={{HookBin}}
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 # Recorded so the shim can tell "this shell typed the command" from
 # "an unmapped descendant spawned the wrapped binary"; only the former
@@ -109,7 +114,7 @@ __jitenv_chpwd() {
     # JITENV_HOOK_DEBUG is set). Swallowing stderr here would
     # hide debug diagnostics + a "jitenv: command not found"
     # if the binary ever falls off $PATH mid-session.
-    jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
+    "$__JITENV_BIN" __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
     # Exit 10 means a wrapper was added or removed. Clear bash's
     # command-hash table so the change takes effect immediately: bash
     # caches command→path lookups, so a wrapper added for a command that
@@ -238,7 +243,7 @@ __jitenv_debug_trap() {
     fi
 
     __jitenv_log "candidate cmd=[$cmd] resolved=[$resolved]"
-    jitenv is-mapped "$resolved" >/dev/null 2>&1
+    "$__JITENV_BIN" is-mapped "$resolved" >/dev/null 2>&1
     local rc=$?
     __jitenv_log "is-mapped rc=$rc"
     case "$rc" in
@@ -253,9 +258,10 @@ __jitenv_debug_trap() {
             # so a filename containing `"`, `$`, backtick, or other
             # bash-active characters (legal on Linux) can't break the
             # eval string's quoting (security #123).
-            local quoted_resolved
+            local quoted_resolved quoted_bin
             printf -v quoted_resolved '%q' "$resolved"
-            eval "jitenv run $quoted_resolved$rest"
+            printf -v quoted_bin '%q' "$__JITENV_BIN"
+            eval "$quoted_bin run $quoted_resolved$rest"
             unset __JITENV_REENTRY
             return 1
             ;;

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -109,6 +109,30 @@ __jitenv_chpwd() {
     # startup file (e.g. ~/.profile's `~/.local/bin` prepend) shoved
     # it back (#224).
     __jitenv_ensure_path
+
+    local base="${__JITENV_WRAP_DIR%/bin}"
+    # Per-command injection marker (#182): drop it so the next typed
+    # command re-injects from scratch. The `[[ -e ]]` test is a builtin
+    # (no fork); `rm` only runs right after a mapped command actually set
+    # the marker, never in the steady state.
+    [[ -e "$base/injected" ]] && command rm -f "$base/injected" 2>/dev/null
+
+    # In-shell short-circuit (#263): skip the `jitenv-hook __chpwd` fork
+    # entirely when neither the cwd nor the config changed since our last
+    # reconcile. A single fork/exec is ~17ms on WSL2, so forking every
+    # prompt just to learn "nothing changed" is the dominant prompt cost.
+    # `last-mtime` is the stamp jitenv writes on every reconcile; bash's
+    # `-nt` is whole-second, so a config edit in the SAME wall-second as
+    # the last reconcile is picked up on the next cd rather than the next
+    # prompt (never wrong — a newly added mapping just activates a beat
+    # late). The Go side keeps the authoritative nanosecond check for when
+    # we DO fork. No config / no stamp yet → fall through and fork.
+    local cfg="${JITENV_CONFIG:-$__JITENV_CFG_PATH}"
+    if [[ "$PWD" == "${__JITENV_LAST_PWD-}" && -f "$base/last-mtime" \
+          && ! "$cfg" -nt "$base/last-mtime" ]]; then
+        return 0
+    fi
+
     # No 2>/dev/null on purpose: the chpwd subcommand is silent
     # in normal operation (it only writes to stderr when
     # JITENV_HOOK_DEBUG is set). Swallowing stderr here would
@@ -127,7 +151,8 @@ __jitenv_chpwd() {
     local rc=$?
     [[ $rc -eq 10 ]] && hash -r 2>/dev/null
     # Refresh the in-shell anchor cache (cheap: a builtin read of a tiny
-    # file, no fork) so the trap's pre-filter tracks config edits.
+    # file, no fork) — only after a reconcile, since anchors change only
+    # when the config does.
     __jitenv_load_anchors
     __JITENV_LAST_PWD="$PWD"
 }

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -58,6 +58,27 @@ __jitenv_cfg_path() {
         print -r -- "$__JITENV_CFG_PATH"
     fi
 }
+# Path/glob match anchors (issue #260). See bash.sh for the full
+# rationale: `jitenv __chpwd` writes a per-shell sidecar of the path/glob
+# mapping anchors so the accept-line widget can decide, WITHOUT forking
+# `jitenv is-mapped`, whether a typed command could match. cwd_glob is
+# served by the PATH wrappers, not here.
+__JITENV_ANCHORS_FILE="${__JITENV_WRAP_DIR%/bin}/match-anchors"
+typeset -gA __JITENV_EXACT
+typeset -ga __JITENV_PREFIX
+__jitenv_load_anchors() {
+    __JITENV_EXACT=()
+    __JITENV_PREFIX=()
+    [[ -r "$__JITENV_ANCHORS_FILE" ]] || return 0
+    local kind val
+    while IFS=$'\t' read -r kind val; do
+        case "$kind" in
+            E) __JITENV_EXACT[$val]=1 ;;
+            P) __JITENV_PREFIX+=("$val") ;;
+        esac
+    done < "$__JITENV_ANCHORS_FILE"
+}
+
 # precmd-style hook: fires every time the prompt is about to redraw,
 # including after a cd. The Go side compares pwd and the config-file
 # mtime against per-shell sidecar state ($__JITENV_RUNTIME_DIR/shells/
@@ -79,6 +100,8 @@ __jitenv_chpwd() {
     # assignment resets it so we don't leak a non-zero status.
     local rc=$?
     [[ $rc -eq 10 ]] && rehash
+    # Refresh the in-shell anchor cache (cheap builtin read, no fork).
+    __jitenv_load_anchors
     __JITENV_LAST_PWD="$PWD"
 }
 typeset -ga precmd_functions
@@ -110,6 +133,22 @@ fi
 # Set JITENV_HOOK_DEBUG=1 to log each branch the widget takes.
 __jitenv_log() {
     [[ -n "${JITENV_HOOK_DEBUG:-}" ]] && printf 'jitenv-hook: %s\n' "$*" >&2
+}
+
+# __jitenv_anchor_match returns 0 if the resolved path could match a
+# path/glob mapping (an exact target, or under some glob's literal
+# prefix), so the widget only forks `jitenv is-mapped` for plausible
+# candidates. Empty anchor sets (no path/glob mappings — e.g. cwd_glob
+# only) never match → no fork. Conservative: a prefix hit can only cause
+# an extra is-mapped fork that then declines, never a missed injection.
+# (issue #260)
+__jitenv_anchor_match() {
+    local r="$1" pfx
+    [[ -n "${__JITENV_EXACT[$r]}" ]] && return 0
+    for pfx in "${__JITENV_PREFIX[@]}"; do
+        [[ "$r" == "$pfx"* ]] && return 0
+    done
+    return 1
 }
 
 __jitenv_accept_line() {
@@ -149,7 +188,7 @@ __jitenv_accept_line() {
                 fi
                 ;;
         esac
-        if [[ -n "$resolved" && -f "$resolved" ]]; then
+        if [[ -n "$resolved" && -f "$resolved" ]] && __jitenv_anchor_match "$resolved"; then
             __jitenv_log "candidate cmd=[$BUFFER] resolved=[$resolved]"
             jitenv is-mapped "$resolved" >/dev/null 2>&1
             local rc=$?

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -219,13 +219,12 @@ __jitenv_accept_line() {
         first="${first#\'}"; first="${first%\'}"
         case "$first" in
             /*)        resolved="$first" ;;
-            ./*|../*)
-                # Normalize the same way bash.sh does so zsh and bash
-                # produce identical canonical absolute paths and stay in
-                # sync. The old `${PWD}/${first#./}` only stripped a
-                # leading `./`, so `../foo` became `$PWD/../foo` — an
-                # unnormalized path that won't path-equality-match a
-                # mapping stored in canonical absolute form (issue #245).
+            */*)
+                # Any token containing a slash is a pathname (./x, ../x,
+                # dir/x, a/b/c), not a $PATH lookup — resolve it relative to
+                # the cwd, canonicalized via cd+pwd (issue #245). NOT gated
+                # by the bare-name $PATH check below: a relative path can
+                # match a path/glob mapping regardless of $PATH (#237/#263).
                 resolved="$(cd "$(dirname "$first")" 2>/dev/null && pwd)/$(basename "$first")"
                 ;;
             *)

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -69,9 +69,25 @@ __jitenv_cfg_path() {
 __JITENV_ANCHORS_FILE="${__JITENV_WRAP_DIR%/bin}/match-anchors"
 typeset -gA __JITENV_EXACT
 typeset -ga __JITENV_PREFIX
+# Whether a bare command could resolve (via $PATH) to a mapped file —
+# gates the widget's bare-name `whence -p`. See bash.sh (#263).
+typeset -g __JITENV_BARENAME_ACTIVE=0
+
+# $PATH minus WSL2 Windows mounts (/mnt/*) so the bare-name `whence -p`
+# never stats the slow 9P filesystem. See bash.sh (#263).
+__jitenv_native_path() {
+    local d
+    __JITENV_NATIVE_PATH=
+    for d in "${(s|:|)PATH}"; do
+        case "$d" in /mnt/*) continue ;; esac
+        __JITENV_NATIVE_PATH="${__JITENV_NATIVE_PATH:+$__JITENV_NATIVE_PATH:}$d"
+    done
+}
+
 __jitenv_load_anchors() {
     __JITENV_EXACT=()
     __JITENV_PREFIX=()
+    __JITENV_BARENAME_ACTIVE=0
     [[ -r "$__JITENV_ANCHORS_FILE" ]] || return 0
     local kind val
     while IFS=$'\t' read -r kind val; do
@@ -80,6 +96,24 @@ __jitenv_load_anchors() {
             P) __JITENV_PREFIX+=("$val") ;;
         esac
     done < "$__JITENV_ANCHORS_FILE"
+
+    # See bash.sh: a bare command can only match an exact anchor whose dir
+    # is on $PATH, or a glob whose prefix overlaps a $PATH dir. If none do,
+    # the widget skips the bare-name resolve. /mnt/* ignored. (#263)
+    local d pd p
+    typeset -A _pd
+    for d in "${(s|:|)PATH}"; do
+        case "$d" in /mnt/*) continue ;; esac
+        _pd[$d]=1
+    done
+    for pd in "${(@k)__JITENV_EXACT}"; do
+        if [[ -n "${_pd[${pd:h}]}" ]]; then __JITENV_BARENAME_ACTIVE=1; return 0; fi
+    done
+    for p in "${__JITENV_PREFIX[@]}"; do
+        for d in "${(@k)_pd}"; do
+            if [[ "$d/" == "$p"* || "$p" == "$d/"* ]]; then __JITENV_BARENAME_ACTIVE=1; return 0; fi
+        done
+    done
 }
 
 # precmd-style hook: fires every time the prompt is about to redraw,
@@ -196,17 +230,19 @@ __jitenv_accept_line() {
                 ;;
             *)
                 # Bare name → resolve through $PATH so `path`/`glob`
-                # mappings fire on PATH-invoked commands too, not just
-                # explicit-path ones. `whence -p` reports only a real
-                # executable file (skips builtins, aliases, functions,
-                # and typos, which yield an empty result → run normally).
-                # If it resolves to a cwd_glob wrapper, the wrapper shim
-                # already calls is-mapped itself, so don't double-dispatch
-                # — leave resolved empty and let the wrapper handle it.
-                # (issue #237)
-                resolved="$(whence -p -- "$first" 2>/dev/null)"
-                if [[ "$resolved" == "$__JITENV_WRAP_DIR/"* ]]; then
-                    resolved=""
+                # mappings fire on PATH-invoked commands too (issue #237).
+                # Skip unless an anchor is reachable via $PATH, and resolve
+                # through $PATH minus the WSL2 /mnt/* (9P) mounts — see
+                # bash.sh for the rationale (issue #263). `whence -p`
+                # reports only a real executable file (skips builtins,
+                # aliases, functions, typos → empty → run normally). A
+                # cwd_glob wrapper hit is left empty so the shim handles it.
+                if [[ ${__JITENV_BARENAME_ACTIVE:-0} -eq 1 ]]; then
+                    __jitenv_native_path
+                    resolved="$(PATH="$__JITENV_NATIVE_PATH" whence -p -- "$first" 2>/dev/null)"
+                    if [[ "$resolved" == "$__JITENV_WRAP_DIR/"* ]]; then
+                        resolved=""
+                    fi
                 fi
                 ;;
         esac

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -93,6 +93,24 @@ __jitenv_chpwd() {
     # Keep the wrap dir at the front of PATH even if a downstream
     # startup file (e.g. ~/.zprofile prepends) shoved it back (#224).
     __jitenv_ensure_path
+
+    local base="${__JITENV_WRAP_DIR%/bin}"
+    # Per-command injection marker (#182): builtin test; rm only after a
+    # mapped command actually set it. See bash.sh.
+    [[ -e "$base/injected" ]] && command rm -f "$base/injected" 2>/dev/null
+
+    # In-shell short-circuit (#263): skip the fork when neither cwd nor
+    # config changed since the last reconcile. A fork/exec is ~17ms on
+    # WSL2, so forking every prompt to learn "nothing changed" is the main
+    # prompt cost. `-nt` is whole-second; a same-wall-second config edit
+    # is caught on the next cd, not the next prompt (never wrong). See
+    # bash.sh for the full rationale.
+    local cfg="${JITENV_CONFIG:-$__JITENV_CFG_PATH}"
+    if [[ "$PWD" == "${__JITENV_LAST_PWD-}" && -f "$base/last-mtime" \
+          && ! "$cfg" -nt "$base/last-mtime" ]]; then
+        return 0
+    fi
+
     # No 2>/dev/null on purpose; see bash.sh for the rationale.
     "$__JITENV_BIN" __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
     # Exit 10 means a wrapper was added or removed → rebuild zsh's
@@ -103,7 +121,8 @@ __jitenv_chpwd() {
     # assignment resets it so we don't leak a non-zero status.
     local rc=$?
     [[ $rc -eq 10 ]] && rehash
-    # Refresh the in-shell anchor cache (cheap builtin read, no fork).
+    # Refresh the in-shell anchor cache (cheap builtin read, no fork) —
+    # only after a reconcile, since anchors change only when config does.
     __jitenv_load_anchors
     __JITENV_LAST_PWD="$PWD"
 }

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -20,6 +20,9 @@ export __JITENV_SESSION_NONCE
 
 __JITENV_RUNTIME_DIR={{RuntimeDir}}
 __JITENV_CFG_PATH={{ConfigPath}}
+# Hot-path binary: lightweight `jitenv-hook` when installed (≈1.5ms
+# startup), else bare `jitenv`. See bash.sh for the rationale.
+__JITENV_BIN={{HookBin}}
 export __JITENV_WRAP_DIR="$__JITENV_RUNTIME_DIR/shells/$$/bin"
 # See bash.sh — gates env injection in the shim so vars don't leak
 # into children of unmapped commands (issue #52).
@@ -91,7 +94,7 @@ __jitenv_chpwd() {
     # startup file (e.g. ~/.zprofile prepends) shoved it back (#224).
     __jitenv_ensure_path
     # No 2>/dev/null on purpose; see bash.sh for the rationale.
-    jitenv __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
+    "$__JITENV_BIN" __chpwd "$$" "${__JITENV_LAST_PWD-}" "$PWD"
     # Exit 10 means a wrapper was added or removed → rebuild zsh's
     # command hash table so the change takes effect immediately. Without
     # it, a wrapper added for an already-run command stays masked by the
@@ -190,7 +193,7 @@ __jitenv_accept_line() {
         esac
         if [[ -n "$resolved" && -f "$resolved" ]] && __jitenv_anchor_match "$resolved"; then
             __jitenv_log "candidate cmd=[$BUFFER] resolved=[$resolved]"
-            jitenv is-mapped "$resolved" >/dev/null 2>&1
+            "$__JITENV_BIN" is-mapped "$resolved" >/dev/null 2>&1
             local rc=$?
             __jitenv_log "is-mapped rc=$rc"
             case "$rc" in
@@ -203,7 +206,7 @@ __jitenv_accept_line() {
                     # so a filename containing `"`, `$`, backtick, or
                     # other zsh-active characters (legal on Linux/macOS)
                     # can't break BUFFER's quoting (security #123).
-                    BUFFER="jitenv run ${(q+)resolved}$rest"
+                    BUFFER="${(q+)__JITENV_BIN} run ${(q+)resolved}$rest"
                     ;;
                 *)
                     # rc=1 (not mapped) or rc=2 (config unreadable) →

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -4,8 +4,11 @@ $ErrorActionPreference = 'Stop'
 # GitHub and verify its SHA256 before extracting. __URL64__ /
 # __CHECKSUM64__ are rendered at pack time by chocolatey.yml from the
 # published release + its SHA256SUMS asset. Extracting into $toolsDir
-# lets chocolatey's auto-shim put BOTH jitenv.exe and jitenv-tui.exe on
-# PATH (the latter is the re-exec target for `jitenv config`, #182).
+# lets chocolatey's auto-shim put jitenv.exe, jitenv-hook.exe and
+# jitenv-tui.exe on PATH (jitenv-hook is the lightweight hot-path binary
+# the shell hook spawns; jitenv-tui is the re-exec target for
+# `jitenv config`, #182). Whatever .exe files the release zip carries are
+# extracted into $toolsDir and shimmed automatically.
 
 $packageName = 'jitenv'
 $toolsDir    = Split-Path -Parent $MyInvocation.MyCommand.Definition

--- a/packaging/macos/cask-publish.sh
+++ b/packaging/macos/cask-publish.sh
@@ -74,6 +74,7 @@ cask "${CASK_NAME}" do
   homepage "https://github.com/Galvill/jitenv"
 
   binary "jitenv"
+  binary "jitenv-hook"
   binary "jitenv-tui"
 end
 EOF


### PR DESCRIPTION
## Problem

Since #237, the bash DEBUG trap (and zsh accept-line widget) fork `jitenv is-mapped` for **every** resolved command. Under `extdebug` the trap also fires for the commands bash runs inside `PROMPT_COMMAND`, so a **git-prompt turns every prompt into a fork storm** — one `jitenv` process spawn + TOML parse per prompt-internal command, every prompt.

Two earlier attempts were partial and are superseded by this PR:
- the `PROMPT_COMMAND` latch (PR #259) was **fragile** — it only works when the prompt commands sit inside jitenv's bracket; reproduced breaking when the prompt is registered after the hook;
- the narrow "skip when no path/glob mappings" gate only helped configs *without* path/glob mappings.

A user with a `path`/`glob` mapping **and** a git-prompt got nothing from either.

## Real fix

The trap must not spawn a subprocess for commands that **cannot** match. `jitenv __chpwd` (already run every prompt, already config-mtime aware) now writes a per-shell **match-anchors** sidecar: the exact `path` targets plus the **literal directory prefix** of every `glob` (the run before the first wildcard). The hook loads it with a builtin file read (no fork) and, before forking `is-mapped`, checks the resolved path against the anchors **in-shell**:

- no path/glob mappings → anchors empty → trap short-circuits, **no fork**;
- resolved is not an exact target and under no prefix → return, **no fork**;
- plausible match → fork `is-mapped` (still the source of truth).

The literal-prefix test is a *necessary* condition for a doublestar match, so it's **conservative**: it can only ever cause an extra `is-mapped` fork that then declines — **never a missed injection**. This restores the pre-#237 "cheap trap" property for *every* config shape — cwd_glob-only, unmapped, **and `path`/`glob` + a git-prompt** — independent of `PROMPT_COMMAND` structure. cwd_glob interception is unchanged (served by the PATH wrappers, not this path).

## Changes
- `config`: `Index.Anchors()` + `literalPrefix()` (+ unit tests for prefix extraction incl. escaping/brace/class cases).
- `chpwd`: write the `match-anchors` sidecar on the reconcile path (skipped on the short-circuit, so it tracks config edits).
- `bash`/`zsh` hooks: load anchors in `__chpwd`; pre-filter before `is-mapped`.
- e2e: no fork for commands outside every anchor; fork only on a plausible (under-prefix) match; zero forks at all with no path/glob mappings.

## Verification
- Manual repro: with no path/glob mappings, prompt redraw + interactive both produce **zero** `is-mapped` forks. With a glob mapping, a command outside its prefix produces no fork while one under it does.
- `go test ./...` green; `go vet ./...` clean; full `internal/shell` + `internal/run` e2e suites pass.

Supersedes the `PROMPT_COMMAND` latch in PR #259.
Closes #260