### PR TITLE
fix(agent): configurable spawn timeout + clearer locked-agent countdown copy

### DIFF
--- a/docs/shell-hook.md
+++ b/docs/shell-hook.md
@@ -64,8 +64,9 @@ bug:
 `jitenv is-mapped` reads the config file directly and never contacts
 the agent, so an exit code 2 always means the on-disk config is
 missing or malformed. The agent-unreachable UX (a red countdown with
-**Press [u] to unlock and inject, [Enter] to continue without env,
-[Ctrl+C] to abort**) lives inside `jitenv run` and the cwd_glob shim —
+**Press [u] to enter the passphrase and unlock. Any other key continues
+without injecting; [Ctrl+C] aborts**) lives inside `jitenv run` and the
+cwd_glob shim —
 see `internal/agentwarn/agentwarn.go`. It only fires *after*
 `is-mapped` returned 0 and `jitenv run` then failed to reach the
 agent.
@@ -73,8 +74,9 @@ agent.
 If you press **`u`**, jitenv runs the unlock flow inline: it prompts
 for your passphrase, starts the agent in the background, re-fetches
 the env vars, and only then execs your command — so the mapped
-command *is* injected, without you leaving the prompt. **Enter**
-continues the command with no env injection; **Ctrl+C** aborts it.
+command *is* injected, without you leaving the prompt. **Any other key**
+(Enter, Space, …) continues the command with no env injection;
+**Ctrl+C** aborts it.
 The inline-unlock option is offered only on a real TTY; piped or
 non-interactive invocations skip the countdown entirely (the warning
 line still prints once so the failure is visible in logs).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,13 +12,17 @@ three options at the countdown prompt without leaving the command:
 - **`u`** — unlock inline. jitenv prompts for your passphrase, starts
   the agent in the background, re-fetches the env vars, and execs your
   command *with* them injected. This is the fast path.
-- **Enter** — continue the command now, with no env injection.
+- **Any other key** (Enter, Space, …) — continue the command now, with
+  no env injection.
 - **Ctrl+C** — abort the command.
 
-Or just run `jitenv unlock` ahead of time. If unlock itself fails
-with "agent did not start within 3s", read the agent log — by
-default it's at `${XDG_RUNTIME_DIR}/jitenv/agent.log`, and at
-`/tmp/jitenv-<uid>/agent.log` if `XDG_RUNTIME_DIR` is unset.
+Or just run `jitenv unlock` ahead of time. If unlock (or the inline
+`[u]` flow) fails with "agent did not start within 10s", the child
+agent's first config read + decrypt + listen didn't finish in time —
+common on slow disks such as WSL2 9P mounts. Raise the ceiling with
+`JITENV_AGENT_SPAWN_TIMEOUT` (a Go duration, e.g. `20s`), then read the
+agent log — by default it's at `${XDG_RUNTIME_DIR}/jitenv/agent.log`,
+and at `/tmp/jitenv-<uid>/agent.log` if `XDG_RUNTIME_DIR` is unset.
 
 To temporarily silence the warning while you debug, `JITENV_HOOK_DELAY=0`
 in the shell. The inline `[u]` prompt is only offered on a real TTY;

--- a/e2e/scenarios/locked-agent-warning.yaml
+++ b/e2e/scenarios/locked-agent-warning.yaml
@@ -3,7 +3,7 @@ description: |
   Exercises the two "agent unavailable" UX paths:
 
     1. `jitenv run` against a mapped script with no running agent. The
-       Go-side WarnAndWait prints the red "agent is not loaded" line on
+       Go-side WarnAndWait prints the red "jitenv is locked" line on
        stderr, suppresses the interactive countdown because stdin is
        not a TTY under `docker exec -T`, then executes the script with
        the parent env (no injected vars). Exit code is the script's.
@@ -66,7 +66,7 @@ steps:
   - name: assert-run-exit-ok
     assert_exit_code: 0
   - name: assert-warning-printed
-    assert_stderr_contains: "agent is not loaded"
+    assert_stderr_contains: "jitenv is locked"
   - name: assert-script-ran
     assert_stdout_contains: "ran=ok"
   - name: assert-no-injection

--- a/internal/agent/daemonize.go
+++ b/internal/agent/daemonize.go
@@ -3,9 +3,29 @@ package agent
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/gv/jitenv/internal/crypto"
 )
+
+// defaultSpawnTimeout is how long SpawnDaemon waits for the freshly
+// spawned agent to bind its socket before giving up. It matches the
+// default countdown length (JITENV_HOOK_DELAY, 10s) so the inline-unlock
+// flow in agentwarn has room to complete on slow disks (issue #264).
+const defaultSpawnTimeout = 10 * time.Second
+
+// spawnTimeout returns how long to wait for the agent socket to appear.
+// Operators on slow-disk environments (e.g. WSL2 9P mounts) can raise it
+// via JITENV_AGENT_SPAWN_TIMEOUT, parsed as a Go duration (e.g. "20s").
+// An empty value or a parse error falls back to defaultSpawnTimeout.
+func spawnTimeout() time.Duration {
+	if v := os.Getenv("JITENV_AGENT_SPAWN_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultSpawnTimeout
+}
 
 // SpawnDaemon re-execs the current binary as a detached agent process,
 // passing the derived key over an inherited pipe. It returns once the

--- a/internal/agent/daemonize_unix.go
+++ b/internal/agent/daemonize_unix.go
@@ -81,7 +81,8 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 	pw.Close()
 
 	// Wait for the socket to appear, indicating Listen succeeded.
-	deadline := time.Now().Add(3 * time.Second)
+	timeout := spawnTimeout()
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(paths.Socket); err == nil {
 			// Detach from the child completely.
@@ -95,5 +96,7 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 		time.Sleep(50 * time.Millisecond)
 	}
 	_ = cmd.Process.Kill()
-	return errors.New("agent did not start within 3s; check ${XDG_RUNTIME_DIR}/jitenv/agent.log")
+	return fmt.Errorf("agent did not start within %s "+
+		"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
+		"check ${XDG_RUNTIME_DIR}/jitenv/agent.log", timeout)
 }

--- a/internal/agent/daemonize_windows.go
+++ b/internal/agent/daemonize_windows.go
@@ -112,7 +112,8 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 	// has bound its listener. Unlike Unix where the socket is a file on
 	// disk and os.Stat suffices, Windows pipes live in a separate
 	// namespace — the only reliable "is it up?" check is to dial it.
-	deadline := time.Now().Add(3 * time.Second)
+	timeout := spawnTimeout()
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		conn, derr := dialAgent(ctx, paths.Socket, 200*time.Millisecond)
@@ -128,5 +129,7 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 		time.Sleep(50 * time.Millisecond)
 	}
 	_ = cmd.Process.Kill()
-	return errors.New("agent did not start within 3s; check the agent log under %LOCALAPPDATA%\\jitenv\\agent.log")
+	return fmt.Errorf("agent did not start within %s "+
+		"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
+		"check the agent log under %%LOCALAPPDATA%%\\jitenv\\agent.log", timeout)
 }

--- a/internal/agent/spawn_timeout_test.go
+++ b/internal/agent/spawn_timeout_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSpawnTimeout exercises the JITENV_AGENT_SPAWN_TIMEOUT knob added in
+// issue #264: a valid duration overrides the default, while an empty,
+// unparseable, zero, or negative value falls back to the 10s default.
+func TestSpawnTimeout(t *testing.T) {
+	// An empty value is treated identically to "unset" by the parser, so
+	// it stands in for the unset case (t.Setenv can only set, not unset).
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{name: "empty (unset)", env: "", want: defaultSpawnTimeout},
+		{name: "valid seconds", env: "20s", want: 20 * time.Second},
+		{name: "valid sub-second", env: "1500ms", want: 1500 * time.Millisecond},
+		{name: "unparseable", env: "soon", want: defaultSpawnTimeout},
+		{name: "bare number rejected", env: "5", want: defaultSpawnTimeout},
+		{name: "zero falls back", env: "0s", want: defaultSpawnTimeout},
+		{name: "negative falls back", env: "-3s", want: defaultSpawnTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("JITENV_AGENT_SPAWN_TIMEOUT", tc.env)
+			if got := spawnTimeout(); got != tc.want {
+				t.Fatalf("spawnTimeout() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSpawnTimeoutDefault is a focused check that the default matches the
+// 10s countdown ceiling the inline-unlock flow relies on (#264).
+func TestSpawnTimeoutDefault(t *testing.T) {
+	if defaultSpawnTimeout != 10*time.Second {
+		t.Fatalf("defaultSpawnTimeout = %s, want 10s", defaultSpawnTimeout)
+	}
+}

--- a/internal/agentwarn/agentwarn.go
+++ b/internal/agentwarn/agentwarn.go
@@ -1,4 +1,4 @@
-// Package agentwarn renders the "agent is not loaded" countdown
+// Package agentwarn renders the "jitenv is locked" countdown
 // shared by the path-mapped runner (jitenv run) and the cwd_glob shim.
 //
 // During the countdown the user can:
@@ -6,7 +6,8 @@
 //	u        → caller drops the countdown and runs the unlock flow,
 //	           then re-fetches env so the mapped command IS injected.
 //	wait     → caller proceeds with the parent environment.
-//	Enter    → caller proceeds immediately, no further wait.
+//	any key  → caller proceeds immediately, no further wait (any
+//	           non-`u`, non-Ctrl+C key counts as continue).
 //	Ctrl+C   → caller aborts; nothing runs.
 //
 // JITENV_HOOK_DELAY (default 10) controls the wait length to match
@@ -34,7 +35,7 @@ type Action int
 
 const (
 	// ActionContinue: run the command without injected env (the user
-	// pressed Enter / any non-`u` key, or the countdown timed out).
+	// pressed any non-`u`, non-Ctrl+C key, or the countdown timed out).
 	ActionContinue Action = iota
 	// ActionAbort: the user pressed Ctrl+C; the caller must not exec.
 	ActionAbort
@@ -65,16 +66,17 @@ func WarnAndWait(target string) Action {
 
 	if !stdinIsTTY() {
 		fmt.Fprintf(os.Stderr,
-			"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
+			"%sjitenv is locked — env vars for %q will NOT be injected.%s\n",
 			red, target, reset)
 		return ActionContinue
 	}
 
 	fmt.Fprintf(os.Stderr,
-		"%sjitenv agent is not loaded — env vars for %q will NOT be set.%s\n",
+		"%sjitenv is locked — env vars for %q will NOT be injected.%s\n",
 		red, target, reset)
 	fmt.Fprintf(os.Stderr,
-		"%sPress [u] to unlock and inject, [Enter] to continue without env, [Ctrl+C] to abort.%s\n",
+		"%sPress [u] to enter the passphrase and unlock. "+
+			"Any other key continues without injecting; [Ctrl+C] aborts.%s\n",
 		red, reset)
 
 	if total == 0 {
@@ -102,45 +104,35 @@ func WarnAndWait(target string) Action {
 		defer restore()
 	}
 
-	// Drain stdin in a goroutine; report the first decisive keystroke.
-	// `u`/`U` → unlock, newline → continue, Ctrl+C (0x03) → abort. We
-	// don't tear it down at return time: on the continue/abort paths
-	// the caller is about to syscall.Exec (which replaces the process
-	// image and reaps the goroutine for free), and on the unlock path
-	// WarnAndWait returns before the passphrase prompt opens — the
-	// single outstanding Read has already consumed the keystroke, so it
-	// can't steal a byte from the subsequent term.ReadPassword on the
-	// same TTY.
+	// Drain stdin in a goroutine; report the first keystroke. `u`/`U` →
+	// unlock, Ctrl+C (0x03) → abort, and ANY other byte → continue (so
+	// Enter, Space, or a stray key all mean "run without env" — the
+	// prompt advertises exactly these semantics). We don't tear it down
+	// at return time: on the continue/abort paths the caller is about to
+	// syscall.Exec (which replaces the process image and reaps the
+	// goroutine for free), and on the unlock path WarnAndWait returns
+	// before the passphrase prompt opens — the single outstanding Read
+	// has already consumed the keystroke, so it can't steal a byte from
+	// the subsequent term.ReadPassword on the same TTY.
 	keyCh := make(chan Action, 1)
 	go func() {
 		buf := make([]byte, 1)
-		for {
-			n, err := os.Stdin.Read(buf)
-			if err != nil || n == 0 {
-				return
-			}
-			switch buf[0] {
-			case 'u', 'U':
-				select {
-				case keyCh <- ActionUnlock:
-				default:
-				}
-				return
-			case 0x03: // Ctrl+C in raw mode (no SIGINT is raised)
-				select {
-				case keyCh <- ActionAbort:
-				default:
-				}
-				return
-			case '\n', '\r':
-				select {
-				case keyCh <- ActionContinue:
-				default:
-				}
-				return
-			}
-			// Any other key: keep reading until a decisive keystroke,
-			// the countdown elapses, or stdin closes.
+		n, err := os.Stdin.Read(buf)
+		if err != nil || n == 0 {
+			return
+		}
+		var act Action
+		switch buf[0] {
+		case 'u', 'U':
+			act = ActionUnlock
+		case 0x03: // Ctrl+C in raw mode (no SIGINT is raised)
+			act = ActionAbort
+		default: // Enter, Space, or any other key
+			act = ActionContinue
+		}
+		select {
+		case keyCh <- act:
+		default:
 		}
 	}()
 

--- a/internal/agentwarn/agentwarn_test.go
+++ b/internal/agentwarn/agentwarn_test.go
@@ -1,7 +1,10 @@
 package agentwarn
 
 import (
+	"bytes"
+	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -112,4 +115,98 @@ func TestWarnAndWait_EnterKey(t *testing.T) {
 		t.Fatal("WarnAndWait did not return on Enter before the countdown elapsed")
 	}
 	w.Close()
+}
+
+// TestWarnAndWait_AnyOtherKeyContinues: per issue #264 the prompt now
+// advertises "any other key continues", so a non-`u`, non-Ctrl+C byte
+// (here a plain letter) must yield ActionContinue immediately instead of
+// looping until Enter / the countdown elapses.
+func TestWarnAndWait_AnyOtherKeyContinues(t *testing.T) {
+	t.Setenv("JITENV_HOOK_DELAY", "10")
+
+	for _, key := range []string{"x", " ", "q"} {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("pipe: %v", err)
+		}
+		withStdin(t, r)
+
+		if _, err := w.WriteString(key); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		done := make(chan Action, 1)
+		go func() { done <- WarnAndWait("/some/script.sh") }()
+
+		select {
+		case act := <-done:
+			if act != ActionContinue {
+				t.Fatalf("key %q: expected ActionContinue, got %v", key, act)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("key %q: WarnAndWait did not return before the countdown elapsed", key)
+		}
+		w.Close()
+		r.Close()
+	}
+}
+
+// TestWarnAndWait_PromptCopy asserts the #264 wording: the warning line
+// says jitenv is "locked" and the prompt names the [u] / any-other-key /
+// [Ctrl+C] options.
+func TestWarnAndWait_PromptCopy(t *testing.T) {
+	t.Setenv("JITENV_HOOK_DELAY", "10")
+
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	defer inR.Close()
+	withStdin(t, inR)
+
+	// Capture stderr for the duration of the call.
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	prevStderr := os.Stderr
+	os.Stderr = errW
+	t.Cleanup(func() { os.Stderr = prevStderr })
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, errR)
+		captured <- buf.String()
+	}()
+
+	// Continue immediately so the call returns without waiting.
+	if _, err := inW.WriteString("\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	done := make(chan Action, 1)
+	go func() { done <- WarnAndWait("/some/script.sh") }()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("WarnAndWait did not return before the countdown elapsed")
+	}
+	inW.Close()
+	errW.Close()
+	os.Stderr = prevStderr
+
+	out := <-captured
+	for _, want := range []string{
+		"jitenv is locked",
+		"will NOT be injected",
+		"Press [u] to enter the passphrase and unlock",
+		"Any other key continues without injecting",
+		"[Ctrl+C] aborts",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("prompt copy missing %q\nfull output:\n%s", want, out)
+		}
+	}
 }

--- a/internal/run/inline_unlock_e2e_test.go
+++ b/internal/run/inline_unlock_e2e_test.go
@@ -125,7 +125,7 @@ func TestRunInlineUnlock(t *testing.T) {
 		return false
 	}
 
-	if !waitFor("Press [u] to unlock", 5*time.Second) {
+	if !waitFor("Press [u] to enter the passphrase", 5*time.Second) {
 		t.Fatalf("never saw the inline-unlock prompt;\noutput=%s", readAll())
 	}
 

--- a/internal/run/inline_unlock_e2e_test.go
+++ b/internal/run/inline_unlock_e2e_test.go
@@ -99,13 +99,13 @@ func TestRunInlineUnlock(t *testing.T) {
 	mu <- ""
 	go func() {
 		buf := make([]byte, 4096)
-		acc := ""
+		var acc strings.Builder
 		for {
 			n, rerr := ptmx.Read(buf)
 			if n > 0 {
-				acc += string(buf[:n])
+				acc.Write(buf[:n])
 				<-mu
-				mu <- acc
+				mu <- acc.String()
 			}
 			if rerr != nil {
 				return

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -45,10 +45,10 @@ const (
 //
 // When the agent is unreachable (locked, never started, …), the
 // command isn't refused: the user gets the same agent-down countdown
-// the shim uses ("Press [u] to unlock and inject, [Enter] to continue
-// without env, [Ctrl+C] to abort"). Pressing `u` runs the inline
-// unlock flow and re-fetches env so the command IS injected; Enter /
-// timeout runs the script with the parent env. This is what the bash
+// the shim uses ("Press [u] to enter the passphrase and unlock. Any
+// other key continues without injecting; [Ctrl+C] aborts."). Pressing
+// `u` runs the inline unlock flow and re-fetches env so the command IS
+// injected; any other key / timeout runs the script with the parent env. This is what the bash
 // hook used to paint inline; moving it here means `jitenv run`'s
 // behaviour is consistent whether it was invoked by the hook, by hand,
 // or by another tool.
@@ -199,7 +199,9 @@ func fetchOrWarn(ctx context.Context, socket, abs string) (map[string]string, bo
 func fetchAfterUnlock(ctx context.Context, abs string) (map[string]string, bool, error) {
 	res, err := unlock.Spawn("")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "jitenv: unlock failed (%v) — running without injected env.\n", err)
+		fmt.Fprintf(os.Stderr,
+			"jitenv: unlock failed (%v) — running without injected env. "+
+				"On slow disks, raise JITENV_AGENT_SPAWN_TIMEOUT (e.g. 20s).\n", err)
 		return nil, false, nil
 	}
 	cli := agent.NewClient(res.Socket)

--- a/internal/run/run_e2e_test.go
+++ b/internal/run/run_e2e_test.go
@@ -557,7 +557,7 @@ func TestRunRespectsInjectedMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run: %v\nstderr=%s", err, stderr.String())
 	}
-	if strings.Contains(stderr.String(), "agent is not loaded") {
+	if strings.Contains(stderr.String(), "jitenv is locked") {
 		t.Fatalf("agent-down warning fired despite matching marker; stderr=%q", stderr.String())
 	}
 	if strings.Contains(stderr.String(), "jitenv: injected") {
@@ -596,7 +596,7 @@ func TestRunRejectsStaleInjectedMarker(t *testing.T) {
 	_, _ = cmd.Output()
 	// Without the nonce, the marker is invalid. run.go must attempt to
 	// reach the agent and surface the down-warning when it isn't there.
-	if !strings.Contains(stderr.String(), "agent is not loaded") {
+	if !strings.Contains(stderr.String(), "jitenv is locked") {
 		t.Errorf("expected agent-down warning (stale marker should NOT bypass); stderr=%q", stderr.String())
 	}
 }

--- a/internal/shell/cwd_path_change_e2e_test.go
+++ b/internal/shell/cwd_path_change_e2e_test.go
@@ -370,7 +370,7 @@ fakecmd
 	if !strings.Contains(lk, "fakecmd") {
 		t.Errorf("locked: expected the fakecmd wrapper to be built without an agent; got:\n%s", lk)
 	}
-	if !strings.Contains(lk, "agent is not loaded") {
+	if !strings.Contains(lk, "jitenv is locked") {
 		t.Errorf("locked: expected the agent-down warning; got:\n%s", lk)
 	}
 	if !strings.Contains(lk, "FOO=MISSING") {

--- a/internal/shell/hook_e2e_test.go
+++ b/internal/shell/hook_e2e_test.go
@@ -176,8 +176,8 @@ eval "$(%s/jitenv hook bash)"
 		t.Fatalf("bash run: %v\noutput=%s", err, out)
 	}
 	got := string(out)
-	if !strings.Contains(got, "agent is not loaded") {
-		t.Errorf("expected red 'agent is not loaded' warning; got:\n%s", got)
+	if !strings.Contains(got, "jitenv is locked") {
+		t.Errorf("expected red 'jitenv is locked' warning; got:\n%s", got)
 	}
 	if !strings.Contains(got, "RAN") {
 		t.Errorf("expected the script to still run; got:\n%s", got)
@@ -249,7 +249,7 @@ eval "$(%s/jitenv hook bash)"
 		t.Fatalf("bash run: %v\noutput=%s", err, out)
 	}
 	got := string(out)
-	if strings.Contains(got, "agent is not loaded") {
+	if strings.Contains(got, "jitenv is locked") {
 		t.Errorf("expected NO warning for unmapped script; got:\n%s", got)
 	}
 	if !strings.Contains(got, "UNMAPPED-RAN") {
@@ -308,7 +308,7 @@ xyzfdsa-typo
 	out, _ := cmd.CombinedOutput()
 	elapsed := time.Since(start)
 	got := string(out)
-	if strings.Contains(got, "agent is not loaded") {
+	if strings.Contains(got, "jitenv is locked") {
 		t.Errorf("hook leaked the agent-down warning for command_not_found_handle; got:\n%s", got)
 	}
 	if elapsed > 500*time.Millisecond {

--- a/internal/shell/hook_unlock_lock_test.go
+++ b/internal/shell/hook_unlock_lock_test.go
@@ -124,10 +124,10 @@ echo '--- step 4 (agent down) ---'
 	if !strings.Contains(step2, "FOO=value-from-noop") {
 		t.Errorf("step 2: expected env to be injected; got:\n%s", step2)
 	}
-	if strings.Contains(step2, "agent is not loaded") {
+	if strings.Contains(step2, "jitenv is locked") {
 		t.Errorf("step 2: did not expect the warning while agent is up; got:\n%s", step2)
 	}
-	if !strings.Contains(step4, "agent is not loaded") {
+	if !strings.Contains(step4, "jitenv is locked") {
 		t.Errorf("step 4: expected the agent-down warning; got:\n%s", step4)
 	}
 	if !strings.Contains(step4, "FOO=MISSING") {

--- a/internal/shell/hook_wrapper_test.go
+++ b/internal/shell/hook_wrapper_test.go
@@ -332,8 +332,8 @@ fakecmd
 		t.Fatalf("bash run: %v\noutput=%s", err, out)
 	}
 	got := string(out)
-	if !strings.Contains(got, "agent is not loaded") {
-		t.Errorf("expected red 'agent is not loaded' warning; got:\n%s", got)
+	if !strings.Contains(got, "jitenv is locked") {
+		t.Errorf("expected red 'jitenv is locked' warning; got:\n%s", got)
 	}
 	if !strings.Contains(got, "RAN") {
 		t.Errorf("expected fakecmd to still run; got:\n%s", got)

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -519,7 +519,9 @@ func fetchEnv(cmd string) (map[string]string, error) {
 func fetchAfterUnlock(cmd string) (map[string]string, error) {
 	res, err := unlock.Spawn("")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "jitenv: unlock failed (%v) — running without injected env.\n", err)
+		fmt.Fprintf(os.Stderr,
+			"jitenv: unlock failed (%v) — running without injected env. "+
+				"On slow disks, raise JITENV_AGENT_SPAWN_TIMEOUT (e.g. 20s).\n", err)
 		return nil, err
 	}
 	pwd, err := os.Getwd()

--- a/internal/shim/shim_test.go
+++ b/internal/shim/shim_test.go
@@ -112,8 +112,8 @@ func TestShimSuppressesWarningWithMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first run: %v\noutput=%s", err, out1)
 	}
-	if !strings.Contains(out1, "agent is not loaded") {
-		t.Errorf("first run: expected 'agent is not loaded' warning;\noutput=%s", out1)
+	if !strings.Contains(out1, "jitenv is locked") {
+		t.Errorf("first run: expected 'jitenv is locked' warning;\noutput=%s", out1)
 	}
 	if !strings.Contains(out1, "RAN") {
 		t.Errorf("first run: expected fakecmd to exec ('RAN');\noutput=%s", out1)
@@ -124,7 +124,7 @@ func TestShimSuppressesWarningWithMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second run: %v\noutput=%s", err, out2)
 	}
-	if strings.Contains(out2, "agent is not loaded") {
+	if strings.Contains(out2, "jitenv is locked") {
 		t.Errorf("second run: warning fired despite __JITENV_AGENT_WARNED=1;\noutput=%s", out2)
 	}
 	if !strings.Contains(out2, "RAN") {
@@ -213,7 +213,7 @@ func TestShimSuppressesInjectionWithMarker(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run: %v\noutput=%s", err, out)
 	}
-	if strings.Contains(out, "agent is not loaded") {
+	if strings.Contains(out, "jitenv is locked") {
 		t.Errorf("warning fired despite matching marker; output=%s", out)
 	}
 	if strings.Contains(out, "jitenv: injected") {
@@ -312,7 +312,7 @@ func TestShimRecoversWrapDirFromPath(t *testing.T) {
 	}
 	out := buf.String()
 
-	if strings.Contains(out, "agent is not loaded") {
+	if strings.Contains(out, "jitenv is locked") {
 		t.Errorf("warning fired despite recoverable wrap dir + marker file; output=%s", out)
 	}
 	if strings.Contains(out, "jitenv: injected") {
@@ -396,7 +396,7 @@ func TestShimSuppressesInjectionViaMarkerFile(t *testing.T) {
 	}
 	out := buf.String()
 
-	if strings.Contains(out, "agent is not loaded") {
+	if strings.Contains(out, "jitenv is locked") {
 		t.Errorf("warning fired despite marker file; output=%s", out)
 	}
 	if strings.Contains(out, "jitenv: injected") {
@@ -475,7 +475,7 @@ func TestShimWarnPathWritesMarkerFile(t *testing.T) {
 		t.Fatalf("run: %v\noutput=%s", err, buf.String())
 	}
 	out := buf.String()
-	if !strings.Contains(out, "agent is not loaded") {
+	if !strings.Contains(out, "jitenv is locked") {
 		t.Errorf("expected agent-down warning;\noutput=%s", out)
 	}
 	if !strings.Contains(out, "RAN") {


### PR DESCRIPTION
Closes #264

## Problem

Running a mapped command while the agent is locked, pressing `u`, and entering the correct passphrase failed with `agent did not start within 3s` and fell through to "run without env". The inline-unlock flow (#232) runs immediately after two back-to-back raw-mode TTY toggles (`WarnAndWait` then `PromptPassphrase`); on a cold disk in WSL2 the child agent's first `config.toml` read + decrypt + `Listen` doesn't fit in the 3s `SpawnDaemon` deadline.

## Changes

**1. Configurable spawn deadline (default 10s).**
- `SpawnDaemon` now waits up to a 10s default (matching the countdown ceiling) instead of 3s, tunable via `JITENV_AGENT_SPAWN_TIMEOUT` (a Go duration, e.g. `20s`). Empty / unparseable / `<= 0` values fall back to the default.
- The env parse is factored into one platform-neutral helper, `spawnTimeout()` in `internal/agent/daemonize.go`, shared by the Unix and Windows paths (no duplication).
- The `cmd.ProcessState != nil` early-exit branch is preserved on both platforms, so a dead child still reports immediately. The timeout error message names the knob.

**2. Clearer countdown copy + "any other key continues".**
- New wording: `jitenv is locked — env vars for "…" will NOT be injected.` / `Press [u] to enter the passphrase and unlock. Any other key continues without injecting; [Ctrl+C] aborts.`
- The keystroke goroutine is collapsed so any non-`u`, non-Ctrl+C byte yields `ActionContinue` (matching what the prompt now advertises). Behavior is unchanged for `u` (unlock) and Ctrl+C (abort).

**3. Self-bump hint + docs.**
- `internal/run/run.go` and `internal/shim/shim.go` unlock-failure hints now mention `JITENV_AGENT_SPAWN_TIMEOUT`.
- `docs/troubleshooting.md` and `docs/shell-hook.md` updated for the new copy + the knob.

## Tests
- `spawn_timeout_test.go`: env-knob table (valid duration, sub-second, unparseable, bare number, zero, negative, empty).
- `agentwarn_test.go`: new "any other key continues" and prompt-copy assertions; existing Enter/unlock cases still pass.
- Updated existing warning-string assertions across `internal/run`, `internal/shell`, `internal/shim`, and the `locked-agent-warning` e2e scenario to the new copy.
- `go test ./...` green except a pre-existing, unrelated failure in `TestBashWrapperReReconcilesOnConfigEdit` (fails on the clean base too) — filed as #265. `go vet` and `golangci-lint` clean. Windows agent cross-compiles.