### PR TITLE
fix(agent): SpawnDaemon re-execs full jitenv, not jitenv-hook (#268)

### DIFF
--- a/internal/agent/daemonize_unix.go
+++ b/internal/agent/daemonize_unix.go
@@ -39,7 +39,7 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 	defer pr.Close()
 	defer pw.Close()
 
-	exe, err := os.Executable()
+	exe, err := resolveAgentExecutable()
 	if err != nil {
 		return err
 	}
@@ -89,14 +89,16 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 			_ = cmd.Process.Release()
 			return nil
 		}
-		// If the child died early, surface that.
+		// If the child died early, surface that — with the tail of the
+		// agent log so the actual child stderr (e.g. a re-exec of the
+		// wrong binary printing `unknown command "__agent"`) is visible.
 		if cmd.ProcessState != nil {
-			return fmt.Errorf("agent exited early: %s", cmd.ProcessState)
+			return fmt.Errorf("agent exited early: %s%s", cmd.ProcessState, logTailSuffix(paths.LogFile))
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	_ = cmd.Process.Kill()
 	return fmt.Errorf("agent did not start within %s "+
 		"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
-		"check ${XDG_RUNTIME_DIR}/jitenv/agent.log", timeout)
+		"check ${XDG_RUNTIME_DIR}/jitenv/agent.log%s", timeout, logTailSuffix(paths.LogFile))
 }

--- a/internal/agent/daemonize_windows.go
+++ b/internal/agent/daemonize_windows.go
@@ -62,7 +62,7 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 		return fmt.Errorf("clear inherit on write end: %w", err)
 	}
 
-	exe, err := os.Executable()
+	exe, err := resolveAgentExecutable()
 	if err != nil {
 		pr.Close()
 		return err
@@ -124,12 +124,12 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 			return nil
 		}
 		if cmd.ProcessState != nil {
-			return fmt.Errorf("agent exited early: %s", cmd.ProcessState)
+			return fmt.Errorf("agent exited early: %s%s", cmd.ProcessState, logTailSuffix(paths.LogFile))
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	_ = cmd.Process.Kill()
 	return fmt.Errorf("agent did not start within %s "+
 		"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
-		"check the agent log under %%LOCALAPPDATA%%\\jitenv\\agent.log", timeout)
+		"check the agent log under %%LOCALAPPDATA%%\\jitenv\\agent.log%s", timeout, logTailSuffix(paths.LogFile))
 }

--- a/internal/agent/resolve_exe.go
+++ b/internal/agent/resolve_exe.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// resolveAgentExecutable returns the path to the binary SpawnDaemon should
+// re-exec as the long-lived `__agent` daemon. It is normally just
+// os.Executable(), but when the currently-running binary is the lightweight
+// `jitenv-hook` (#263) — which deliberately omits the agent/TUI/source graph
+// and has no `__agent` subcommand — it resolves the sibling full `jitenv`
+// binary installed alongside it.
+//
+// This mirrors, in the opposite direction, the resolution in
+// internal/shell/render.go:hookBin, which prefers `jitenv-hook` next to
+// `jitenv` and falls back when missing. Here we prefer `jitenv` next to
+// `jitenv-hook` because only the full binary can serve as the agent.
+//
+// Without this, inline unlock (#264/#268) re-execs jitenv-hook, the child
+// hits its default switch case (`unknown command "__agent"`), exits 2, and
+// the socket-appearance loop times out.
+func resolveAgentExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	base := filepath.Base(exe)
+	if base == "jitenv-hook" || base == "jitenv-hook.exe" {
+		name := "jitenv"
+		if runtime.GOOS == "windows" {
+			name = "jitenv.exe"
+		}
+		cand := filepath.Join(filepath.Dir(exe), name)
+		if _, err := os.Stat(cand); err != nil {
+			return "", fmt.Errorf("inline unlock needs the full jitenv binary alongside jitenv-hook (looked for %s): %w", cand, err)
+		}
+		exe = cand
+	}
+	return exe, nil
+}
+
+// tailLog reads up to the last maxBytes of the file at path and returns it
+// as a trimmed string. It is best-effort: on any error (missing file, read
+// failure) it returns "". Used to surface the child agent's stderr (written
+// to the agent log) in the "agent did not start" error so failures like
+// `unknown command "__agent"` are visible to the caller.
+func tailLog(path string, maxBytes int64) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	size := info.Size()
+	if size > maxBytes {
+		if _, err := f.Seek(size-maxBytes, io.SeekStart); err != nil {
+			return ""
+		}
+	}
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(buf))
+}
+
+// logTailSuffix returns a "\n--- agent log tail ---\n<…>" suffix suitable for
+// appending to a spawn-failure error, or "" when the log is empty/unreadable.
+func logTailSuffix(path string) string {
+	tail := tailLog(path, 2048)
+	if tail == "" {
+		return ""
+	}
+	return "\n--- agent log tail ---\n" + tail
+}

--- a/internal/agent/resolve_exe_test.go
+++ b/internal/agent/resolve_exe_test.go
@@ -1,0 +1,157 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// hookExeName / jitenvExeName mirror the platform-suffix logic in
+// resolveAgentExecutable so the test fakes the right filenames.
+func hookExeName() string {
+	if runtime.GOOS == "windows" {
+		return "jitenv-hook.exe"
+	}
+	return "jitenv-hook"
+}
+
+func jitenvExeName() string {
+	if runtime.GOOS == "windows" {
+		return "jitenv.exe"
+	}
+	return "jitenv"
+}
+
+// withExecutable swaps the package-level os.Executable() result by re-execing
+// the test under the faked binary path. Since os.Executable() reads the real
+// running binary, we instead validate resolveAgentExecutable's path logic by
+// exercising resolveSibling directly via a tiny indirection: we can't easily
+// override os.Executable, so we test the resolution rule by faking the dir
+// layout and asserting on the candidate-selection behaviour through a copy of
+// the running test binary named jitenv-hook.
+
+// TestResolveAgentExecutable_SiblingResolution copies the running test binary
+// to a temp dir as `jitenv-hook`, places a sibling `jitenv`, and runs a
+// subprocess of the hook copy that calls resolveAgentExecutable and prints the
+// result. This exercises the real os.Executable() path.
+func TestResolveAgentExecutable_SiblingResolution(t *testing.T) {
+	if os.Getenv("JITENV_RESOLVE_HELPER") == "1" {
+		// We are the re-execed `jitenv-hook` copy. Run the resolver and
+		// print its outcome for the parent to assert on.
+		exe, err := resolveAgentExecutable()
+		if err != nil {
+			os.Stdout.WriteString("ERR:" + err.Error())
+			os.Exit(0)
+		}
+		os.Stdout.WriteString("OK:" + exe)
+		os.Exit(0)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	data, err := os.ReadFile(self)
+	if err != nil {
+		t.Fatalf("read self: %v", err)
+	}
+
+	t.Run("resolves sibling jitenv", func(t *testing.T) {
+		dir := t.TempDir()
+		hookPath := filepath.Join(dir, hookExeName())
+		jitenvPath := filepath.Join(dir, jitenvExeName())
+		if err := os.WriteFile(hookPath, data, 0o755); err != nil {
+			t.Fatalf("write hook copy: %v", err)
+		}
+		// A real (non-empty) sibling jitenv so os.Stat succeeds.
+		if err := os.WriteFile(jitenvPath, []byte("jitenv"), 0o755); err != nil {
+			t.Fatalf("write sibling jitenv: %v", err)
+		}
+		out := runHelper(t, hookPath)
+		want := "OK:" + jitenvPath
+		if out != want {
+			t.Fatalf("resolved = %q, want %q", out, want)
+		}
+	})
+
+	t.Run("errors when sibling jitenv missing", func(t *testing.T) {
+		dir := t.TempDir()
+		hookPath := filepath.Join(dir, hookExeName())
+		if err := os.WriteFile(hookPath, data, 0o755); err != nil {
+			t.Fatalf("write hook copy: %v", err)
+		}
+		out := runHelper(t, hookPath)
+		if !strings.HasPrefix(out, "ERR:") {
+			t.Fatalf("expected ERR for missing sibling, got %q", out)
+		}
+		if !strings.Contains(out, "full jitenv binary alongside jitenv-hook") {
+			t.Fatalf("error did not mention sibling-jitenv requirement: %q", out)
+		}
+	})
+}
+
+func TestTailLog(t *testing.T) {
+	t.Run("missing file returns empty", func(t *testing.T) {
+		if got := tailLog(filepath.Join(t.TempDir(), "nope.log"), 2048); got != "" {
+			t.Fatalf("tailLog(missing) = %q, want empty", got)
+		}
+	})
+
+	t.Run("small file returned whole and trimmed", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "agent.log")
+		if err := os.WriteFile(p, []byte("  jitenv-hook: unknown command \"__agent\"\n"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got := tailLog(p, 2048)
+		if got != "jitenv-hook: unknown command \"__agent\"" {
+			t.Fatalf("tailLog = %q", got)
+		}
+	})
+
+	t.Run("large file truncated to last maxBytes", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "agent.log")
+		body := strings.Repeat("A", 5000) + "TAIL-MARKER"
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got := tailLog(p, 100)
+		if len(got) > 100 {
+			t.Fatalf("tailLog len = %d, want <= 100", len(got))
+		}
+		if !strings.HasSuffix(got, "TAIL-MARKER") {
+			t.Fatalf("tailLog did not return the tail: %q", got)
+		}
+	})
+
+	t.Run("logTailSuffix wraps non-empty tail", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "agent.log")
+		if err := os.WriteFile(p, []byte("boom"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got := logTailSuffix(p)
+		if !strings.Contains(got, "--- agent log tail ---") || !strings.HasSuffix(got, "boom") {
+			t.Fatalf("logTailSuffix = %q", got)
+		}
+		if empty := logTailSuffix(filepath.Join(t.TempDir(), "absent.log")); empty != "" {
+			t.Fatalf("logTailSuffix(missing) = %q, want empty", empty)
+		}
+	})
+}
+
+// runHelper executes the faked `jitenv-hook` binary (a copy of this test
+// binary) so its os.Executable() reports the hook path, with the env flag set
+// to take the helper branch in TestResolveAgentExecutable_SiblingResolution.
+// It returns the helper's stdout ("OK:<path>" or "ERR:<msg>").
+func runHelper(t *testing.T, hookPath string) string {
+	t.Helper()
+	cmd := exec.Command(hookPath, "-test.run", "TestResolveAgentExecutable_SiblingResolution")
+	cmd.Env = append(os.Environ(), "JITENV_RESOLVE_HELPER=1")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run helper %s: %v (stdout=%q)", hookPath, err, string(out))
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/run/inline_unlock_hook_e2e_test.go
+++ b/internal/run/inline_unlock_hook_e2e_test.go
@@ -1,0 +1,180 @@
+//go:build !windows
+
+package run_test
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/creack/pty"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// buildBothBinaries builds the full `jitenv` and the lightweight
+// `jitenv-hook` into the same directory and returns their paths. The
+// shared directory is what lets SpawnDaemon's sibling-resolution find
+// the full binary next to the hook.
+func buildBothBinaries(t *testing.T) (jitenv, hook string) {
+	t.Helper()
+	dir := t.TempDir()
+	jitenv = filepath.Join(dir, "jitenv")
+	hook = filepath.Join(dir, "jitenv-hook")
+	for src, out := range map[string]string{
+		"../../cmd/jitenv":      jitenv,
+		"../../cmd/jitenv-hook": hook,
+	} {
+		cmd := exec.Command("go", "build", "-o", out, src)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("build %s: %v", src, err)
+		}
+	}
+	return jitenv, hook
+}
+
+// TestRunInlineUnlockFromHookBinary is the issue #268 regression: the
+// lightweight `jitenv-hook` binary (which has no `__agent` subcommand)
+// drives the inline-unlock flow. SpawnDaemon must re-exec the sibling
+// full `jitenv`, not jitenv-hook — otherwise the child dies with
+// `unknown command "__agent"`, the spawn loop times out, and the script
+// runs WITHOUT injected env.
+//
+// We assert the script runs WITH its injected env, proving the freshly
+// spawned agent actually came up. This is the same PTY-driven flow as
+// TestRunInlineUnlock, but invoked through jitenv-hook.
+func TestRunInlineUnlockFromHookBinary(t *testing.T) {
+	jitenvBin, hookBin := buildBothBinaries(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	if err := os.WriteFile(scriptPath,
+		[]byte("#!/bin/sh\nprintf 'A=%s\\n' \"$A\"\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-hook-inline-unlock")
+	if err := config.InitNew(cfgPath, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	off := false
+	cfg.Agent.PreRunNotice = &off
+	cfg.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"a": "from-agent"}},
+	}
+	cfg.Mappings = []config.Mapping{
+		{Path: scriptPath, Vars: []config.VarRef{
+			{Name: "A", Source: "n", Ref: "a"},
+		}},
+	}
+	tmp, _ := os.CreateTemp(dir, "save-*.toml")
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	tmp.Close()
+	if err := os.Rename(tmp.Name(), cfgPath); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	// Empty runtime dir → no agent socket → agent-down countdown.
+	runtimeDir := shortRuntimeDir(t)
+
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_CONFIG="+cfgPath,
+		"JITENV_HOOK_DELAY=10",
+		"TERM=dumb",
+	)
+
+	// Invoke through the lightweight hook binary, exactly as the shell
+	// hook does (#263). The sibling jitenv lives in the same dir.
+	cmd := exec.Command(hookBin, "run", scriptPath)
+	cmd.Env = subprocEnv
+	_ = jitenvBin // present alongside hookBin so SpawnDaemon can resolve it
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty start: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = cmd.Process.Kill() }()
+
+	var mu = make(chan string, 1)
+	mu <- ""
+	go func() {
+		buf := make([]byte, 4096)
+		acc := ""
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				acc += string(buf[:n])
+				<-mu
+				mu <- acc
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	readAll := func() string { s := <-mu; mu <- s; return s }
+
+	waitFor := func(substr string, d time.Duration) bool {
+		deadline := time.Now().Add(d)
+		for time.Now().Before(deadline) {
+			if strings.Contains(readAll(), substr) {
+				return true
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return false
+	}
+
+	if !waitFor("Press [u] to enter the passphrase and unlock", 5*time.Second) {
+		t.Fatalf("never saw the inline-unlock prompt;\noutput=%s", readAll())
+	}
+	if _, err := ptmx.Write([]byte("u")); err != nil {
+		t.Fatalf("write u: %v", err)
+	}
+	if !waitFor("unlock passphrase", 5*time.Second) {
+		t.Fatalf("never saw the passphrase prompt after `u`;\noutput=%s", readAll())
+	}
+	if _, err := ptmx.Write(append(pw, '\n')); err != nil {
+		t.Fatalf("write passphrase: %v", err)
+	}
+
+	// The script must run with the injected env — proving the agent the
+	// hook spawned (via the resolved sibling jitenv) actually came up.
+	if !waitFor("A=from-agent", 15*time.Second) {
+		t.Fatalf("script did not run with injected env after inline unlock via jitenv-hook;\noutput=%s", readAll())
+	}
+
+	// Guard against the exact #268 failure mode leaking through.
+	if strings.Contains(readAll(), `unknown command "__agent"`) {
+		t.Fatalf("SpawnDaemon re-execed jitenv-hook (issue #268);\noutput=%s", readAll())
+	}
+
+	go func() { _, _ = io.Copy(io.Discard, ptmx) }()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("child did not exit;\noutput=%s", readAll())
+	}
+
+	if strings.Contains(readAll(), "running without injected env") {
+		t.Fatalf("inline unlock fell back to no-env path;\noutput=%s", readAll())
+	}
+}


### PR DESCRIPTION
## Summary

Root cause for the inline-unlock failure in #264. `agent.SpawnDaemon` resolved the binary to re-exec with `os.Executable()`. When inline unlock fired from inside the lightweight `jitenv-hook` binary (#263) — which deliberately omits the `__agent` subcommand — `os.Executable()` returned the hook path. The child hit its `default` switch case (`jitenv-hook: unknown command "__agent"`), exited 2 before listening, and the socket-appearance loop timed out. The user saw `agent did not start within 3s` and the mapped command ran without env.

## Changes

- **`resolveAgentExecutable()`** — new platform-neutral helper in the `agent` package that returns `os.Executable()` unless the running binary is `jitenv-hook`/`jitenv-hook.exe`, in which case it resolves the sibling full `jitenv` installed alongside it. Errors clearly when the sibling is missing. Mirrors `internal/shell/render.go:hookBin` in the opposite direction (the hook prefers `jitenv-hook` next to `jitenv`; the agent prefers `jitenv` next to `jitenv-hook`).
- Wired into both `daemonize_unix.go` and `daemonize_windows.go` in place of the raw `os.Executable()` call.
- **Log-tail surfacing** — both spawn-failure errors (`agent exited early` and `agent did not start within 3s`) now append the last ~2KiB of `paths.LogFile` via a shared `logTailSuffix`/`tailLog`, so the real child stderr is visible. The `cmd.ProcessState != nil` early-exit branch is preserved.

## Tests

- `internal/agent/resolve_exe_test.go` — fakes a `jitenv-hook` copy next to a real `jitenv` and asserts the resolver picks the sibling `jitenv`; also covers the missing-sibling error path. `tailLog`/`logTailSuffix` unit tests (missing file, whole-file trim, truncation to last N bytes, suffix wrapping).
- `internal/run/inline_unlock_hook_e2e_test.go` — drives the full inline-unlock flow through `jitenv-hook run <script>` over a PTY (type `u`, then the passphrase) and asserts the freshly spawned agent injects env. Verified to FAIL on the pre-fix code with `--- agent log tail ---\njitenv-hook: unknown command "__agent"` and PASS with the fix.

## Verification

- `go test ./internal/agent/ ./internal/run/` — pass
- `go build ./...` and `GOOS=windows go build ./...` — pass
- `golangci-lint run ./internal/agent/... ./internal/run/...` — clean

## Notes

- Pre-existing, unrelated test failure `TestBashWrapperReReconcilesOnConfigEdit` (consistently fails on this Linux/WSL2 env on a clean checkout, independent of this change) filed as #270 per the don't-expand-scope convention.
- Folding `__agent` into `jitenv-hook` is an explicit non-goal (per #268). The countdown copy and `JITENV_AGENT_SPAWN_TIMEOUT` items noted in #268 are out of scope here.

Closes #268