### PR TITLE
fix(config): keep pre-id-migration backup on disk; surface a one-shot notice (#269)

### DIFF
--- a/internal/cli/bag_import.go
+++ b/internal/cli/bag_import.go
@@ -156,8 +156,12 @@ func runBagImport(cmd *cobra.Command, opts importOpts) error {
 	// One-shot opaque-ID migration (#248) so a legacy config gets the
 	// sealed name_map + backup before we mint a new bag/keys into it,
 	// matching the clone/unlock paths.
-	if err := migrateOpaqueIDsLocked(cfgPath, key); err != nil {
+	migrated, err := migrateOpaqueIDsLocked(cfgPath, key)
+	if err != nil {
 		return err
+	}
+	if migrated {
+		printMigrationNotice(cmd.ErrOrStderr(), cfgPath)
 	}
 	cfg, err = config.Load(cfgPath)
 	if err != nil {

--- a/internal/cli/bag_import_test.go
+++ b/internal/cli/bag_import_test.go
@@ -421,3 +421,46 @@ func TestBagImport_DryRun_OnCollisionAsk_NoTTY(t *testing.T) {
 		t.Errorf("dry-run must not modify the config")
 	}
 }
+
+// TestMigrationNoticeEmittedOnce verifies the #269 contract: when a
+// legacy config is migrated to opaque-ID format during a key-holding
+// command (here, bag import), the one-shot backup notice is printed to
+// stderr exactly once — and a SECOND import (config already migrated)
+// emits no notice, because the migration is idempotent. The notice must
+// name the absolute backup path and warn that the backup holds secrets.
+func TestMigrationNoticeEmittedOnce(t *testing.T) {
+	cfgPath := newLegacyImportTestConfig(t, "prod", "A", "old")
+	backup := cfgPath + config.MigrationBackupSuffix
+
+	// First import triggers the migration → notice fires once.
+	_, errOut, err := runImport(t, "B=2\n", "prod", "--stdin")
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	const marker = "upgraded config to opaque-ID format (#248)"
+	if n := strings.Count(errOut, marker); n != 1 {
+		t.Fatalf("migration notice should fire exactly once, got %d:\n%s", n, errOut)
+	}
+	if !strings.Contains(errOut, backup) {
+		t.Errorf("notice must name the absolute backup path %q, got:\n%s", backup, errOut)
+	}
+	if !strings.Contains(errOut, "do not check it in or sync it") {
+		t.Errorf("notice must warn the backup holds secrets, got:\n%s", errOut)
+	}
+	if _, statErr := os.Stat(backup); statErr != nil {
+		t.Fatalf("backup must exist after migration: %v", statErr)
+	}
+
+	// Second import: config is already migrated, so no notice.
+	_, errOut2, err := runImport(t, "C=3\n", "prod", "--stdin")
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if strings.Contains(errOut2, marker) {
+		t.Errorf("migration notice must NOT re-fire on an already-migrated config, got:\n%s", errOut2)
+	}
+	// And the save from the second import must NOT have removed the backup (#269).
+	if _, statErr := os.Stat(backup); statErr != nil {
+		t.Fatalf("backup must survive subsequent saves (#269): %v", statErr)
+	}
+}

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -100,8 +100,12 @@ func runClone(cmd *cobra.Command, args []string, tokenStdin bool, bagOverride st
 	// One-shot opaque-ID migration (#248) so a legacy config cloned into
 	// gets the sealed name_map + backup like the unlock/TUI paths, rather
 	// than silently migrating on save without a backup.
-	if err := migrateOpaqueIDsLocked(cfgPath, key); err != nil {
+	migrated, err := migrateOpaqueIDsLocked(cfgPath, key)
+	if err != nil {
 		return err
+	}
+	if migrated {
+		printMigrationNotice(cmd.ErrOrStderr(), cfgPath)
 	}
 	cfg, err = config.Load(cfgPath)
 	if err != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -274,17 +275,27 @@ func resolveJitenvTUIPath() (string, error) {
 // "another jitenv process is migrating/editing right now" and surfaced
 // so the user retries rather than proceeding on a possibly-half-written
 // config.
-func migrateOpaqueIDsLocked(cfgPath string, key []byte) error {
+//
+// Returns migrated=true when the on-disk config was rewritten, so the
+// caller can print the one-shot backup notice (printMigrationNotice).
+func migrateOpaqueIDsLocked(cfgPath string, key []byte) (migrated bool, err error) {
 	lock, lockErr := lockfile.Acquire(cfgPath + ".tui.lock")
 	if lockErr != nil {
 		if errors.Is(lockErr, os.ErrExist) {
-			return fmt.Errorf("another jitenv session is editing %s — close it, then retry", cfgPath)
+			return false, fmt.Errorf("another jitenv session is editing %s — close it, then retry", cfgPath)
 		}
-		return fmt.Errorf("acquire config lock for migration: %w", lockErr)
+		return false, fmt.Errorf("acquire config lock for migration: %w", lockErr)
 	}
 	defer lock.Close()
-	_, err := config.MigrateToOpaqueIDs(cfgPath, key)
-	return err
+	return config.MigrateToOpaqueIDs(cfgPath, key)
+}
+
+// printMigrationNotice writes the one-shot post-migration backup notice
+// (#269) to w. Shared by every key-holding CLI surface (unlock, bag
+// import) so the copy — including the absolute backup path and the
+// "don't sync this" warning — stays identical to the TUI's.
+func printMigrationNotice(w io.Writer, cfgPath string) {
+	fmt.Fprintln(w, config.MigrationNotice(cfgPath))
 }
 
 func zeroBytes(b []byte) {

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -47,8 +47,12 @@ func newUnlockCmd() *cobra.Command {
 			// spawned and starts serving. Guarded by the same .tui.lock
 			// the TUI uses so a concurrent `jitenv config` migration can't
 			// race this one.
-			if err := migrateOpaqueIDsLocked(cfgPath, key); err != nil {
+			migrated, err := migrateOpaqueIDsLocked(cfgPath, key)
+			if err != nil {
 				return err
+			}
+			if migrated {
+				printMigrationNotice(cmd.ErrOrStderr(), cfgPath)
 			}
 			// Reload cfg in case migration rewrote it (idle timeout etc.
 			// are unchanged by migration, but read the fresh bytes so the

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -161,19 +161,16 @@ func atomicSave(path string, c *Config) error {
 }
 
 // AtomicSave is the exported variant for callers outside this package
-// (e.g. the TUI). On a successful write it also consumes the pre-#248
-// migration backup escape hatch (#248): the FIRST config-modifying save
-// after a migration unlinks config.toml.pre-id-migration.bak. The
-// migration's own write goes through the unexported atomicSave so it
-// keeps the backup it just created — only the *next* user-facing save
-// removes it. A save that didn't follow a migration simply finds no
-// backup (no-op).
+// (e.g. the TUI). It writes c to a sibling tempfile then renames over
+// path (mode 0600).
+//
+// Unlike earlier behavior (#248), AtomicSave no longer consumes the
+// pre-id-migration backup. The verbatim pre-#248 backup written by
+// MigrateToOpaqueIDs persists on disk until the user removes it
+// themselves (#269) — saving the config no longer silently deletes the
+// only rollback escape hatch.
 func AtomicSave(path string, c *Config) error {
-	if err := atomicSave(path, c); err != nil {
-		return err
-	}
-	removeMigrationBackup(path)
-	return nil
+	return atomicSave(path, c)
 }
 
 func zero(b []byte) {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -5,12 +5,45 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
+// MigrationBackupPath returns the absolute path of the verbatim
+// pre-#248 backup sibling for the given config path. Used by the
+// user-facing migration notice so the message names the exact file.
+func MigrationBackupPath(cfgPath string) string {
+	bak := cfgPath + MigrationBackupSuffix
+	if abs, err := filepath.Abs(bak); err == nil {
+		return abs
+	}
+	return bak
+}
+
+// MigrationNotice is the one-shot, user-facing message printed after the
+// opaque-ID migration (#248) runs. It tells the user a verbatim backup
+// of their pre-upgrade config was written, where it lives, that it holds
+// secrets sealed under the old scheme (so it must not be checked in or
+// sync'd), and how to remove it once they've verified the upgrade (#269).
+//
+// All surfaces (unlock / bag import stderr, the TUI status line) render
+// the SAME text via this helper so the copy stays consistent.
+func MigrationNotice(cfgPath string) string {
+	bak := MigrationBackupPath(cfgPath)
+	return "jitenv: upgraded config to opaque-ID format (#248).\n" +
+		"A verbatim backup of the pre-upgrade config has been written to:\n" +
+		"  " + bak + "\n" +
+		"This file is left in place so you can roll back if the migration\n" +
+		"caused any problem. Once you have verified the upgrade, you can\n" +
+		"delete the backup manually:\n" +
+		"  rm " + bak + "\n" +
+		"Note: the backup contains your secret values sealed under the old\n" +
+		"scheme — keep it local; do not check it in or sync it."
+}
+
 // MigrationBackupSuffix is appended to the config path for the verbatim
-// pre-migration backup written by MigrateToOpaqueIDs. The backup is
-// removed automatically by the next successful AtomicSave from a
-// master-key-holding path (see AtomicSave).
+// pre-migration backup written by MigrateToOpaqueIDs. The backup is left
+// in place after migration and is never removed automatically (#269) —
+// the user deletes it themselves once they've verified the upgrade.
 const MigrationBackupSuffix = ".pre-id-migration.bak"
 
 // MigrateToOpaqueIDs upgrades a legacy name-keyed config (pre-#248) to
@@ -36,16 +69,20 @@ const MigrationBackupSuffix = ".pre-id-migration.bak"
 //  5. AtomicSave the new form.
 //
 // Failure handling: a decrypt or save error leaves the ORIGINAL file
-// untouched (we only AtomicSave at the very end) and retains the backup,
+// untouched (we only atomicSave at the very end) and retains the backup,
 // so the next run under a fixed binary/passphrase is a clean retry. The
-// backup written here is removed by the next successful AtomicSave.
+// backup written here persists on disk; nothing removes it
+// automatically (#269) — the user deletes it once they've verified the
+// upgrade.
 //
-// Returns migrated=true only when the on-disk file was rewritten.
+// Returns migrated=true only when the on-disk file was rewritten. Every
+// caller that surfaces this bool to a user should print the one-shot
+// backup notice (see internal/cli MigrationNotice).
 //
 // IRREVERSIBILITY: once migrated, the names live only inside the sealed
 // name_map; an older jitenv binary (pre-#248) cannot read the opaque-ID
-// config. The backup is the escape hatch until the next save consumes
-// it.
+// config. The backup is the rollback escape hatch and stays on disk
+// until the user removes it.
 func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
 	c, err := Load(path)
 	if err != nil {
@@ -74,9 +111,9 @@ func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
 		return false, fmt.Errorf("migrate: re-encrypt under opaque IDs: %w (original left untouched; backup at %s)", err, backupPath)
 	}
 
-	// Write via the unexported atomicSave so the migration does NOT
-	// remove the backup it just created — the backup is the escape hatch
-	// until the NEXT user-facing AtomicSave (#248).
+	// Write via the unexported atomicSave (AtomicSave is identical now,
+	// but keep the internal call explicit). The verbatim backup created
+	// above stays on disk as the rollback escape hatch (#269).
 	if err := atomicSave(path, c); err != nil {
 		return false, fmt.Errorf("migrate: save migrated config: %w (original left untouched; backup at %s)", err, backupPath)
 	}
@@ -122,10 +159,11 @@ func writeVerbatimBackup(src, dst string) error {
 }
 
 // removeMigrationBackup unlinks the pre-migration backup sibling for
-// path, if present. Called from AtomicSave after a successful rename so
-// the escape-hatch copy is cleaned up on the first config-modifying save
-// under the new binary. Best-effort: a failure to remove is non-fatal
-// (the save already succeeded), so the error is swallowed.
+// path, if present. As of #269 nothing in the save path calls this —
+// the backup is intentionally left on disk for the user to remove. The
+// helper is retained for callers that want to explicitly delete the
+// backup (and is exercised by tests). Best-effort: a failure to remove
+// is non-fatal, so the error is swallowed.
 func removeMigrationBackup(path string) {
 	_ = os.Remove(path + MigrationBackupSuffix)
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -35,7 +35,7 @@ func MigrationNotice(cfgPath string) string {
 		"This file is left in place so you can roll back if the migration\n" +
 		"caused any problem. Once you have verified the upgrade, you can\n" +
 		"delete the backup manually:\n" +
-		"  rm " + bak + "\n" +
+		fmt.Sprintf("  rm %q\n", bak) +
 		"Note: the backup contains your secret values sealed under the old\n" +
 		"scheme — keep it local; do not check it in or sync it."
 }
@@ -77,7 +77,8 @@ const MigrationBackupSuffix = ".pre-id-migration.bak"
 //
 // Returns migrated=true only when the on-disk file was rewritten. Every
 // caller that surfaces this bool to a user should print the one-shot
-// backup notice (see internal/cli MigrationNotice).
+// backup notice (see config.MigrationNotice in this package; the CLI
+// wrapper is printMigrationNotice).
 //
 // IRREVERSIBILITY: once migrated, the names live only inside the sealed
 // name_map; an older jitenv binary (pre-#248) cannot read the opaque-ID

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gv/jitenv/internal/crypto"
@@ -178,9 +179,12 @@ func TestMigrateToOpaqueIDs_ValidateStructure(t *testing.T) {
 	}
 }
 
-// TestAtomicSave_RemovesMigrationBackup verifies the first config-
-// modifying save after a migration consumes the backup escape hatch.
-func TestAtomicSave_RemovesMigrationBackup(t *testing.T) {
+// TestAtomicSave_PreservesMigrationBackup verifies that, as of #269,
+// AtomicSave no longer consumes the pre-migration backup: the verbatim
+// backup written by the migration survives subsequent config-modifying
+// saves so the user keeps a rollback escape hatch until they delete it
+// themselves.
+func TestAtomicSave_PreservesMigrationBackup(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	key := writeLegacyConfig(t, path)
@@ -196,10 +200,48 @@ func TestAtomicSave_RemovesMigrationBackup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
+	// Two saves to be sure nothing in the save path removes it.
 	if err := AtomicSave(path, c); err != nil {
 		t.Fatalf("save: %v", err)
 	}
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("backup must be preserved across AtomicSave (#269), stat err=%v", err)
+	}
+
+	// removeMigrationBackup remains the explicit way to delete it.
+	removeMigrationBackup(path)
 	if _, err := os.Stat(backup); !os.IsNotExist(err) {
-		t.Fatalf("backup should be removed after the next AtomicSave, stat err=%v", err)
+		t.Fatalf("removeMigrationBackup should unlink the backup, stat err=%v", err)
+	}
+}
+
+// TestMigrationNotice_ContentAndPath verifies the shared notice copy
+// names the ABSOLUTE backup path, includes the rollback rm command, and
+// carries the one-line "this holds secrets — don't sync" warning (#269).
+func TestMigrationNotice_ContentAndPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	bak := MigrationBackupPath(path)
+	if !filepath.IsAbs(bak) {
+		t.Fatalf("MigrationBackupPath must be absolute, got %q", bak)
+	}
+	if filepath.Base(bak) != "config.toml"+MigrationBackupSuffix {
+		t.Fatalf("backup basename = %q", filepath.Base(bak))
+	}
+
+	notice := MigrationNotice(path)
+	for _, want := range []string{
+		"upgraded config to opaque-ID format (#248)",
+		bak,
+		"rm " + bak,
+		"do not check it in or sync it",
+	} {
+		if !strings.Contains(notice, want) {
+			t.Errorf("notice missing %q:\n%s", want, notice)
+		}
 	}
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -237,7 +238,7 @@ func TestMigrationNotice_ContentAndPath(t *testing.T) {
 	for _, want := range []string{
 		"upgraded config to opaque-ID format (#248)",
 		bak,
-		"rm " + bak,
+		fmt.Sprintf("rm %q", bak),
 		"do not check it in or sync it",
 	} {
 		if !strings.Contains(notice, want) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -44,6 +44,14 @@ type rootModel struct {
 	// to remind the user the TUI was opened by `jitenv clone`.
 	footerHint string
 
+	// migrationNotice, when non-empty, is a one-shot status-line
+	// notice shown when the opaque-ID migration (#248) just ran. It is
+	// surfaced exactly once — the first View consumes it into the flash
+	// slot and clears the field so subsequent model rebuilds / renders
+	// don't re-emit it (#269). The full multi-line copy is printed to
+	// stderr on exit by runModel.
+	migrationNotice string
+
 	err    error // fatal error returned from prog.Run
 	width  int
 	height int
@@ -59,7 +67,21 @@ func (r *rootModel) Init() tea.Cmd {
 	if len(r.stack) == 0 {
 		return nil
 	}
-	return r.top().Init()
+	cmd := r.top().Init()
+	// One-shot post-migration notice (#269). Init runs exactly once, so
+	// emitting the status flash here (and clearing the field) guarantees
+	// it surfaces a single time and is never re-emitted on a later model
+	// rebuild or render.
+	if r.migrationNotice != "" {
+		notice := r.migrationNotice
+		r.migrationNotice = ""
+		flash := func() tea.Msg { return statusMsg(notice) }
+		if cmd == nil {
+			return flash
+		}
+		return tea.Batch(cmd, flash)
+	}
+	return cmd
 }
 
 func (r *rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -37,13 +37,13 @@ func Run(cfgPath string) error {
 	if err != nil {
 		return err
 	}
-	cfg, key, err := loadOrInit(cfgPath)
+	cfg, key, migrated, err := loadOrInit(cfgPath)
 	if err != nil {
 		return err
 	}
 	defer zero(key)
 
-	return runModel(cfgPath, cfg, key, nil)
+	return runModel(cfgPath, cfg, key, nil, migrated)
 }
 
 // RunWithMappingTemplate runs the TUI with a freshly-reloaded config
@@ -74,9 +74,11 @@ func RunWithMappingTemplate(cfgPath string, key []byte, template *config.Mapping
 	if err != nil {
 		return err
 	}
-	if migrated, err := config.MigrateToOpaqueIDs(cfgPath, key); err != nil {
+	migrated, err := config.MigrateToOpaqueIDs(cfgPath, key)
+	if err != nil {
 		return fmt.Errorf("migrate config for post-clone follow-up: %w", err)
-	} else if migrated {
+	}
+	if migrated {
 		cfg, err = config.Load(cfgPath)
 		if err != nil {
 			return err
@@ -85,7 +87,7 @@ func RunWithMappingTemplate(cfgPath string, key []byte, template *config.Mapping
 	if err := config.DecryptInPlace(cfg, key); err != nil {
 		return fmt.Errorf("decrypt config for post-clone follow-up: %w", err)
 	}
-	return runModel(cfgPath, cfg, key, &mappingTemplate{m: template, hint: footerHint})
+	return runModel(cfgPath, cfg, key, &mappingTemplate{m: template, hint: footerHint}, migrated)
 }
 
 // mappingTemplate is the optional "open on a pre-filled mapping form"
@@ -96,8 +98,14 @@ type mappingTemplate struct {
 	hint string
 }
 
-func runModel(cfgPath string, cfg *config.Config, key []byte, tmpl *mappingTemplate) error {
+func runModel(cfgPath string, cfg *config.Config, key []byte, tmpl *mappingTemplate, migrated bool) error {
 	m := newRootModel(cfgPath, cfg, key)
+	if migrated {
+		// One-shot status-line toast inside the TUI; the full multi-line
+		// backup notice is printed to stderr after the alt-screen
+		// restores (below), mirroring maybeAutoInstallHook (#269).
+		m.migrationNotice = "upgraded config to opaque-ID format — pre-upgrade backup kept (see notice on exit)"
+	}
 	if tmpl != nil && tmpl.m != nil {
 		// Append the template mapping and push the form screen on
 		// top of the default menu — Esc returns to the menu, save
@@ -118,6 +126,15 @@ func runModel(cfgPath string, cfg *config.Config, key []byte, tmpl *mappingTempl
 	}
 	if root.savedSinceLastReload {
 		_ = pingAgentReload()
+	}
+	// Print the full multi-line post-migration backup notice (#269) to
+	// stderr once the alt-screen has restored, so the long copy (absolute
+	// backup path + rollback instructions + "don't sync" warning) is
+	// readable below the shell prompt. The in-TUI status line was just a
+	// short toast.
+	if migrated {
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, config.MigrationNotice(cfgPath))
 	}
 	// Auto-install the shell hook on TUI exit when there's at least
 	// one mapping configured and the hook isn't already wired. We
@@ -164,58 +181,60 @@ func maybeAutoInstallHook(w io.Writer, cfgPath string) {
 // loadOrInit handles the "no config yet" first-run path: prompt the
 // user, create a fresh encrypted file, then load it. On the existing-
 // config path it just prompts for the passphrase and decrypts.
-func loadOrInit(cfgPath string) (*config.Config, []byte, error) {
+func loadOrInit(cfgPath string) (*config.Config, []byte, bool, error) {
 	if _, err := os.Stat(cfgPath); errors.Is(err, os.ErrNotExist) {
 		fmt.Fprintf(os.Stderr, "No config at %s.\nCreate a new one? [y/N] ", cfgPath)
 		ans, _ := bufio.NewReader(os.Stdin).ReadString('\n')
 		switch strings.ToLower(strings.TrimSpace(ans)) {
 		case "y", "yes":
 		default:
-			return nil, nil, errors.New("aborted")
+			return nil, nil, false, errors.New("aborted")
 		}
 		pw, err := crypto.PromptPassphrase("jitenv config: new passphrase: ", true)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		defer zero(pw)
 		if err := config.InitNew(cfgPath, pw); err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		fmt.Fprintf(os.Stderr, "Created %s\n", cfgPath)
 	}
 
 	pw, err := crypto.PromptPassphrase("jitenv config passphrase: ", false)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	defer zero(pw)
 	c, err := config.Load(cfgPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	key, err := config.DeriveKeyFromMeta(c, pw)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	// One-shot opaque-ID migration (#248). Runs under the TUI lock held
 	// by `jitenv config`, so it can't race the agent-spawn migration.
-	if migrated, err := config.MigrateToOpaqueIDs(cfgPath, key); err != nil {
+	migrated, err := config.MigrateToOpaqueIDs(cfgPath, key)
+	if err != nil {
 		zero(key)
-		return nil, nil, err
-	} else if migrated {
+		return nil, nil, false, err
+	}
+	if migrated {
 		// Reload the rewritten (opaque-ID) form so DecryptInPlace below
 		// works on the migrated bytes.
 		c, err = config.Load(cfgPath)
 		if err != nil {
 			zero(key)
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 	}
 	if err := config.DecryptInPlace(c, key); err != nil {
 		zero(key)
-		return nil, nil, err
+		return nil, nil, false, err
 	}
-	return c, key, nil
+	return c, key, migrated, nil
 }
 
 // pingAgentReload sends an OpReload to a running agent. Errors are


### PR DESCRIPTION
## What

Implements #269. Two changes:

1. **Remove the auto-cleanup.** `config.AtomicSave` no longer unlinks `config.toml.pre-id-migration.bak`. The verbatim pre-#248 backup written by `MigrateToOpaqueIDs` now persists on disk until the user removes it themselves — saving the config no longer silently deletes the only rollback escape hatch. `removeMigrationBackup` and `MigrationBackupSuffix` are kept (the helper remains the explicit-delete path and is exercised by a test).

2. **Surface a one-shot notice when migration runs.** The `migrated bool` is plumbed from `MigrateToOpaqueIDs` through every key-holding surface:
   - `migrateOpaqueIDsLocked` now returns `(migrated bool, err error)`.
   - `jitenv unlock`, `jitenv bag import`, and `jitenv clone` print the notice to stderr when `migrated == true`.
   - The TUI (`jitenv config` and the post-clone follow-up) shows a one-shot status-line toast — emitted from `rootModel.Init` and cleared so it never re-fires on a later model rebuild/render — plus the full multi-line notice on exit (stderr, after the alt-screen restores, mirroring the hook-install notice).

A single shared helper, `config.MigrationNotice(cfgPath)`, renders identical copy everywhere: the absolute backup path, the `rm` rollback command, and a one-line warning that the backup holds secrets sealed under the old scheme (keep it local; do not check it in or sync it). `config.MigrationBackupPath` returns the absolute backup path.

## Tests

- Inverted `TestAtomicSave_RemovesMigrationBackup` → `TestAtomicSave_PreservesMigrationBackup`: the backup survives repeated saves, and `removeMigrationBackup` still deletes it explicitly.
- Added `TestMigrationNoticeEmittedOnce` (CLI, via bag import): the notice fires exactly once on the migrating run, names the absolute backup path, carries the secrets warning, and does **not** re-fire on a second (already-migrated) run — and the backup survives the second save.
- Added `TestMigrationNotice_ContentAndPath` (config) asserting the shared copy's path/rm/warning content.

`go test ./internal/config/... ./internal/cli/... ./internal/tui/...`, `go vet`, `gofmt -l`, and `golangci-lint run` on the touched packages all pass.

## Notes

- While working on this I found a pre-existing failure in `internal/shell` — `TestBashWrapperReReconcilesOnConfigEdit` fails on a clean tree, unrelated to this change. Filed as #272 rather than expanding scope here.

Closes #269