### PR TITLE
unlock: run opaque-ID migration inside Spawn (closes #275)

### DIFF
--- a/internal/cli/bag_import.go
+++ b/internal/cli/bag_import.go
@@ -155,8 +155,10 @@ func runBagImport(cmd *cobra.Command, opts importOpts) error {
 
 	// One-shot opaque-ID migration (#248) so a legacy config gets the
 	// sealed name_map + backup before we mint a new bag/keys into it,
-	// matching the clone/unlock paths.
-	migrated, err := migrateOpaqueIDsLocked(cfgPath, key)
+	// matching the clone/unlock paths. The lock against `jitenv config`
+	// and concurrent migrations is taken internally by
+	// config.MigrateToOpaqueIDs (#275 hoist).
+	migrated, err := config.MigrateToOpaqueIDs(cfgPath, key)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -99,8 +99,10 @@ func runClone(cmd *cobra.Command, args []string, tokenStdin bool, bagOverride st
 	defer zeroBytes(key)
 	// One-shot opaque-ID migration (#248) so a legacy config cloned into
 	// gets the sealed name_map + backup like the unlock/TUI paths, rather
-	// than silently migrating on save without a backup.
-	migrated, err := migrateOpaqueIDsLocked(cfgPath, key)
+	// than silently migrating on save without a backup. The lock against
+	// `jitenv config` and concurrent migrations is taken internally by
+	// config.MigrateToOpaqueIDs (#275 hoist) — no external wrapper needed.
+	migrated, err := config.MigrateToOpaqueIDs(cfgPath, key)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -266,30 +266,6 @@ func resolveJitenvTUIPath() (string, error) {
 	)
 }
 
-// migrateOpaqueIDsLocked runs the one-shot opaque-ID migration (#248)
-// under the shared .tui.lock so the agent-spawn path and a concurrent
-// `jitenv config` TUI session can't both rewrite the config at once.
-// The lock is held only for the duration of the migration (a no-op when
-// the config is already migrated), then released so the TUI can still be
-// opened while the agent runs. A "lock already held" error is treated as
-// "another jitenv process is migrating/editing right now" and surfaced
-// so the user retries rather than proceeding on a possibly-half-written
-// config.
-//
-// Returns migrated=true when the on-disk config was rewritten, so the
-// caller can print the one-shot backup notice (printMigrationNotice).
-func migrateOpaqueIDsLocked(cfgPath string, key []byte) (migrated bool, err error) {
-	lock, lockErr := lockfile.Acquire(cfgPath + ".tui.lock")
-	if lockErr != nil {
-		if errors.Is(lockErr, os.ErrExist) {
-			return false, fmt.Errorf("another jitenv session is editing %s — close it, then retry", cfgPath)
-		}
-		return false, fmt.Errorf("acquire config lock for migration: %w", lockErr)
-	}
-	defer lock.Close()
-	return config.MigrateToOpaqueIDs(cfgPath, key)
-}
-
 // printMigrationNotice writes the one-shot post-migration backup notice
 // (#269) to w. Shared by every key-holding CLI surface (unlock, bag
 // import) so the copy — including the absolute backup path and the

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -44,10 +44,11 @@ func newUnlockCmd() *cobra.Command {
 			defer lockKey(key)()
 
 			// One-shot opaque-ID migration (#248), before the agent is
-			// spawned and starts serving. Guarded by the same .tui.lock
-			// the TUI uses so a concurrent `jitenv config` migration can't
-			// race this one.
-			migrated, err := migrateOpaqueIDsLocked(cfgPath, key)
+			// spawned and starts serving. config.MigrateToOpaqueIDs holds
+			// its own internal .tui.lock (#275 hoist) so a concurrent
+			// `jitenv config` migration can't race this one — callers no
+			// longer wrap the call themselves.
+			migrated, err := config.MigrateToOpaqueIDs(cfgPath, key)
 			if err != nil {
 				return err
 			}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -6,7 +6,16 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/gv/jitenv/internal/lockfile"
 )
+
+// MigrationLockSuffix is the sibling-file suffix used to serialize the
+// one-shot opaque-ID migration. It deliberately reuses the .tui.lock
+// sibling already taken by `jitenv config` so a concurrent TUI session
+// and a concurrent agent-spawn migration cannot race each other on the
+// same on-disk config (see #275 / #166).
+const MigrationLockSuffix = ".tui.lock"
 
 // MigrationBackupPath returns the absolute path of the verbatim
 // pre-#248 backup sibling for the given config path. Used by the
@@ -85,7 +94,36 @@ const MigrationBackupSuffix = ".pre-id-migration.bak"
 // config. The backup is the rollback escape hatch and stays on disk
 // until the user removes it.
 func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
+	// Cheap fast-path probe BEFORE taking the lock: an already-migrated
+	// config is the common case and we want the no-op path to stay
+	// lock-free so it costs nothing for every inline unlock (#275).
 	c, err := Load(path)
+	if err != nil {
+		return false, err
+	}
+	if !NeedsIDMigration(c) {
+		return false, nil
+	}
+
+	// Migration is needed — serialize with any concurrent `jitenv config`
+	// TUI session or another agent-spawn migration (#275). Lock is held
+	// only for the duration of this single migration; a "lock already
+	// held" error is surfaced so the caller retries rather than racing on
+	// a possibly-half-written config.
+	lock, lockErr := lockfile.Acquire(path + MigrationLockSuffix)
+	if lockErr != nil {
+		if errors.Is(lockErr, os.ErrExist) {
+			return false, fmt.Errorf("another jitenv session is editing %s — close it, then retry", path)
+		}
+		return false, fmt.Errorf("acquire config lock for migration: %w", lockErr)
+	}
+	defer lock.Close()
+
+	// Re-check under the lock: another process may have just finished
+	// the migration while we waited (or were probing). This makes the
+	// function safe to call from multiple key-holding entry points
+	// without an explicit external guard.
+	c, err = Load(path)
 	if err != nil {
 		return false, err
 	}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -6,8 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gv/jitenv/internal/crypto"
+	"github.com/gv/jitenv/internal/lockfile"
 )
 
 // writeLegacyConfig builds and writes a pre-#248 (name-keyed,
@@ -216,6 +218,71 @@ func TestAtomicSave_PreservesMigrationBackup(t *testing.T) {
 	removeMigrationBackup(path)
 	if _, err := os.Stat(backup); !os.IsNotExist(err) {
 		t.Fatalf("removeMigrationBackup should unlink the backup, stat err=%v", err)
+	}
+}
+
+// TestMigrateToOpaqueIDs_AlreadyMigratedSkipsLock verifies the #275
+// invariant: an already-migrated config does NOT acquire the internal
+// migration lock. This keeps the no-op fast path lock-free so every
+// inline unlock against a modern config costs nothing extra, and lets
+// the no-op path coexist with a TUI session that's currently holding
+// the .tui.lock for editing.
+func TestMigrateToOpaqueIDs_AlreadyMigratedSkipsLock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+
+	// First migration brings the config to the modern shape.
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+
+	// Hold the migration lock externally (simulates a concurrent
+	// `jitenv config` TUI session).
+	heldF, err := lockfile.Acquire(path + MigrationLockSuffix)
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+	t.Cleanup(func() { _ = heldF.Close() })
+
+	// A second migration must short-circuit BEFORE touching the lock —
+	// otherwise this call would block forever (or fail) on the held
+	// lock. The fast-path probe at the top of MigrateToOpaqueIDs is
+	// what guarantees this.
+	done := make(chan error, 1)
+	go func() {
+		_, err := MigrateToOpaqueIDs(path, key)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("already-migrated MigrateToOpaqueIDs must be a no-op even when the lock is held; got err=%v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("already-migrated MigrateToOpaqueIDs blocked on the held lock; the no-op path must skip locking")
+	}
+}
+
+// TestMigrateToOpaqueIDs_LegacyContendsOnLock verifies that a legacy
+// config (still needing migration) DOES contend on the internal lock,
+// so two concurrent migrations can't race each other on a half-written
+// config (#275).
+func TestMigrateToOpaqueIDs_LegacyContendsOnLock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+
+	heldF, err := lockfile.Acquire(path + MigrationLockSuffix)
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+	t.Cleanup(func() { _ = heldF.Close() })
+
+	if _, err := MigrateToOpaqueIDs(path, key); err == nil {
+		t.Fatal("migration on a legacy config should fail when the lock is held externally")
+	} else if !strings.Contains(err.Error(), "another jitenv session is editing") {
+		t.Fatalf("expected 'another jitenv session is editing' error, got: %v", err)
 	}
 }
 

--- a/internal/run/inline_unlock_migrate_e2e_test.go
+++ b/internal/run/inline_unlock_migrate_e2e_test.go
@@ -1,0 +1,208 @@
+//go:build !windows
+
+package run_test
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// TestRunInlineUnlock_MigratesLegacyConfig is the issue #275 regression:
+// a user whose first jitenv interaction after upgrading across the
+// opaque-ID migration (#248) is a mapped command in a fresh shell with
+// the agent locked. They press `u` at the agent-down countdown, type
+// their passphrase, and the inline-unlock flow MUST:
+//
+//  1. run the migration (writing the .pre-id-migration.bak),
+//  2. surface the post-migration backup notice (#269) on stderr so the
+//     rollback escape hatch is visible, and
+//  3. still inject the mapped env into the wrapped command.
+//
+// Before #275 the inline-unlock path silently skipped the migration:
+// the agent worked, the script ran with its env, but the user never saw
+// the backup and never learned about the rollback escape hatch.
+func TestRunInlineUnlock_MigratesLegacyConfig(t *testing.T) {
+	bin := buildBinary(t)
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "show.sh")
+	if err := os.WriteFile(scriptPath,
+		[]byte("#!/bin/sh\nprintf 'A=%s\\n' \"$A\"\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2-inline-unlock-migrate")
+	writeLegacyConfigForTest(t, cfgPath, pw, scriptPath)
+
+	// Sanity: the on-disk config must be in the legacy (pre-#248) shape
+	// or this test isn't exercising the migration path at all.
+	pre, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load pre: %v", err)
+	}
+	if !config.NeedsIDMigration(pre) {
+		t.Fatal("fixture is not in legacy shape — migration would no-op")
+	}
+
+	// Empty runtime dir → no agent socket → run.go hits the agent-down
+	// countdown, which is where the inline-unlock prompt lives.
+	runtimeDir := shortRuntimeDir(t)
+
+	subprocEnv := append(filterEnvKeys(os.Environ(), "CI", "JITENV_NO_NOTICE"),
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"JITENV_CONFIG="+cfgPath,
+		"JITENV_HOOK_DELAY=10",
+		"TERM=dumb",
+	)
+
+	cmd := exec.Command(bin, "run", scriptPath)
+	cmd.Env = subprocEnv
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty start: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = cmd.Process.Kill() }()
+
+	mu := make(chan string, 1)
+	mu <- ""
+	go func() {
+		buf := make([]byte, 4096)
+		var acc strings.Builder
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				acc.Write(buf[:n])
+				<-mu
+				mu <- acc.String()
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	readAll := func() string { s := <-mu; mu <- s; return s }
+
+	waitFor := func(substr string, d time.Duration) bool {
+		deadline := time.Now().Add(d)
+		for time.Now().Before(deadline) {
+			if strings.Contains(readAll(), substr) {
+				return true
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		return false
+	}
+
+	if !waitFor("Press [u] to enter the passphrase", 5*time.Second) {
+		t.Fatalf("never saw the inline-unlock prompt;\noutput=%s", readAll())
+	}
+	if _, err := ptmx.Write([]byte("u")); err != nil {
+		t.Fatalf("write u: %v", err)
+	}
+	if !waitFor("unlock passphrase", 5*time.Second) {
+		t.Fatalf("never saw the passphrase prompt after `u`;\noutput=%s", readAll())
+	}
+	if _, err := ptmx.Write(append(pw, '\n')); err != nil {
+		t.Fatalf("write passphrase: %v", err)
+	}
+
+	// The mapped script should still run with its injected env after
+	// the migration runs inline.
+	if !waitFor("A=from-noop", 15*time.Second) {
+		t.Fatalf("script did not run with injected env after inline unlock + migration;\noutput=%s", readAll())
+	}
+	// The post-migration backup notice (#269) must be visible on stderr.
+	if !waitFor("upgraded config to opaque-ID format", 5*time.Second) {
+		t.Fatalf("inline-unlock migration did not surface the backup notice;\noutput=%s", readAll())
+	}
+
+	go func() { _, _ = io.Copy(io.Discard, ptmx) }()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("child did not exit;\noutput=%s", readAll())
+	}
+
+	// The .pre-id-migration.bak must have been written by the inline
+	// unlock — this is the #269 rollback escape hatch the user can
+	// reach via the backup notice.
+	backup := cfgPath + config.MigrationBackupSuffix
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("inline-unlock did not write the pre-migration backup at %s: %v", backup, err)
+	}
+
+	// And the on-disk config is now in the migrated (opaque-ID) shape:
+	// a second inline unlock would be a no-op.
+	post, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load post: %v", err)
+	}
+	if config.NeedsIDMigration(post) {
+		t.Fatal("config is still in legacy shape after inline-unlock migration")
+	}
+}
+
+// writeLegacyConfigForTest builds a pre-#248 (name-keyed, name-AAD-sealed)
+// config to path using passphrase pw, with a single mapping that injects
+// env var A from a noop source for scriptPath. Mirrors the package-private
+// writeLegacyConfig helper in internal/config but works from outside the
+// package — uses only exported symbols.
+func writeLegacyConfigForTest(t *testing.T, path string, pw []byte, scriptPath string) {
+	t.Helper()
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zeroBytesForTest(key)
+
+	// noop source with one param "a" sealed under the legacy NAME-based
+	// AAD so DecryptInPlace at migration time succeeds against the
+	// pre-#248 context.
+	aParam, _ := crypto.EncryptField(key, "from-noop", config.SourceParamAAD("n", "a"))
+	c.Sources = map[string]config.SourceConfig{
+		"n": {Type: "noop", Params: map[string]any{"a": aParam}},
+	}
+	// One var sealed under slot-index AADs (unchanged across #248).
+	vName, _ := crypto.EncryptField(key, "A", config.VarFieldAAD(0, 0, "name"))
+	vSrc, _ := crypto.EncryptField(key, "n", config.VarFieldAAD(0, 0, "source"))
+	vRef, _ := crypto.EncryptField(key, "a", config.VarFieldAAD(0, 0, "ref"))
+	c.Mappings = []config.Mapping{{
+		Path: scriptPath,
+		Vars: []config.VarRef{{Name: vName, Source: vSrc, Ref: vRef}},
+	}}
+	// Disable the pre-run notice so the only injected-env signal we
+	// assert on is the script's own output.
+	off := false
+	c.Agent.PreRunNotice = &off
+	if err := config.Save(path, c); err != nil {
+		t.Fatalf("save legacy: %v", err)
+	}
+}
+
+func zeroBytesForTest(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gv/jitenv/internal/agent"
 	"github.com/gv/jitenv/internal/agentwarn"
+	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/runnotice"
 	"github.com/gv/jitenv/internal/unlock"
 )
@@ -203,6 +204,14 @@ func fetchAfterUnlock(ctx context.Context, abs string) (map[string]string, bool,
 			"jitenv: unlock failed (%v) — running without injected env. "+
 				"On slow disks, raise JITENV_AGENT_SPAWN_TIMEOUT (e.g. 20s).\n", err)
 		return nil, false, nil
+	}
+	// Surface the one-shot opaque-ID migration backup notice (#275): a
+	// user whose first jitenv interaction post-#248 upgrade is an inline
+	// unlock via the agent-down countdown otherwise never sees the
+	// .pre-id-migration.bak rollback hint (#269).
+	if res.Migrated {
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, config.MigrationNotice(res.CfgPath))
 	}
 	cli := agent.NewClient(res.Socket)
 	dctx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gv/jitenv/internal/agent"
 	"github.com/gv/jitenv/internal/agentwarn"
+	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/runnotice"
 	"github.com/gv/jitenv/internal/unlock"
 )
@@ -523,6 +524,14 @@ func fetchAfterUnlock(cmd string) (map[string]string, error) {
 			"jitenv: unlock failed (%v) — running without injected env. "+
 				"On slow disks, raise JITENV_AGENT_SPAWN_TIMEOUT (e.g. 20s).\n", err)
 		return nil, err
+	}
+	// Surface the one-shot opaque-ID migration backup notice (#275): a
+	// user whose first jitenv interaction post-#248 upgrade is an inline
+	// unlock from the cwd_glob shim's agent-down countdown otherwise
+	// never sees the .pre-id-migration.bak rollback hint (#269).
+	if res.Migrated {
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, config.MigrationNotice(res.CfgPath))
 	}
 	pwd, err := os.Getwd()
 	if err != nil {

--- a/internal/unlock/unlock.go
+++ b/internal/unlock/unlock.go
@@ -11,6 +11,7 @@
 package unlock
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gv/jitenv/internal/agent"
@@ -20,8 +21,15 @@ import (
 
 // Result reports what happened after a Spawn attempt. Socket is the
 // agent socket / pipe the caller can dial once unlock succeeds.
+// Migrated is true when the one-shot opaque-ID migration (#248) rewrote
+// the on-disk config during this Spawn call; the caller should print
+// config.MigrationNotice(CfgPath) on stderr so the inline-unlock flow
+// surfaces the #269 backup-rollback hint to the user (#275). CfgPath
+// is the resolved config path the migration ran against.
 type Result struct {
-	Socket string
+	Socket   string
+	Migrated bool
+	CfgPath  string
 }
 
 // Spawn prompts for the passphrase on the controlling terminal,
@@ -55,6 +63,30 @@ func Spawn(cfgPath string) (Result, error) {
 	defer zeroBytes(key)
 	defer lockKey(key)()
 
+	// One-shot opaque-ID migration (#248) BEFORE the agent is spawned.
+	// Lifting this here from `jitenv unlock` ensures every key-holding
+	// entry point — including the inline-unlock prompt fired from the
+	// agent-down countdown in run/shim (#232) — runs the migration by
+	// construction, so the user always sees the .pre-id-migration.bak
+	// and the post-migration backup notice (#275). config.MigrateToOpaqueIDs
+	// takes its own internal lock against `jitenv config` and concurrent
+	// migrations, so this call is safe to make from every caller.
+	migrated, err := config.MigrateToOpaqueIDs(resolved, key)
+	if err != nil {
+		return Result{}, fmt.Errorf("migrate to opaque IDs: %w", err)
+	}
+	if migrated {
+		// Reload so the cfg we read fields off (idle timeout) below
+		// matches the now-rewritten on-disk file. The agent itself
+		// reads the path it's given, so this only affects the values
+		// the unlock flow consults pre-spawn — but it keeps
+		// in-memory and on-disk consistent.
+		cfg, err = config.Load(resolved)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
 	paths, err := agent.DefaultPaths()
 	if err != nil {
 		return Result{}, err
@@ -63,7 +95,7 @@ func Spawn(cfgPath string) (Result, error) {
 	if err := agent.SpawnDaemon(paths, resolved, idle, key); err != nil {
 		return Result{}, err
 	}
-	return Result{Socket: paths.Socket}, nil
+	return Result{Socket: paths.Socket, Migrated: migrated, CfgPath: resolved}, nil
 }
 
 // ParseIdle mirrors the agent idle-timeout parsing used by the unlock


### PR DESCRIPTION
## Summary

- Lift the one-shot opaque-ID migration (#248) into `unlock.Spawn` so every key-holding entry point — including the inline-unlock prompt fired from run/shim's agent-down countdown (#232) — runs it by construction. Before this fix, a user upgrading across #248 whose first interaction was a mapped command in a fresh shell got a working agent but never saw the `.pre-id-migration.bak` or the #269 backup notice, so the rollback escape hatch was invisible to them.
- Move `.tui.lock` serialization into `config.MigrateToOpaqueIDs` itself (new `config.MigrationLockSuffix` constant) so callers don't have to remember to wrap. The no-op fast path stays lock-free.
- Drop the now-redundant `migrateOpaqueIDsLocked` wrapper from `internal/cli/config.go`; `cli/{unlock,clone,bag_import}.go` call `config.MigrateToOpaqueIDs` directly.
- Run / shim's `fetchAfterUnlock` print `config.MigrationNotice` on stderr when `unlock.Spawn` reports `Migrated=true`, mirroring the CLI and TUI surfaces.

Closes #275

## Test plan

- [x] `go test ./internal/config -run TestMigrate -v` — covers the new internal lock (fast-path skips it, legacy path contends on it).
- [x] `go test ./internal/run -run TestRunInlineUnlock -v` — new `TestRunInlineUnlock_MigratesLegacyConfig` drives the full PTY scenario: legacy config + locked agent + user types `u`+passphrase, asserts the backup, the on-disk migrated shape, and the stderr notice.
- [x] `go test ./...`
- [x] `golangci-lint run ./...`