### PR TITLE
crypto+syncconfig: keep DEK off the Go-string heap (closes #277)

### DIFF
--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"bytes"
 	"encoding/base64"
 	"strings"
 	"testing"
@@ -61,6 +62,128 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 	}
 	if pt != "hunter2" {
 		t.Fatalf("unexpected plaintext %q", pt)
+	}
+}
+
+// TestEnvelopeBytesRoundTrip covers the []byte-typed twins
+// EncryptFieldBytes/DecryptFieldBytes that exist specifically so raw
+// key material (e.g. the sync DEK, issue #277) never has to transit a
+// Go string and pollute the heap with unzeroable copies.
+func TestEnvelopeBytesRoundTrip(t *testing.T) {
+	key := mustKey(t)
+	// Use a binary payload with NULs and high bytes to make sure the
+	// helpers don't accidentally rely on string-y assumptions like
+	// UTF-8 validity or NUL-termination.
+	pt := []byte{0x00, 0x01, 0xfe, 0xff, 'a', 'b', 'c', 0x00}
+	env, err := EncryptFieldBytes(key, pt, "test.ad")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if !IsEnvelope(env) {
+		t.Fatalf("expected envelope prefix, got %q", env)
+	}
+	got, err := DecryptFieldBytes(key, env, "test.ad")
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(got, pt) {
+		t.Fatalf("roundtrip mismatch: %x != %x", got, pt)
+	}
+}
+
+// TestEnvelopeBytesCrossCompatible asserts that envelopes produced by
+// EncryptFieldBytes are readable by the string-typed DecryptField (and
+// vice versa). The on-disk format is identical; only the in-memory
+// types differ. This matters because the read path for older
+// (string-encrypted) on-disk envelopes must keep working when callers
+// switch to the bytes APIs.
+func TestEnvelopeBytesCrossCompatible(t *testing.T) {
+	key := mustKey(t)
+
+	// bytes -> string read
+	envB, err := EncryptFieldBytes(key, []byte("hunter2"), "test.ad")
+	if err != nil {
+		t.Fatalf("encrypt bytes: %v", err)
+	}
+	if pt, err := DecryptField(key, envB, "test.ad"); err != nil || pt != "hunter2" {
+		t.Fatalf("string-read of bytes-envelope: pt=%q err=%v", pt, err)
+	}
+
+	// string -> bytes read
+	envS, err := EncryptField(key, "hunter2", "test.ad")
+	if err != nil {
+		t.Fatalf("encrypt string: %v", err)
+	}
+	got, err := DecryptFieldBytes(key, envS, "test.ad")
+	if err != nil {
+		t.Fatalf("bytes-read of string-envelope: %v", err)
+	}
+	if !bytes.Equal(got, []byte("hunter2")) {
+		t.Fatalf("bytes-read mismatch: %q", got)
+	}
+}
+
+// TestEnvelopeBytesRejectsTransplant mirrors TestEnvelopeRejectsTransplant
+// for the bytes path: an enc:v2 envelope decrypted via DecryptFieldBytes
+// MUST refuse a wrong AD. Same defense (security #110), same guarantee.
+func TestEnvelopeBytesRejectsTransplant(t *testing.T) {
+	key := mustKey(t)
+	env, err := EncryptFieldBytes(key, []byte{0xde, 0xad, 0xbe, 0xef}, "sync.dek")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	// Correct AD must succeed.
+	if _, err := DecryptFieldBytes(key, env, "sync.dek"); err != nil {
+		t.Fatalf("decrypt with correct ad: %v", err)
+	}
+	// Wrong AD must fail.
+	if _, err := DecryptFieldBytes(key, env, "src.aws.secret_access_key"); err == nil {
+		t.Fatal("decrypt with wrong ad must fail (transplantation)")
+	}
+	// Empty AD on v2 must fail.
+	if _, err := DecryptFieldBytes(key, env, ""); err == nil {
+		t.Fatal("decrypt with empty ad must fail when envelope is v2")
+	}
+}
+
+// TestEncryptFieldBytesRejectsEmptyAD covers the input-validation
+// branch — without a per-call AAD, an attacker who can write the
+// envelope back can transplant it elsewhere.
+func TestEncryptFieldBytesRejectsEmptyAD(t *testing.T) {
+	key := mustKey(t)
+	if _, err := EncryptFieldBytes(key, []byte("x"), ""); err == nil {
+		t.Fatal("expected error for empty ad")
+	}
+}
+
+func TestDecryptFieldBytesRejectsMalformed(t *testing.T) {
+	key := mustKey(t)
+	if _, err := DecryptFieldBytes(key, "not-an-envelope", "test.ad"); err == nil {
+		t.Fatalf("expected error for non-envelope")
+	}
+	if _, err := DecryptFieldBytes(key, EnvelopePrefix+"!!!not-base64!!!", "test.ad"); err == nil {
+		t.Fatalf("expected error for malformed base64")
+	}
+	if _, err := DecryptFieldBytes(key, EnvelopePrefix+"YWFh", "test.ad"); err == nil {
+		t.Fatalf("expected error for short blob")
+	}
+}
+
+// TestDecryptFieldBytesAcceptsLegacyV1 mirrors the string-path legacy
+// test: enc:v1 envelopes (no AAD) must still decrypt regardless of ad.
+func TestDecryptFieldBytesAcceptsLegacyV1(t *testing.T) {
+	key := mustKey(t)
+	blob, err := Seal(key, []byte("legacy-value"), nil)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	v1 := EnvelopeLegacyV1Prefix + b64encode(blob)
+	got, err := DecryptFieldBytes(key, v1, "any.context.string")
+	if err != nil {
+		t.Fatalf("decrypt v1 with arbitrary ad must succeed: %v", err)
+	}
+	if !bytes.Equal(got, []byte("legacy-value")) {
+		t.Fatalf("unexpected plaintext: %q", got)
 	}
 }
 

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -56,6 +56,27 @@ func EncryptField(key []byte, plaintext, ad string) (string, error) {
 	return EnvelopePrefix + base64.StdEncoding.EncodeToString(blob), nil
 }
 
+// EncryptFieldBytes is the []byte-typed twin of EncryptField. It exists
+// for raw key material (e.g. the sync DEK) that must never transit a Go
+// string: strings are immutable and unzeroable, so any string copy of
+// the secret lingers in the heap until GC. Callers like
+// syncconfig.WrapDEK pass the DEK directly here instead of round-
+// tripping via string(dek), keeping the key inside zeroable []byte
+// buffers end-to-end (CLAUDE.md "Master key handling").
+//
+// The on-disk envelope format is identical to EncryptField's, so values
+// produced by either are interchangeable on the read side.
+func EncryptFieldBytes(key, plaintext []byte, ad string) (string, error) {
+	if ad == "" {
+		return "", errors.New("EncryptFieldBytes: ad must be non-empty")
+	}
+	blob, err := Seal(key, plaintext, []byte(ad))
+	if err != nil {
+		return "", err
+	}
+	return EnvelopePrefix + base64.StdEncoding.EncodeToString(blob), nil
+}
+
 // DecryptField unwraps an envelope.
 //
 // For enc:v2: the supplied ad MUST match the one passed to
@@ -92,6 +113,38 @@ func DecryptField(key []byte, env, ad string) (string, error) {
 		return string(pt), nil
 	default:
 		return "", errors.New("not an envelope")
+	}
+}
+
+// DecryptFieldBytes is the []byte-typed twin of DecryptField. It exists
+// for raw key material (e.g. the sync DEK) that must never transit a
+// Go string on the read path either — string(pt) would spawn an
+// unzeroable copy of the secret in the heap that lives until GC.
+// Callers like syncconfig.UnwrapDEK use this to keep the DEK inside
+// zeroable []byte buffers end-to-end (CLAUDE.md "Master key handling").
+//
+// Behaviour matches DecryptField exactly: enc:v2 envelopes require a
+// matching non-empty ad; enc:v1 envelopes ignore ad for backward
+// compatibility.
+func DecryptFieldBytes(key []byte, env, ad string) ([]byte, error) {
+	switch {
+	case strings.HasPrefix(env, EnvelopePrefix):
+		if ad == "" {
+			return nil, errors.New("DecryptFieldBytes: ad must be non-empty for enc:v2")
+		}
+		blob, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(env, EnvelopePrefix))
+		if err != nil {
+			return nil, err
+		}
+		return Open(key, blob, []byte(ad))
+	case strings.HasPrefix(env, EnvelopeLegacyV1Prefix):
+		blob, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(env, EnvelopeLegacyV1Prefix))
+		if err != nil {
+			return nil, err
+		}
+		return Open(key, blob, nil) // legacy: pre-AAD, ignore ad
+	default:
+		return nil, errors.New("not an envelope")
 	}
 }
 

--- a/internal/syncconfig/syncconfig.go
+++ b/internal/syncconfig/syncconfig.go
@@ -162,8 +162,14 @@ func NewDEK() ([]byte, error) {
 }
 
 // WrapDEK seals dek under masterKey and stores it in f.WrappedDEK.
+//
+// The DEK is passed to the crypto layer as []byte (via EncryptFieldBytes)
+// rather than going through `string(dek)`: Go strings are immutable and
+// unzeroable, so a string-typed copy of a 256-bit key would linger in
+// the heap until GC even after the caller zeroed its own buffer
+// (CLAUDE.md "Master key handling", issue #277).
 func (f *File) WrapDEK(masterKey, dek []byte) error {
-	env, err := crypto.EncryptField(masterKey, string(dek), dekWrapAAD)
+	env, err := crypto.EncryptFieldBytes(masterKey, dek, dekWrapAAD)
 	if err != nil {
 		return err
 	}
@@ -174,15 +180,20 @@ func (f *File) WrapDEK(masterKey, dek []byte) error {
 // UnwrapDEK recovers the DEK from f.WrappedDEK using masterKey. A wrong
 // passphrase (wrong master key) fails closed here via the AEAD tag.
 // Caller must zero the result.
+//
+// The plaintext is returned as []byte straight from the crypto layer
+// (via DecryptFieldBytes); it never transits through a Go string, so
+// the only live copies of the DEK are zeroable buffers the caller owns
+// (CLAUDE.md "Master key handling", issue #277).
 func (f *File) UnwrapDEK(masterKey []byte) ([]byte, error) {
 	if f.WrappedDEK == "" {
 		return nil, errors.New("sync sidecar has no wrapped DEK; run `jitenv sync init`")
 	}
-	pt, err := crypto.DecryptField(masterKey, f.WrappedDEK, dekWrapAAD)
+	dek, err := crypto.DecryptFieldBytes(masterKey, f.WrappedDEK, dekWrapAAD)
 	if err != nil {
 		return nil, errors.New("cannot unwrap sync key (wrong passphrase, or sidecar is for a different config)")
 	}
-	return []byte(pt), nil
+	return dek, nil
 }
 
 // SealBlob encrypts the config.toml bytes under the DEK into one opaque

--- a/internal/syncconfig/syncconfig_test.go
+++ b/internal/syncconfig/syncconfig_test.go
@@ -47,6 +47,37 @@ func TestDEKWrapUnwrapRoundTrip(t *testing.T) {
 	}
 }
 
+// TestUnwrapDEKReadsLegacyStringPathWrap is a regression for issue #277:
+// WrapDEK now uses crypto.EncryptFieldBytes to keep the DEK off the Go
+// string heap, but the on-disk envelope format is identical to what the
+// previous string-typed path produced. Existing sync.toml files written
+// by older builds must still unwrap with the bytes-path UnwrapDEK.
+func TestUnwrapDEKReadsLegacyStringPathWrap(t *testing.T) {
+	f := newTestFile(t)
+	mk, err := f.DeriveMasterKey([]byte("correct horse battery staple"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dek, err := NewDEK()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the OLD wrap path explicitly: string(dek) -> EncryptField.
+	env, err := crypto.EncryptField(mk, string(dek), dekWrapAAD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WrappedDEK = env
+
+	got, err := f.UnwrapDEK(mk)
+	if err != nil {
+		t.Fatalf("unwrap of legacy-shaped envelope: %v", err)
+	}
+	if string(got) != string(dek) {
+		t.Fatal("legacy-shaped DEK roundtrip mismatch")
+	}
+}
+
 func TestUnwrapWrongPassphraseFailsClosed(t *testing.T) {
 	f := newTestFile(t)
 	mk, _ := f.DeriveMasterKey([]byte("right"))


### PR DESCRIPTION
## Summary

- Add `crypto.EncryptFieldBytes` / `crypto.DecryptFieldBytes` so raw key material can be sealed/unsealed without ever transiting a Go `string`. Go strings are immutable and unzeroable, so any string-typed copy of a secret lingers in the heap until GC, defeating the caller's `defer zeroBytes(...)`.
- Switch `syncconfig.WrapDEK` / `syncconfig.UnwrapDEK` to the new bytes-typed helpers. The 256-bit DEK now stays inside zeroable `[]byte` buffers end-to-end, matching the CLAUDE.md "Master key handling" convention.
- On-disk envelope format is unchanged, so existing `sync.toml` files written by older builds keep unwrapping. A regression test simulates the old string-path wrap and asserts the new `UnwrapDEK` reads it back.

## Scope audit

- `engine.go` / `merge.go` never round-trip the DEK through `string` — they hand the `[]byte` directly to `SealBlob`/`OpenBlob`, which already go to `crypto.Seal`/`crypto.Open`. No change needed.
- All other `EncryptField`/`DecryptField` call sites (`internal/config/*`, e2e seed, etc.) operate on genuinely-string content (env var names, tokens, etc.) and intentionally stay on the string path. Only the DEK is raw key bytes.

## Test plan

- [x] `go test ./internal/crypto/... ./internal/syncconfig/...`
- [x] `go test ./...` (full suite)
- [x] `golangci-lint run ./...`
- [x] New unit tests cover: bytes-bytes round-trip with binary payload, bytes-vs-string cross-compatibility on the read side, AAD-transplant rejection, empty-AD rejection, malformed-envelope rejection, legacy enc:v1 acceptance, and a sync-side regression that unwraps a DEK sealed via the old string-typed path.

Closes #277.