### PR TITLE
agent: detect early child exit in SpawnDaemon via wait goroutine (closes #276)

### DIFF
--- a/internal/agent/daemonize_unix.go
+++ b/internal/agent/daemonize_unix.go
@@ -81,24 +81,49 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 	pw.Close()
 
 	// Wait for the socket to appear, indicating Listen succeeded.
+	//
+	// We must learn about an early child exit promptly. cmd.ProcessState
+	// is only populated by cmd.Wait(), so the previous "if
+	// cmd.ProcessState != nil" branch was dead code (#276) — a crashing
+	// child (wrong binary, panic in init, denied socket dir) blocked the
+	// caller for the full spawnTimeout (10s by default since #266).
+	//
+	// Park a goroutine on cmd.Wait() and race it against the socket
+	// appearing. On success we return without joining the goroutine; it
+	// sits parked on Wait for the lifetime of the agent process and exits
+	// when the agent exits. We deliberately drop the earlier
+	// cmd.Process.Release() call — Release tells Go to forget the
+	// process, but the goroutine still wants it for Wait(). The OS reaps
+	// the agent via init reparenting once the parent (this `jitenv
+	// unlock` invocation) exits.
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
 	timeout := spawnTimeout()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
 		if _, err := os.Stat(paths.Socket); err == nil {
-			// Detach from the child completely.
-			_ = cmd.Process.Release()
 			return nil
 		}
-		// If the child died early, surface that — with the tail of the
-		// agent log so the actual child stderr (e.g. a re-exec of the
-		// wrong binary printing `unknown command "__agent"`) is visible.
-		if cmd.ProcessState != nil {
-			return fmt.Errorf("agent exited early: %s%s", cmd.ProcessState, logTailSuffix(paths.LogFile))
+		select {
+		case waitErr := <-waitCh:
+			// Child died before the socket appeared — surface the exit
+			// status plus the tail of the agent log so the actual stderr
+			// (e.g. `unknown command "__agent"`) is visible.
+			return fmt.Errorf("agent exited early: %v%s", waitErr, logTailSuffix(paths.LogFile))
+		case <-deadline.C:
+			_ = cmd.Process.Kill()
+			// Drain the Wait goroutine so it doesn't leak past return.
+			<-waitCh
+			return fmt.Errorf("agent did not start within %s "+
+				"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
+				"check ${XDG_RUNTIME_DIR}/jitenv/agent.log%s", timeout, logTailSuffix(paths.LogFile))
+		case <-ticker.C:
+			// loop and re-stat the socket
 		}
-		time.Sleep(50 * time.Millisecond)
 	}
-	_ = cmd.Process.Kill()
-	return fmt.Errorf("agent did not start within %s "+
-		"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
-		"check ${XDG_RUNTIME_DIR}/jitenv/agent.log%s", timeout, logTailSuffix(paths.LogFile))
 }

--- a/internal/agent/daemonize_windows.go
+++ b/internal/agent/daemonize_windows.go
@@ -112,24 +112,42 @@ func SpawnDaemon(paths Paths, configFile string, idle time.Duration, key []byte)
 	// has bound its listener. Unlike Unix where the socket is a file on
 	// disk and os.Stat suffices, Windows pipes live in a separate
 	// namespace — the only reliable "is it up?" check is to dial it.
+	//
+	// As on Unix, the prior `cmd.ProcessState != nil` early-exit check
+	// was dead code (#276): exec.Cmd populates ProcessState only via
+	// cmd.Wait(). Park a goroutine on Wait() to surface early child exits
+	// promptly; otherwise a crashing child blocked the caller for the
+	// full spawnTimeout (10s default). The goroutine sits parked for the
+	// lifetime of the agent on the success path and dies with the parent
+	// `jitenv unlock` invocation.
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
 	timeout := spawnTimeout()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		conn, derr := dialAgent(ctx, paths.Socket, 200*time.Millisecond)
 		cancel()
 		if derr == nil {
 			conn.Close()
-			_ = cmd.Process.Release()
 			return nil
 		}
-		if cmd.ProcessState != nil {
-			return fmt.Errorf("agent exited early: %s%s", cmd.ProcessState, logTailSuffix(paths.LogFile))
+		select {
+		case waitErr := <-waitCh:
+			return fmt.Errorf("agent exited early: %v%s", waitErr, logTailSuffix(paths.LogFile))
+		case <-deadline.C:
+			_ = cmd.Process.Kill()
+			<-waitCh
+			return fmt.Errorf("agent did not start within %s "+
+				"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
+				"check the agent log under %%LOCALAPPDATA%%\\jitenv\\agent.log%s", timeout, logTailSuffix(paths.LogFile))
+		case <-ticker.C:
+			// loop and re-dial
 		}
-		time.Sleep(50 * time.Millisecond)
 	}
-	_ = cmd.Process.Kill()
-	return fmt.Errorf("agent did not start within %s "+
-		"(raise JITENV_AGENT_SPAWN_TIMEOUT to extend); "+
-		"check the agent log under %%LOCALAPPDATA%%\\jitenv\\agent.log%s", timeout, logTailSuffix(paths.LogFile))
 }

--- a/internal/agent/resolve_exe.go
+++ b/internal/agent/resolve_exe.go
@@ -24,7 +24,10 @@ import (
 // Without this, inline unlock (#264/#268) re-execs jitenv-hook, the child
 // hits its default switch case (`unknown command "__agent"`), exits 2, and
 // the socket-appearance loop times out.
-func resolveAgentExecutable() (string, error) {
+//
+// Exposed as a function variable so tests can inject a fake binary path
+// (#276 covers the early-child-exit detection that exercises this seam).
+var resolveAgentExecutable = func() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
 		return "", err

--- a/internal/agent/spawn_early_exit_test.go
+++ b/internal/agent/spawn_early_exit_test.go
@@ -1,0 +1,112 @@
+//go:build !windows
+
+package agent
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// TestMain doubles as the fake-agent helper for
+// TestSpawnDaemonSurfacesEarlyChildExit. When JITENV_TEST_FAKE_AGENT=1,
+// the binary drains the key pipe on fd 3 (so the parent's key write
+// doesn't EPIPE) and then exits with the requested code instead of
+// binding a socket — emulating a child that crashes before Listen
+// succeeds (issue #276).
+func TestMain(m *testing.M) {
+	if os.Getenv("JITENV_TEST_FAKE_AGENT") == "1" {
+		fakeAgent()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func fakeAgent() {
+	// Drain fd 3 so the parent's pw.Write(key) returns cleanly. The
+	// Unix SpawnDaemon plumbs the master-key pipe as fd 3 via
+	// cmd.ExtraFiles; not consuming it would race-EPIPE the parent
+	// before it even reaches the wait loop.
+	if f := os.NewFile(3, "key-pipe"); f != nil {
+		_, _ = io.Copy(io.Discard, f)
+		_ = f.Close()
+	}
+	if msg := os.Getenv("JITENV_TEST_FAKE_AGENT_STDERR"); msg != "" {
+		// Mimic the wrong-binary path that printed
+		// `unknown command "__agent"` — the log tail in the error
+		// should propagate this verbatim.
+		_, _ = os.Stderr.WriteString(msg + "\n")
+	}
+	os.Exit(1)
+}
+
+// TestSpawnDaemonSurfacesEarlyChildExit is the regression for #276: the
+// parent's socket-appearance wait loop must learn about a child that
+// dies before Listen succeeds and surface "agent exited early" within
+// ~100ms instead of blocking for the full spawnTimeout (10s by
+// default since #266).
+//
+// We swap resolveAgentExecutable for one that returns the test binary's
+// own path with JITENV_TEST_FAKE_AGENT=1, so the child is the fakeAgent
+// branch above: read key, exit 1 — never binding the socket.
+func TestSpawnDaemonSurfacesEarlyChildExit(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	prev := resolveAgentExecutable
+	resolveAgentExecutable = func() (string, error) { return self, nil }
+	t.Cleanup(func() { resolveAgentExecutable = prev })
+
+	// The test binary's process env propagates to the spawned child
+	// (exec.Cmd defaults to os.Environ() when Env is nil), so this
+	// flag flips the child into fakeAgent mode.
+	t.Setenv("JITENV_TEST_FAKE_AGENT", "1")
+	t.Setenv("JITENV_TEST_FAKE_AGENT_STDERR", `unknown command "__agent"`)
+	// Don't let an operator-set timeout slow the test down — even with
+	// the wait-goroutine fix the kill path drains Wait synchronously,
+	// so any value here would still bound the test runtime.
+	t.Setenv("JITENV_AGENT_SPAWN_TIMEOUT", "10s")
+
+	// Use t.TempDir for the runtime layout; macOS sun_path is fine
+	// since we never actually bind a socket here.
+	runtimeDir := t.TempDir()
+	paths := Paths{
+		Dir:     runtimeDir,
+		Socket:  filepath.Join(runtimeDir, "agent.sock"),
+		PidFile: filepath.Join(runtimeDir, "agent.pid"),
+		LogFile: filepath.Join(runtimeDir, "agent.log"),
+	}
+	key := make([]byte, crypto.KeyLen)
+
+	start := time.Now()
+	err = SpawnDaemon(paths, "/tmp/nope.toml", time.Second, key)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected SpawnDaemon to return an error; got nil")
+	}
+	if !strings.Contains(err.Error(), "agent exited early") {
+		t.Fatalf("expected 'agent exited early' in error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "did not start within") {
+		t.Fatalf("got timeout error instead of early-exit error: %v", err)
+	}
+	// Sanity: the log-tail suffix must carry the child's stderr so the
+	// real cause (e.g. `unknown command "__agent"`) is visible.
+	if !strings.Contains(err.Error(), `unknown command "__agent"`) {
+		t.Fatalf("expected log tail with child stderr, got: %v", err)
+	}
+	// Must complete well under spawnTimeout. 2s gives generous slack
+	// for slow CI hardware while still being orders of magnitude under
+	// the 10s default.
+	if elapsed > 2*time.Second {
+		t.Fatalf("SpawnDaemon took %s for an early-exiting child; want <2s (#276 regression)", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace the dead-code `cmd.ProcessState != nil` check in `SpawnDaemon` (Unix + Windows) with a Wait-goroutine that races against the socket-readiness probe, so a crashing child surfaces `agent exited early: ...` immediately instead of blocking for the full `spawnTimeout` (10s by default since #266).
- Drop the `cmd.Process.Release()` call on success — Release tells Go to forget the process, but the parked Wait goroutine still wants it.
- Convert `resolveAgentExecutable` to a function variable so the new regression test can inject a fake-agent binary.
- New `TestSpawnDaemonSurfacesEarlyChildExit` uses the test binary as a fake agent (drain the key fd, exit 1) and asserts `SpawnDaemon` returns the early-exit error well under 2s.

`exec.Cmd.ProcessState` is only populated by `cmd.Wait()`, which the old code never called — so every early-death failure mode (wrong binary, panic in init, denied socket dir) presented as a generic 10s timeout, hiding the real cause from the inline-unlock flow.

Closes #276

## Test plan
- [x] `go test ./internal/agent -run TestSpawnDaemonSurfacesEarlyChildExit -v` (passes in ~7ms)
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run`
- [x] `go vet ./...`
- [x] `GOOS=windows go build ./...` (Windows path compiles)
- [x] `GOOS=darwin go build ./...` (Darwin path compiles)
- [x] `go test ./internal/run -run TestRunInlineUnlockFromHookBinary` (real SpawnDaemon success-path e2e still works under wait goroutine)