### PR TITLE
cli: pin master key buffer in sources/config commands (closes #280)

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -162,6 +162,7 @@ available, e.g. via an expect-style wrapper).`,
 				return nil
 			}
 			defer zeroBytes(key)
+			defer lockKey(key)()
 			if err := config.DecryptInPlace(c, key); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "note: could not decrypt to compute warnings: %v\n", err)
 				return nil

--- a/internal/cli/sources.go
+++ b/internal/cli/sources.go
@@ -53,6 +53,7 @@ func newSourcesListCmd() *cobra.Command {
 				return err
 			}
 			defer zeroBytes(key)
+			defer lockKey(key)()
 			if err := config.DecryptInPlace(cfg, key); err != nil {
 				return err
 			}
@@ -108,6 +109,7 @@ func newSourcesTestCmd() *cobra.Command {
 				return err
 			}
 			defer zeroBytes(key)
+			defer lockKey(key)()
 			// Decrypt first: post-#248 the on-disk Sources map is keyed by
 			// opaque IDs, and DecryptInPlace translates them back to the
 			// user-facing names this command looks up by.


### PR DESCRIPTION
## Summary

- `sources list`, `sources test`, and `config validate` derived the master key with `defer zeroBytes(key)` but no matching `defer lockKey(key)()`, leaving the 32-byte buffer in pageable memory for the command's lifetime.
- Every other key-holding entry point in the codebase already pins via `lockKey` (`internal/cli/unlock.go`, `bag_import.go`, `agent_internal.go`, `internal/unlock/unlock.go`).
- Net regression vs pre-#248 for `sources list` and `config validate`, which previously didn't derive a key at all.

Three-line diff — adds `defer lockKey(key)()` immediately after each `defer zeroBytes(key)`.

Closes #280

## Test plan

- [x] `go test ./...` (all packages green)
- [x] `go vet ./internal/cli/...`
- [x] `golangci-lint run ./internal/cli/...` (clean)
- [x] Convention check: `grep -nE 'DeriveKeyFromMeta|lockKey' internal/cli/*.go internal/unlock/*.go` shows every key-deriving site now pairs zeroBytes with lockKey