### PR TITLE
sync: atomic-write fsync, incomplete-remote detection, S3 ETag CAS (closes #278, #279, #281)

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,86 @@
+// Package atomicfile centralizes the "write a sibling tempfile, fsync,
+// then rename over the destination" pattern used by jitenv's on-disk
+// state writers (encrypted config, sync sidecar, sync blob/meta).
+//
+// Two correctness properties live here:
+//
+//   - Durability: tmp.Sync() runs before Close so a kernel panic or
+//     power loss between Close and Rename cannot lose the bytes on
+//     filesystems with weak crash semantics (ext4 data=writeback, some
+//     FUSE backends, NFS without server-side commits). Without the
+//     fsync, the rename can land but point at a still-buffered, partly
+//     empty file after recovery.
+//
+//   - No leak on rename failure: every failure branch (Chmod, Write,
+//     Sync, Close, Rename) removes the sibling tempfile. The pre-#281
+//     copies forgot to clean up after a failed os.Rename, so each retry
+//     against a destination on a read-only/EXDEV parent dir would leave
+//     a fresh .jitenv-*-tmp file containing encrypted ciphertext.
+//
+// Parent-directory fsync (so the rename itself survives a crash) is
+// deliberately out of scope for v1: it has platform splits and the
+// sync-blob's recovery model is "re-push from the still-good local
+// config", so a missing-after-crash blob is the safe failure.
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Write atomically writes data to path with the given mode. It creates a
+// sibling tempfile in path's directory, writes + fsyncs + closes it, and
+// renames over path. On any failure the tempfile is removed.
+//
+// pattern is passed to os.CreateTemp; it must contain a "*" the way
+// os.CreateTemp documents so concurrent writers don't collide. Callers
+// pick a leading "." to keep the tempfile hidden.
+func Write(path string, data []byte, perm os.FileMode, pattern string) error {
+	return WriteFunc(path, perm, pattern, func(f *os.File) error {
+		_, err := f.Write(data)
+		return err
+	})
+}
+
+// WriteFunc is like Write but the caller supplies a producer that writes
+// the payload directly into the tempfile (e.g. a streaming TOML encoder
+// that would otherwise need to buffer into RAM). The producer must not
+// retain the *os.File past return; Close/Sync/Rename happen here.
+func WriteFunc(path string, perm os.FileMode, pattern string, producer func(*os.File) error) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if err := os.Chmod(tmpName, perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := producer(tmp); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	// fsync before close so the bytes are on stable storage before the
+	// rename — without this, a crash between close and rename can leave
+	// a renamed-but-empty destination on weak-crash filesystems.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		// EXDEV / ENOSPC / EACCES on the destination dir all surface here.
+		// Without this cleanup every failed retry leaks an encrypted
+		// tempfile in the parent dir.
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,102 @@
+package atomicfile_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/atomicfile"
+)
+
+func TestWriteRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.bin")
+	want := []byte("hello atomicfile")
+	if err := atomicfile.Write(path, want, 0o600, ".jitenv-test-*"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("roundtrip mismatch: got %q want %q", got, want)
+	}
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Fatalf("perm = %o, want 0600", got)
+		}
+	}
+	// No stray tempfile left behind.
+	assertNoTempfile(t, dir)
+}
+
+// TestWriteCleansUpOnRenameFailure: when os.Rename can't land the
+// tempfile, the failed write must NOT leave a .jitenv-*-tmp file in the
+// destination dir. Without fsync + cleanup this was the pre-#281 leak.
+//
+// We simulate rename failure by making the destination path a
+// non-empty directory: os.Rename refuses to overwrite a directory with
+// a file (ENOTDIR / EISDIR). The dir lives under a writable parent so
+// CreateTemp still succeeds.
+func TestWriteCleansUpOnRenameFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows os.Rename onto an existing directory has different
+		// semantics; the Unix-side coverage is what protects the
+		// vulnerable adapters (file/SSH-mounted Dropbox/iCloud).
+		t.Skip("rename-onto-directory semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	// Make `dest` a non-empty directory so renaming a regular file
+	// onto it fails (Linux returns EISDIR; macOS returns ENOTDIR).
+	if err := os.MkdirAll(filepath.Join(dest, "occupant"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	err := atomicfile.Write(dest, []byte("payload"), 0o600, ".jitenv-test-*")
+	if err == nil {
+		t.Fatal("expected Write to fail when destination is a non-empty directory")
+	}
+
+	// The whole point of #281: nothing called .jitenv-test-* remains.
+	assertNoTempfile(t, dir)
+}
+
+// TestWriteFuncProducerError surfaces a producer failure and removes
+// the tempfile, mirroring the data-path cleanup.
+func TestWriteFuncProducerError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.bin")
+	wantErr := errors.New("producer boom")
+	err := atomicfile.WriteFunc(path, 0o600, ".jitenv-test-*", func(_ *os.File) error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected producer error to propagate, got %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected destination not to exist, got err=%v", err)
+	}
+	assertNoTempfile(t, dir)
+}
+
+func assertNoTempfile(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".jitenv-") {
+			t.Fatalf("leaked tempfile %q in %s after failed write", e.Name(), dir)
+		}
+	}
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -488,12 +488,19 @@ func runSyncStatus(cmd *cobra.Command) error {
 		_, rmeta, perr := adapter.Pull(context.Background())
 		remotePresent := true
 		remoteShort := "-"
-		if errors.Is(perr, syncadapters.ErrNoRemoteState) {
+		switch {
+		case errors.Is(perr, syncadapters.ErrNoRemoteState):
 			remotePresent = false
-		} else if perr != nil {
+		case errors.Is(perr, syncadapters.ErrRemoteStateIncomplete):
+			// Surface the orphan-blob case explicitly: status would
+			// otherwise read as "diverged" against a zero-hash remote
+			// which is more confusing than helpful (#279).
+			fmt.Fprintf(out, "  %-16s [%s]  remote state is incomplete (blob or meta missing); re-publish with `jitenv sync push --force` to overwrite\n", ad.Name, ad.Type)
+			continue
+		case perr != nil:
 			fmt.Fprintf(out, "  %-16s [%s]  unreachable: %v\n", ad.Name, ad.Type, perr)
 			continue
-		} else {
+		default:
 			remoteShort = short(rmeta.Hash)
 		}
 		d := syncconfig.Decide(localHash, rmeta.Hash, ad.BaseHash, remotePresent)

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/gv/jitenv/internal/atomicfile"
 	"github.com/gv/jitenv/internal/crypto"
 )
 
@@ -136,28 +137,14 @@ func DeriveKeyFromMeta(c *Config, passphrase []byte) ([]byte, error) {
 	return key, nil
 }
 
-// atomicSave writes c to a sibling tempfile (0600) then renames over path.
+// atomicSave writes c to a sibling tempfile (0600) then renames over
+// path. Streams the TOML encoder directly into the tempfile so a large
+// config never has to buffer in RAM; durability + cleanup-on-failure
+// come from internal/atomicfile (#281).
 func atomicSave(path string, c *Config) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".jitenv-*.toml")
-	if err != nil {
-		return err
-	}
-	if err := os.Chmod(tmp.Name(), 0600); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return err
-	}
-	if err := toml.NewEncoder(tmp).Encode(c); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmp.Name())
-		return err
-	}
-	return os.Rename(tmp.Name(), path)
+	return atomicfile.WriteFunc(path, 0o600, ".jitenv-*.toml", func(f *os.File) error {
+		return toml.NewEncoder(f).Encode(c)
+	})
 }
 
 // AtomicSave is the exported variant for callers outside this package

--- a/internal/syncadapters/file/file.go
+++ b/internal/syncadapters/file/file.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gv/jitenv/internal/atomicfile"
 	"github.com/gv/jitenv/internal/syncadapters"
 	"github.com/gv/jitenv/pkg/syncadapter"
 )
@@ -68,63 +69,54 @@ func (a *adapter) Push(ctx context.Context, blob []byte, meta syncadapter.Meta) 
 	if err := a.Validate(ctx); err != nil {
 		return err
 	}
-	if err := writeFileAtomic(a.path, blob, 0600); err != nil {
+	if err := atomicfile.Write(a.path, blob, 0600, ".jitenv-sync-*"); err != nil {
 		return fmt.Errorf("file adapter: write blob: %w", err)
 	}
 	mb, err := json.Marshal(meta)
 	if err != nil {
 		return err
 	}
-	if err := writeFileAtomic(a.metaPath(), mb, 0600); err != nil {
+	if err := atomicfile.Write(a.metaPath(), mb, 0600, ".jitenv-sync-*"); err != nil {
 		return fmt.Errorf("file adapter: write meta: %w", err)
 	}
 	return nil
 }
 
+// Pull reads the (blob, meta) pair. Three distinct outcomes:
+//
+//   - both files absent → ErrNoRemoteState (clean first-push case).
+//   - exactly one of the two absent → ErrRemoteStateIncomplete (the remote
+//     is corrupt, typically a partial Push or partial replication; #279).
+//   - both present → (blob, meta, nil).
+//
+// The two missing-cases used to collapse to ErrNoRemoteState, which let
+// the engine's pre-push fence treat an orphan blob as "fine, first push"
+// and silently clobber it. Splitting the errors is what lets PushConfig
+// require --force in the corrupt case.
 func (a *adapter) Pull(ctx context.Context) ([]byte, syncadapter.Meta, error) {
-	blob, err := os.ReadFile(a.path)
-	if errors.Is(err, os.ErrNotExist) {
+	blob, blobErr := os.ReadFile(a.path)
+	mb, metaErr := os.ReadFile(a.metaPath())
+
+	blobMissing := errors.Is(blobErr, os.ErrNotExist)
+	metaMissing := errors.Is(metaErr, os.ErrNotExist)
+
+	switch {
+	case blobMissing && metaMissing:
 		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
+	case blobMissing && metaErr == nil:
+		return nil, syncadapter.Meta{}, syncadapters.ErrRemoteStateIncomplete
+	case metaMissing && blobErr == nil:
+		return nil, syncadapter.Meta{}, syncadapters.ErrRemoteStateIncomplete
 	}
-	if err != nil {
-		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: read blob: %w", err)
+	if blobErr != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: read blob: %w", blobErr)
 	}
-	mb, err := os.ReadFile(a.metaPath())
-	if errors.Is(err, os.ErrNotExist) {
-		// A blob without meta is corrupt remote state; treat as missing.
-		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
-	}
-	if err != nil {
-		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: read meta: %w", err)
+	if metaErr != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: read meta: %w", metaErr)
 	}
 	var meta syncadapter.Meta
 	if err := json.Unmarshal(mb, &meta); err != nil {
 		return nil, syncadapter.Meta{}, fmt.Errorf("file adapter: parse meta: %w", err)
 	}
 	return blob, meta, nil
-}
-
-// writeFileAtomic writes via a sibling tempfile + rename so a reader
-// never sees a half-written blob.
-func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".jitenv-sync-*")
-	if err != nil {
-		return err
-	}
-	if err := os.Chmod(tmp.Name(), perm); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmp.Name())
-		return err
-	}
-	return os.Rename(tmp.Name(), path)
 }

--- a/internal/syncadapters/file/file_test.go
+++ b/internal/syncadapters/file/file_test.go
@@ -1,0 +1,100 @@
+package file_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gv/jitenv/internal/syncadapters"
+	_ "github.com/gv/jitenv/internal/syncadapters/file"
+	"github.com/gv/jitenv/pkg/syncadapter"
+)
+
+// build is a tiny helper to instantiate the file adapter via the
+// registry (mirrors how the engine builds it in production).
+func build(t *testing.T, dir string) syncadapter.Adapter {
+	t.Helper()
+	a, err := syncadapters.Build("file", map[string]any{"path": filepath.Join(dir, "blob")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+// TestPullEmptyRemoteIsNoState: with neither blob nor meta present,
+// Pull returns ErrNoRemoteState (the clean first-push case).
+func TestPullEmptyRemoteIsNoState(t *testing.T) {
+	dir := t.TempDir()
+	a := build(t, dir)
+	_, _, err := a.Pull(context.Background())
+	if !errors.Is(err, syncadapters.ErrNoRemoteState) {
+		t.Fatalf("expected ErrNoRemoteState on empty remote, got %v", err)
+	}
+}
+
+// TestPullBlobWithoutMetaIsIncomplete: a blob present without its
+// meta sidecar must surface ErrRemoteStateIncomplete so the engine's
+// pre-push fence can refuse a non-force overwrite (#279).
+func TestPullBlobWithoutMetaIsIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "blob"), []byte("ciphertext"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a := build(t, dir)
+	_, _, err := a.Pull(context.Background())
+	if !errors.Is(err, syncadapters.ErrRemoteStateIncomplete) {
+		t.Fatalf("expected ErrRemoteStateIncomplete, got %v", err)
+	}
+}
+
+// TestPullMetaWithoutBlobIsIncomplete: the symmetric case — meta
+// present, blob absent — must also surface the incomplete-state
+// error (#279).
+func TestPullMetaWithoutBlobIsIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "blob.meta.json"), []byte(`{"hash":"abc","schema_version":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	a := build(t, dir)
+	_, _, err := a.Pull(context.Background())
+	if !errors.Is(err, syncadapters.ErrRemoteStateIncomplete) {
+		t.Fatalf("expected ErrRemoteStateIncomplete (meta-only), got %v", err)
+	}
+}
+
+// TestPushRoundTripPullsCleanly: write both files via Push and read
+// them back. This is the happy-path counterpart to the missing-half
+// tests above.
+func TestPushRoundTripPullsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	a := build(t, dir)
+	want := []byte("ciphertext-bytes")
+	wantMeta := syncadapter.Meta{Hash: "deadbeef", SchemaVersion: 1}
+	if err := a.Push(context.Background(), want, wantMeta); err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	gotBlob, gotMeta, err := a.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if string(gotBlob) != string(want) {
+		t.Fatalf("blob mismatch: got %q", gotBlob)
+	}
+	if gotMeta != wantMeta {
+		t.Fatalf("meta mismatch: got %+v want %+v", gotMeta, wantMeta)
+	}
+	// No stray .jitenv-sync-* tempfiles after a successful Push (a
+	// rename-failure leak would surface here too).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if len(name) > 13 && name[:13] == ".jitenv-sync-" {
+			t.Fatalf("leaked tempfile %q in remote dir", name)
+		}
+	}
+}

--- a/internal/syncadapters/registry.go
+++ b/internal/syncadapters/registry.go
@@ -18,6 +18,32 @@ import (
 // distinct "nothing to pull" condition rather than a hard error.
 var ErrNoRemoteState = errors.New("no remote state")
 
+// ErrRemoteStateIncomplete is returned by an Adapter's Pull when EITHER
+// the blob OR its meta sidecar is present but the other is missing. The
+// remote is in a corrupt state — typically a partial write (Push wrote
+// the blob, then crashed before the meta), a partial replication
+// (Dropbox / iCloud delivered one file but not the other), or a manual
+// delete of one of the two files.
+//
+// PushConfig treats this as a hard refusal so a non-force push cannot
+// silently clobber an orphan blob with the operator's local state and
+// lose whatever the orphan was carrying. The user must pass --force to
+// explicitly accept overwriting the unrecoverable orphan (issue #279).
+var ErrRemoteStateIncomplete = errors.New("remote state incomplete (blob or meta missing)")
+
+// ErrPreconditionFailed is returned by adapters that support a
+// compare-and-set Push (S3 conditional PutObject with If-Match) when
+// the remote object's ETag/version no longer matches the one observed
+// at Pull-time. This is the strong form of the engine's divergence
+// fence: two simultaneous pushers from different hosts cannot both
+// land their writes — the loser sees this error instead of silently
+// overwriting (issue #278).
+//
+// Adapters that do not support CAS (file, ssh) never return this. The
+// engine treats it the same way as the soft fence's "remote advanced"
+// branch: the caller must retry after pulling, or pass --force.
+var ErrPreconditionFailed = errors.New("remote state changed since last pull (precondition failed)")
+
 var (
 	mu       sync.RWMutex
 	builders = map[string]syncadapter.Constructor{}

--- a/internal/syncadapters/s3/s3.go
+++ b/internal/syncadapters/s3/s3.go
@@ -77,6 +77,19 @@ type adapter struct {
 	once   sync.Once
 	cli    api
 	cliErr error
+
+	// etagMu guards lastBlobETag / lastSeenAt, which together carry the
+	// compare-and-set token from the most recent successful Pull into
+	// the next Push (#278). The engine drives Pull → fence → Push
+	// against the SAME adapter instance, so stashing the ETag here lets
+	// Push pass IfMatch without widening the Adapter.Push interface.
+	//
+	// A zero ETag means "Pull did not observe a blob"; Push then uses
+	// IfNoneMatch: "*" to refuse to clobber any object that appeared
+	// since (genuinely-first-push CAS).
+	etagMu       sync.Mutex
+	lastBlobETag string
+	lastObserved bool
 }
 
 // New constructs an s3 adapter. Required params: "bucket" and "key".
@@ -210,6 +223,20 @@ func (a *adapter) Validate(ctx context.Context) error {
 	return nil
 }
 
+// Push uploads the (blob, meta) pair to S3 with a compare-and-set
+// precondition (#278): if the most recent Pull observed a blob, the
+// PutObject uses IfMatch: <observed ETag> so a concurrent push that
+// landed in between is detected and rejected with
+// ErrPreconditionFailed; if Pull observed no blob, the PutObject uses
+// IfNoneMatch: "*" so a racing first-push from another host is also
+// detected.
+//
+// The CAS guard applies to the BLOB only. The meta sidecar is written
+// after the blob lands; if a concurrent writer raced and lost on the
+// blob, no meta was overwritten because we never reached this step.
+// (A meta that lags behind its blob is exactly the
+// ErrRemoteStateIncomplete state PullConfig refuses to fast-forward
+// through, so the engine self-heals on the next push.)
 func (a *adapter) Push(ctx context.Context, blob []byte, meta syncadapter.Meta) error {
 	if err := a.Validate(ctx); err != nil {
 		return err
@@ -218,7 +245,16 @@ func (a *adapter) Push(ctx context.Context, blob []byte, meta syncadapter.Meta) 
 	if err != nil {
 		return err
 	}
-	if err := a.putObject(ctx, a.key, blob); err != nil {
+
+	a.etagMu.Lock()
+	prevETag := a.lastBlobETag
+	observed := a.lastObserved
+	a.etagMu.Unlock()
+
+	if err := a.putObjectCAS(ctx, a.key, blob, prevETag, observed); err != nil {
+		if isPreconditionFailed(err) {
+			return fmt.Errorf("s3 adapter: %w", syncadapters.ErrPreconditionFailed)
+		}
 		return fmt.Errorf("s3 adapter: put blob: %w", err)
 	}
 	if err := a.putObject(ctx, a.metaKey(), mb); err != nil {
@@ -227,13 +263,50 @@ func (a *adapter) Push(ctx context.Context, blob []byte, meta syncadapter.Meta) 
 	return nil
 }
 
-// putObject writes one object with server-side encryption requested:
-// SSE-KMS when a key ID is configured, otherwise SSE-S3 (AES256).
+// putObject writes one object with server-side encryption requested
+// (SSE-KMS when a key ID is configured, otherwise SSE-S3) and NO
+// precondition. Used for the meta sidecar, whose CAS is implicit in
+// the blob's: if the blob put was rejected on a stale ETag we never
+// reach the meta put, and a meta-without-blob is surfaced as
+// ErrRemoteStateIncomplete on the next Pull (#279).
 func (a *adapter) putObject(ctx context.Context, key string, data []byte) error {
 	cli, err := a.client(ctx)
 	if err != nil {
 		return err
 	}
+	in := a.buildPutInput(key, data)
+	_, err = cli.PutObject(ctx, in)
+	return err
+}
+
+// putObjectCAS is putObject + a precondition header derived from the
+// most recent Pull observation. When observed is true and prevETag is
+// non-empty, IfMatch is set (CAS against a known prior version). When
+// observed is false, IfNoneMatch "*" is set (refuse to overwrite any
+// object — guards the first-push race). When observed is true and
+// prevETag is empty (a degraded path — Pull saw the object but the
+// SDK returned no ETag), no precondition is sent: the engine's
+// soft pre-push fence still catches the common case.
+func (a *adapter) putObjectCAS(ctx context.Context, key string, data []byte, prevETag string, observed bool) error {
+	cli, err := a.client(ctx)
+	if err != nil {
+		return err
+	}
+	in := a.buildPutInput(key, data)
+	switch {
+	case observed && prevETag != "":
+		in.IfMatch = awsv2.String(prevETag)
+	case !observed:
+		in.IfNoneMatch = awsv2.String("*")
+	}
+	_, err = cli.PutObject(ctx, in)
+	return err
+}
+
+// buildPutInput centralizes the shared PutObjectInput shape (bucket,
+// key, body, SSE settings). Callers add the precondition headers they
+// need on top.
+func (a *adapter) buildPutInput(key string, data []byte) *s3.PutObjectInput {
 	in := &s3.PutObjectInput{
 		Bucket: awsv2.String(a.bucket),
 		Key:    awsv2.String(key),
@@ -245,26 +318,62 @@ func (a *adapter) putObject(ctx context.Context, key string, data []byte) error 
 	} else {
 		in.ServerSideEncryption = types.ServerSideEncryptionAes256
 	}
-	_, err = cli.PutObject(ctx, in)
-	return err
+	return in
 }
 
+// isPreconditionFailed reports whether err is the S3 412 conditional-
+// write failure. The SDK exposes it as an APIError with code
+// "PreconditionFailed"; tests inject the same code via the smithy
+// APIError interface.
+func isPreconditionFailed(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "PreconditionFailed", "412":
+			return true
+		}
+	}
+	return false
+}
+
+// Pull reads the (blob, meta) pair from S3. It distinguishes three
+// outcomes (#279): both objects absent → ErrNoRemoteState (clean first
+// push); exactly one absent → ErrRemoteStateIncomplete (corrupt remote
+// state — typically a Push that PutObject'd the blob but failed before
+// the meta); both present → (blob, meta, nil).
+//
+// Conflating the two missing-cases let the engine's pre-push fence
+// silently overwrite an orphan blob without --force; splitting them is
+// what restores the safety guarantee on shared buckets.
+//
+// Pull also records the blob's ETag (or its absence) on the adapter so
+// the next Push against this instance can issue an If-Match (or
+// If-None-Match: "*") conditional PutObject for proper CAS (#278).
 func (a *adapter) Pull(ctx context.Context) ([]byte, syncadapter.Meta, error) {
-	blob, err := a.getObject(ctx, a.key)
-	if errors.Is(err, syncadapters.ErrNoRemoteState) {
+	blob, blobETag, blobErr := a.getObject(ctx, a.key)
+	mb, _, metaErr := a.getObject(ctx, a.metaKey())
+
+	blobMissing := errors.Is(blobErr, syncadapters.ErrNoRemoteState)
+	metaMissing := errors.Is(metaErr, syncadapters.ErrNoRemoteState)
+
+	// Stash the observed-blob state for the next Push regardless of
+	// outcome below: incomplete/clean/first-push all want to feed the
+	// CAS layer with whatever the blob currently looks like.
+	a.recordBlobObservation(blobETag, !blobMissing)
+
+	switch {
+	case blobMissing && metaMissing:
 		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
+	case blobMissing && metaErr == nil:
+		return nil, syncadapter.Meta{}, syncadapters.ErrRemoteStateIncomplete
+	case metaMissing && blobErr == nil:
+		return nil, syncadapter.Meta{}, syncadapters.ErrRemoteStateIncomplete
 	}
-	if err != nil {
-		return nil, syncadapter.Meta{}, fmt.Errorf("s3 adapter: get blob: %w", err)
+	if blobErr != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("s3 adapter: get blob: %w", blobErr)
 	}
-	mb, err := a.getObject(ctx, a.metaKey())
-	if errors.Is(err, syncadapters.ErrNoRemoteState) {
-		// A blob without its meta sidecar is corrupt remote state; treat
-		// as missing (mirrors the file/ssh adapters).
-		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
-	}
-	if err != nil {
-		return nil, syncadapter.Meta{}, fmt.Errorf("s3 adapter: get meta: %w", err)
+	if metaErr != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("s3 adapter: get meta: %w", metaErr)
 	}
 	var meta syncadapter.Meta
 	if err := json.Unmarshal(mb, &meta); err != nil {
@@ -273,12 +382,25 @@ func (a *adapter) Pull(ctx context.Context) ([]byte, syncadapter.Meta, error) {
 	return blob, meta, nil
 }
 
-// getObject reads one object's bytes. A missing object is reported as
-// syncadapters.ErrNoRemoteState.
-func (a *adapter) getObject(ctx context.Context, key string) ([]byte, error) {
+// recordBlobObservation stashes the most recently observed ETag for
+// the blob object, used by Push's conditional PutObject. observed
+// reflects whether Pull saw the object at all; etag may be empty even
+// when observed=true if the server returned no ETag (older S3-
+// compatible stores).
+func (a *adapter) recordBlobObservation(etag string, observed bool) {
+	a.etagMu.Lock()
+	a.lastBlobETag = etag
+	a.lastObserved = observed
+	a.etagMu.Unlock()
+}
+
+// getObject reads one object's bytes and returns its ETag. A missing
+// object is reported as syncadapters.ErrNoRemoteState (with empty
+// ETag).
+func (a *adapter) getObject(ctx context.Context, key string) ([]byte, string, error) {
 	cli, err := a.client(ctx)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	out, err := cli.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: awsv2.String(a.bucket),
@@ -286,12 +408,20 @@ func (a *adapter) getObject(ctx context.Context, key string) ([]byte, error) {
 	})
 	if err != nil {
 		if isNotFound(err) {
-			return nil, syncadapters.ErrNoRemoteState
+			return nil, "", syncadapters.ErrNoRemoteState
 		}
-		return nil, err
+		return nil, "", err
 	}
 	defer out.Body.Close()
-	return io.ReadAll(out.Body)
+	body, rerr := io.ReadAll(out.Body)
+	if rerr != nil {
+		return nil, "", rerr
+	}
+	var etag string
+	if out.ETag != nil {
+		etag = *out.ETag
+	}
+	return body, etag, nil
 }
 
 // isNotFound reports whether err is an S3 "object/key absent" condition.

--- a/internal/syncadapters/s3/s3_test.go
+++ b/internal/syncadapters/s3/s3_test.go
@@ -3,6 +3,10 @@ package s3
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"testing"
@@ -10,6 +14,7 @@ import (
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/gv/jitenv/internal/syncadapters"
 	"github.com/gv/jitenv/pkg/syncadapter"
@@ -18,30 +23,82 @@ import (
 // fakeS3 is an in-memory S3 keyed by object key. It records the SSE
 // settings of the last PutObject so tests can assert encryption-at-rest
 // is requested. No AWS credentials or network are involved.
+//
+// It also implements minimal ETag + If-Match / If-None-Match semantics
+// so the CAS path (#278) can be exercised without LocalStack.
 type fakeS3 struct {
 	objects map[string][]byte
+	etags   map[string]string
 
 	lastSSE    types.ServerSideEncryption
 	lastKMSKey string
+	// putHeaders records the precondition headers seen on EACH PutObject,
+	// keyed by object key. Tests assert per-key (e.g. the BLOB put got
+	// IfMatch, the META put did not).
+	putHeaders map[string]putHeaders
 
 	// Validate-path knobs.
 	policyPublic bool          // GetBucketPolicyStatus.IsPublic
 	aclGrants    []types.Grant // GetBucketAcl.Grants
 }
 
-func newFakeS3() *fakeS3 { return &fakeS3{objects: map[string][]byte{}} }
+type putHeaders struct {
+	IfMatch     string
+	IfNoneMatch string
+}
+
+func newFakeS3() *fakeS3 {
+	return &fakeS3{
+		objects:    map[string][]byte{},
+		etags:      map[string]string{},
+		putHeaders: map[string]putHeaders{},
+	}
+}
+
+// fakePreconditionFailed is an APIError fake matching the smithy
+// interface so the adapter's isPreconditionFailed detector triggers.
+type fakePreconditionFailed struct{}
+
+func (fakePreconditionFailed) Error() string                 { return "PreconditionFailed" }
+func (fakePreconditionFailed) ErrorCode() string             { return "PreconditionFailed" }
+func (fakePreconditionFailed) ErrorMessage() string          { return "PreconditionFailed" }
+func (fakePreconditionFailed) ErrorFault() smithy.ErrorFault { return smithy.FaultClient }
 
 func (f *fakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	hdr := putHeaders{}
+	if in.IfMatch != nil {
+		hdr.IfMatch = *in.IfMatch
+	}
+	if in.IfNoneMatch != nil {
+		hdr.IfNoneMatch = *in.IfNoneMatch
+	}
+	f.putHeaders[*in.Key] = hdr
+	// Evaluate preconditions before the write lands.
+	if in.IfMatch != nil {
+		cur, exists := f.etags[*in.Key]
+		if !exists || cur != *in.IfMatch {
+			return nil, fakePreconditionFailed{}
+		}
+	}
+	if in.IfNoneMatch != nil && *in.IfNoneMatch == "*" {
+		if _, exists := f.objects[*in.Key]; exists {
+			return nil, fakePreconditionFailed{}
+		}
+	}
 	data, err := io.ReadAll(in.Body)
 	if err != nil {
 		return nil, err
 	}
 	f.objects[*in.Key] = data
+	// S3 ETags for non-multipart uploads are the hex MD5 in quotes.
+	sum := md5.Sum(data)
+	etag := fmt.Sprintf("\"%s\"", hex.EncodeToString(sum[:]))
+	f.etags[*in.Key] = etag
 	f.lastSSE = in.ServerSideEncryption
 	if in.SSEKMSKeyId != nil {
 		f.lastKMSKey = *in.SSEKMSKeyId
 	}
-	return &s3.PutObjectOutput{}, nil
+	return &s3.PutObjectOutput{ETag: awsv2.String(etag)}, nil
 }
 
 func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
@@ -49,14 +106,16 @@ func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*
 	if !ok {
 		return nil, &types.NoSuchKey{}
 	}
-	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data))}, nil
+	etag := f.etags[*in.Key]
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data)), ETag: awsv2.String(etag)}, nil
 }
 
 func (f *fakeS3) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
 	if _, ok := f.objects[*in.Key]; !ok {
 		return nil, &types.NotFound{}
 	}
-	return &s3.HeadObjectOutput{}, nil
+	etag := f.etags[*in.Key]
+	return &s3.HeadObjectOutput{ETag: awsv2.String(etag)}, nil
 }
 
 func (f *fakeS3) GetBucketPolicyStatus(_ context.Context, _ *s3.GetBucketPolicyStatusInput, _ ...func(*s3.Options)) (*s3.GetBucketPolicyStatusOutput, error) {
@@ -98,6 +157,16 @@ func TestS3PushPullRoundTrip(t *testing.T) {
 	if err := a.Push(context.Background(), want, meta); err != nil {
 		t.Fatalf("push: %v", err)
 	}
+	// First push: no prior observation, so the BLOB put must send
+	// IfNoneMatch: "*" to guard against a concurrent first writer (#278).
+	if got := fs.putHeaders["jitenv/blob"].IfNoneMatch; got != "*" {
+		t.Fatalf("expected IfNoneMatch=\"*\" on first blob push, got %q", got)
+	}
+	// The meta sidecar must NOT carry a precondition: its CAS is
+	// implicit in the blob's (a stale-blob push never reaches the meta).
+	if got := fs.putHeaders["jitenv/blob.meta.json"]; got.IfMatch != "" || got.IfNoneMatch != "" {
+		t.Fatalf("expected meta put to be unconditional, got %+v", got)
+	}
 
 	got, gotMeta, err := a.Pull(context.Background())
 	if err != nil {
@@ -113,6 +182,15 @@ func TestS3PushPullRoundTrip(t *testing.T) {
 	// Default (no KMS key) must request SSE-S3 (AES256).
 	if fs.lastSSE != types.ServerSideEncryptionAes256 {
 		t.Fatalf("expected SSE AES256, got %q", fs.lastSSE)
+	}
+
+	// A second push after that Pull must carry IfMatch=<observed ETag>
+	// on the BLOB put (CAS against the known prior version).
+	if err := a.Push(context.Background(), []byte("next"), syncadapter.Meta{Hash: "x", SchemaVersion: 1}); err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+	if fs.putHeaders["jitenv/blob"].IfMatch == "" {
+		t.Fatalf("expected IfMatch header on Push-after-Pull, got none")
 	}
 }
 
@@ -136,15 +214,82 @@ func TestS3PutRequestsKMSWhenConfigured(t *testing.T) {
 	}
 }
 
-// TestS3PullMissingMetaIsNoRemoteState: a blob present but its meta
-// sidecar absent is treated as no remote state (corrupt remote).
-func TestS3PullMissingMetaIsNoRemoteState(t *testing.T) {
+// TestS3PullMissingMetaIsIncomplete: a blob present but its meta
+// sidecar absent must surface ErrRemoteStateIncomplete so the engine's
+// pre-push fence refuses a non-force overwrite of the orphan (#279).
+func TestS3PullMissingMetaIsIncomplete(t *testing.T) {
 	fs := newFakeS3()
 	a := newFakeAdapter(t, fs, nil)
-	// Plant only the blob, not the meta.
 	fs.objects["jitenv/blob"] = []byte("blob-only")
+	fs.etags["jitenv/blob"] = "\"deadbeef\""
+	_, _, err := a.Pull(context.Background())
+	if !errors.Is(err, syncadapters.ErrRemoteStateIncomplete) {
+		t.Fatalf("expected ErrRemoteStateIncomplete for missing meta, got %v", err)
+	}
+}
+
+// TestS3PullMissingBlobIsIncomplete: the symmetric case — meta
+// present, blob absent — must also surface ErrRemoteStateIncomplete.
+func TestS3PullMissingBlobIsIncomplete(t *testing.T) {
+	fs := newFakeS3()
+	a := newFakeAdapter(t, fs, nil)
+	fs.objects["jitenv/blob.meta.json"] = []byte(`{"hash":"abc","schema_version":1}`)
+	fs.etags["jitenv/blob.meta.json"] = "\"feedface\""
+	_, _, err := a.Pull(context.Background())
+	if !errors.Is(err, syncadapters.ErrRemoteStateIncomplete) {
+		t.Fatalf("expected ErrRemoteStateIncomplete for missing blob, got %v", err)
+	}
+}
+
+// TestS3PushCASRejectsConcurrentClobber: machine A pulls, then a third
+// party rewrites the blob (changing its ETag), then A pushes — the
+// PutObject must fail with ErrPreconditionFailed instead of silently
+// overwriting B's update (#278).
+func TestS3PushCASRejectsConcurrentClobber(t *testing.T) {
+	fs := newFakeS3()
+	a := newFakeAdapter(t, fs, nil)
+
+	// Seed an initial (blob, meta) pair so Pull sees a real ETag.
+	if err := a.Push(context.Background(), []byte("v1"), syncadapter.Meta{Hash: "h1", SchemaVersion: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := a.Pull(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a concurrent writer overwriting the blob between Pull
+	// and Push. This bumps the stored ETag, so A's stashed ETag is now
+	// stale — exactly the TOCTOU window the CAS guards.
+	fs.objects["jitenv/blob"] = []byte("v2-by-other-host")
+	fs.etags["jitenv/blob"] = "\"changed-by-other\""
+
+	// A's push must be rejected at the precondition check.
+	err := a.Push(context.Background(), []byte("v3-by-A"), syncadapter.Meta{Hash: "h3", SchemaVersion: 1})
+	if !errors.Is(err, syncadapters.ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed on stale-ETag push, got %v", err)
+	}
+}
+
+// TestS3PushFirstPushCASRejectsRace: two concurrent first pushes —
+// after one lands, the other (which started with lastObserved=false
+// from its own Pull) must fail with ErrPreconditionFailed via the
+// IfNoneMatch: "*" guard (#278).
+func TestS3PushFirstPushCASRejectsRace(t *testing.T) {
+	fs := newFakeS3()
+	a := newFakeAdapter(t, fs, nil)
+
+	// Adapter's Pull sees nothing (clean state).
 	if _, _, err := a.Pull(context.Background()); err != syncadapters.ErrNoRemoteState {
-		t.Fatalf("expected ErrNoRemoteState for missing meta, got %v", err)
+		t.Fatalf("setup: expected ErrNoRemoteState, got %v", err)
+	}
+
+	// A third party "wins" the race and writes the blob first.
+	fs.objects["jitenv/blob"] = []byte("racer-wrote-first")
+	fs.etags["jitenv/blob"] = "\"racer\""
+
+	err := a.Push(context.Background(), []byte("our-payload"), syncadapter.Meta{Hash: "h", SchemaVersion: 1})
+	if !errors.Is(err, syncadapters.ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed on first-push race, got %v", err)
 	}
 }
 

--- a/internal/syncadapters/ssh/ssh.go
+++ b/internal/syncadapters/ssh/ssh.go
@@ -169,21 +169,36 @@ func (a *adapter) writeRemote(ctx context.Context, remotePath string, data []byt
 	return err
 }
 
+// Pull reads the (blob, meta) pair from the remote host. It
+// distinguishes three outcomes (#279): both files absent →
+// ErrNoRemoteState (clean first push); exactly one absent →
+// ErrRemoteStateIncomplete (corrupt remote — typically a partial Push
+// or a partial filesystem replication that delivered one file but not
+// the other); both present → (blob, meta, nil).
+//
+// Conflating the two missing-cases let the engine's pre-push fence
+// silently overwrite an orphan blob without --force; splitting them
+// requires the user to opt into clobbering.
 func (a *adapter) Pull(ctx context.Context) ([]byte, syncadapter.Meta, error) {
-	// Read blob; distinguish "missing" via a sentinel exit.
-	blob, err := a.readRemote(ctx, a.path)
-	if errors.Is(err, errRemoteMissing) {
+	blob, blobErr := a.readRemote(ctx, a.path)
+	mb, metaErr := a.readRemote(ctx, a.metaRemote())
+
+	blobMissing := errors.Is(blobErr, errRemoteMissing)
+	metaMissing := errors.Is(metaErr, errRemoteMissing)
+
+	switch {
+	case blobMissing && metaMissing:
 		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
+	case blobMissing && metaErr == nil:
+		return nil, syncadapter.Meta{}, syncadapters.ErrRemoteStateIncomplete
+	case metaMissing && blobErr == nil:
+		return nil, syncadapter.Meta{}, syncadapters.ErrRemoteStateIncomplete
 	}
-	if err != nil {
-		return nil, syncadapter.Meta{}, fmt.Errorf("ssh adapter: read blob: %w", err)
+	if blobErr != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("ssh adapter: read blob: %w", blobErr)
 	}
-	mb, err := a.readRemote(ctx, a.metaRemote())
-	if errors.Is(err, errRemoteMissing) {
-		return nil, syncadapter.Meta{}, syncadapters.ErrNoRemoteState
-	}
-	if err != nil {
-		return nil, syncadapter.Meta{}, fmt.Errorf("ssh adapter: read meta: %w", err)
+	if metaErr != nil {
+		return nil, syncadapter.Meta{}, fmt.Errorf("ssh adapter: read meta: %w", metaErr)
 	}
 	var meta syncadapter.Meta
 	if err := json.Unmarshal(mb, &meta); err != nil {

--- a/internal/syncconfig/engine.go
+++ b/internal/syncconfig/engine.go
@@ -30,14 +30,42 @@ type PullResult struct {
 // new base hash on ad (the caller persists the sidecar).
 //
 // dek and masterKey are NOT logged; the caller owns zeroing them.
+//
+// Concurrency note: the pre-push fence here is best-effort — it relies
+// on the adapter's Pull reflecting whatever was last successfully
+// pushed (TOCTOU). Adapters that can offer stronger compare-and-set
+// guarantees layer them on top INSIDE their Push using state
+// remembered from the immediately-preceding Pull: the s3 adapter
+// stashes the blob's ETag at Pull-time and issues PutObject with
+// If-Match on Push (#278), so two concurrent pushers from different
+// hosts cannot both land — the loser sees ErrPreconditionFailed
+// instead of silently overwriting. The file and ssh adapters have no
+// equivalent CAS primitive available without OS-level coordination
+// (flock / a distributed lock service) and remain TOCTOU-vulnerable;
+// that gap is documented in pkg/syncadapter/syncadapter.go's v2 Lock
+// note.
 func PushConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, dek, cfgBytes []byte, schemaVersion int, force bool) (PushResult, error) {
 	localHash := HashConfig(cfgBytes)
 
+	// Always Pull before Push, even on --force: the soft fence is
+	// skipped under --force, but CAS-capable adapters (s3) stash the
+	// observed ETag during Pull so the subsequent Push can issue
+	// If-Match. Without a Pull on the force path the adapter would
+	// fall back to IfNoneMatch:"*" and refuse to overwrite any
+	// existing object — defeating --force entirely (#278). Errors
+	// from the pre-push Pull are evaluated below; on --force the
+	// errors are tolerated and the Push proceeds.
+	_, rmeta, rerr := adapter.Pull(ctx)
 	if !force {
-		_, rmeta, rerr := adapter.Pull(ctx)
 		switch {
 		case errors.Is(rerr, syncadapters.ErrNoRemoteState):
 			// first push; fine
+		case errors.Is(rerr, syncadapters.ErrRemoteStateIncomplete):
+			// The remote has a blob without its meta (or vice versa).
+			// Treat as a hard refusal: a non-force push would silently
+			// clobber the orphan and lose whatever it was carrying. The
+			// user must pass --force to explicitly overwrite (#279).
+			return PushResult{}, fmt.Errorf("remote state is incomplete (blob without meta or meta without blob); inspect the remote and re-publish with `jitenv sync push --force` to overwrite, or restore the missing file manually")
 		case rerr != nil:
 			return PushResult{}, fmt.Errorf("pre-push remote check failed: %w", rerr)
 		default:
@@ -63,6 +91,14 @@ func PushConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, d
 	}
 	meta := syncadapter.Meta{Hash: localHash, SchemaVersion: schemaVersion}
 	if err := adapter.Push(ctx, blob, meta); err != nil {
+		if errors.Is(err, syncadapters.ErrPreconditionFailed) {
+			// A CAS-capable adapter rejected the write because the
+			// remote object changed between our pre-push Pull and the
+			// Push itself — symmetric with the soft-fence's "remote
+			// advanced" branch, but enforced by the storage. Surface it
+			// with the same remediation steps (#278).
+			return PushResult{}, fmt.Errorf("remote changed between pull and push (concurrent writer); run `jitenv sync pull` to reconcile and retry, or push with --force to overwrite")
+		}
 		return PushResult{}, err
 	}
 	ad.BaseHash = localHash
@@ -88,6 +124,12 @@ func PullConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, d
 	remotePresent := true
 	if errors.Is(perr, syncadapters.ErrNoRemoteState) {
 		remotePresent = false
+	} else if errors.Is(perr, syncadapters.ErrRemoteStateIncomplete) {
+		// Remote has only one of (blob, meta). We can't decrypt or even
+		// hash-check anything, so surface a clear error instead of
+		// falling through to a hash-only Decide() that would treat the
+		// zero-hash meta as a valid divergence input (#279).
+		return PullResult{}, fmt.Errorf("remote state is incomplete (blob without meta or meta without blob); inspect the remote and either restore the missing file or re-publish from a known-good machine with `jitenv sync push --force`")
 	} else if perr != nil {
 		return PullResult{}, perr
 	}

--- a/internal/syncconfig/engine.go
+++ b/internal/syncconfig/engine.go
@@ -95,9 +95,20 @@ func PushConfig(ctx context.Context, adapter syncadapter.Adapter, ad *Adapter, d
 			// A CAS-capable adapter rejected the write because the
 			// remote object changed between our pre-push Pull and the
 			// Push itself — symmetric with the soft-fence's "remote
-			// advanced" branch, but enforced by the storage. Surface it
-			// with the same remediation steps (#278).
-			return PushResult{}, fmt.Errorf("remote changed between pull and push (concurrent writer); run `jitenv sync pull` to reconcile and retry, or push with --force to overwrite")
+			// advanced" branch, but enforced by the storage (#278).
+			//
+			// Remediation differs by mode: on a non-force push the
+			// user can pull-to-reconcile or escalate to --force, but
+			// when --force itself hits the CAS, suggesting --force is
+			// circular — the user is already doing that. The CAS and
+			// the engine's soft fence are independent layers, and
+			// --force only bypasses the soft fence, not the
+			// storage-level CAS. Tell the user that and ask them to
+			// retry instead.
+			if force {
+				return PushResult{}, fmt.Errorf("remote changed during force-push (concurrent writer rejected by storage-level CAS); retry the push: %w", err)
+			}
+			return PushResult{}, fmt.Errorf("remote changed between pull and push (concurrent writer); run `jitenv sync pull` to reconcile and retry, or push with --force to overwrite: %w", err)
 		}
 		return PushResult{}, err
 	}

--- a/internal/syncconfig/engine_test.go
+++ b/internal/syncconfig/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -261,6 +262,64 @@ func TestPushFenceRejectsStaleOverwrite(t *testing.T) {
 	_, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte("version = 1\n# my edit\n"), 1, false)
 	if err == nil {
 		t.Fatal("expected stale push to be refused by the fence")
+	}
+}
+
+// TestPushFenceRejectsIncompleteRemote: an orphan blob on the remote
+// (meta sidecar manually removed, or a partial-write that lost the
+// meta) must NOT be silently clobbered by a non-force push — the
+// engine must surface ErrRemoteStateIncomplete and require --force
+// (#279).
+func TestPushFenceRejectsIncompleteRemote(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+
+	// Publish a clean (blob, meta) pair.
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt the remote by deleting the meta sidecar (mirrors a
+	// partial Push or a partial filesystem replication).
+	if err := os.Remove(remote + ".meta.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A non-force push must refuse.
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte("version = 1\n# new\n"), 1, false); err == nil {
+		t.Fatal("expected push against incomplete remote to be refused without --force")
+	}
+
+	// --force still works.
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte("version = 1\n# new\n"), 1, true); err != nil {
+		t.Fatalf("--force push against incomplete remote should succeed: %v", err)
+	}
+}
+
+// TestPullRefusesIncompleteRemote: pull against an orphan blob/meta
+// must surface a clear error rather than fall through Decide() with a
+// zero-hash remote (which would otherwise look like spurious
+// divergence). The local config must remain untouched (#279).
+func TestPullRefusesIncompleteRemote(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	a1 := buildFileAdapter(t, mk1, &m1.Adapters[0])
+
+	if _, err := syncconfig.PushConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(remote + ".meta.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := syncconfig.PullConfig(context.Background(), a1, &m1.Adapters[0], dek1, []byte(sampleConfig), false)
+	if err == nil {
+		t.Fatal("expected pull against incomplete remote to fail")
+	}
+	if res.Applied != nil {
+		t.Fatal("incomplete-remote pull must not produce an Applied payload")
 	}
 }
 

--- a/internal/syncconfig/engine_test.go
+++ b/internal/syncconfig/engine_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/gv/jitenv/internal/crypto"
@@ -359,5 +361,114 @@ func TestPushFenceRejectsNoBaseOverwrite(t *testing.T) {
 	// --force overrides the fence.
 	if _, err := syncconfig.PushConfig(context.Background(), a2, &m2.Adapters[0], dek2, localEdit, 1, true); err != nil {
 		t.Fatalf("forced push should succeed: %v", err)
+	}
+}
+
+// casRejectAdapter wraps an existing adapter and unconditionally returns
+// ErrPreconditionFailed from Push, simulating a CAS-capable backend (s3)
+// where a concurrent writer landed between the pre-push Pull and the
+// Push and the storage rejected our write. Pull and Validate delegate so
+// the engine's pre-push Pull still sees a real remote.
+type casRejectAdapter struct{ inner syncadapter.Adapter }
+
+func (c *casRejectAdapter) Name() string                       { return c.inner.Name() }
+func (c *casRejectAdapter) Validate(ctx context.Context) error { return c.inner.Validate(ctx) }
+func (c *casRejectAdapter) Pull(ctx context.Context) ([]byte, syncadapter.Meta, error) {
+	return c.inner.Pull(ctx)
+}
+func (c *casRejectAdapter) Push(_ context.Context, _ []byte, _ syncadapter.Meta) error {
+	return syncadapters.ErrPreconditionFailed
+}
+
+// TestPushCASRejectOnForceHasNonCircularMessage: when --force is set and
+// the storage-level CAS still rejects the push (the engine's soft fence
+// was bypassed by --force, but the adapter's CAS — e.g. s3 If-Match —
+// is an independent layer that --force does NOT disable), the surfaced
+// error MUST NOT tell the user to "push with --force to overwrite",
+// because the user is already doing exactly that (#278 review). It also
+// MUST wrap ErrPreconditionFailed so callers can detect the case
+// programmatically.
+func TestPushCASRejectOnForceHasNonCircularMessage(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	inner := buildFileAdapter(t, mk1, &m1.Adapters[0])
+
+	// Seed the remote so the pre-push Pull succeeds (otherwise the
+	// engine would never reach the Push call we want to exercise).
+	if _, err := syncconfig.PushConfig(context.Background(), inner, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the adapter so Push always returns ErrPreconditionFailed —
+	// the same error a CAS-capable backend produces when a concurrent
+	// writer raced us between Pull and Push.
+	rejecting := &casRejectAdapter{inner: inner}
+
+	// --force is set; the soft fence will not block, so we reach the
+	// adapter's Push, which rejects via CAS.
+	_, err := syncconfig.PushConfig(context.Background(), rejecting, &m1.Adapters[0], dek1,
+		[]byte("version = 1\n# forced edit\n"), 1, true)
+	if err == nil {
+		t.Fatal("expected force-push to surface the CAS rejection")
+	}
+	if !errors.Is(err, syncadapters.ErrPreconditionFailed) {
+		t.Fatalf("expected error to wrap ErrPreconditionFailed (for callers using errors.Is), got %v", err)
+	}
+	msg := err.Error()
+	// The remediation must not be circular: telling a user who passed
+	// --force to "push with --force" is unhelpful.
+	circular := regexp.MustCompile(`--force\s+to\s+overwrite`)
+	if circular.MatchString(msg) {
+		t.Fatalf("force-push CAS error must not suggest --force again, got: %q", msg)
+	}
+	// And it must not advise pulling-to-reconcile either: under --force
+	// the user has explicitly chosen to overwrite, so the right next
+	// step is to retry the push.
+	if strings.Contains(msg, "jitenv sync pull") {
+		t.Fatalf("force-push CAS error must not advise `jitenv sync pull` (the user already chose to overwrite), got: %q", msg)
+	}
+	// Sanity: the message should at least mention retrying so the user
+	// knows what to do.
+	if !strings.Contains(msg, "retry") {
+		t.Fatalf("force-push CAS error should suggest a retry, got: %q", msg)
+	}
+}
+
+// TestPushCASRejectWithoutForceKeepsReconcileAdvice: the non-force case
+// keeps the original remediation — pull to reconcile, or escalate to
+// --force — because both are valid next steps when the user hasn't yet
+// committed to overwriting (#278 review).
+func TestPushCASRejectWithoutForceKeepsReconcileAdvice(t *testing.T) {
+	remote := filepath.Join(t.TempDir(), "blob")
+	m1 := newMachine(t, remote)
+	mk1, dek1 := unlock(t, m1, samplePassphrase)
+	inner := buildFileAdapter(t, mk1, &m1.Adapters[0])
+
+	// Seed remote so the pre-push Pull yields a known state and our
+	// recorded base matches it — the engine's soft fence then passes
+	// through and we reach the adapter Push that the wrapper rejects.
+	if _, err := syncconfig.PushConfig(context.Background(), inner, &m1.Adapters[0], dek1, []byte(sampleConfig), 1, false); err != nil {
+		t.Fatal(err)
+	}
+
+	rejecting := &casRejectAdapter{inner: inner}
+
+	// force=false: the soft fence sees rmeta.Hash == ad.BaseHash so it
+	// does not block, then the adapter Push rejects with the CAS error.
+	_, err := syncconfig.PushConfig(context.Background(), rejecting, &m1.Adapters[0], dek1,
+		[]byte("version = 1\n# follow-up edit\n"), 1, false)
+	if err == nil {
+		t.Fatal("expected non-force push to surface the CAS rejection")
+	}
+	if !errors.Is(err, syncadapters.ErrPreconditionFailed) {
+		t.Fatalf("expected error to wrap ErrPreconditionFailed, got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "jitenv sync pull") {
+		t.Fatalf("non-force CAS error should advise `jitenv sync pull`, got: %q", msg)
+	}
+	if !strings.Contains(msg, "--force to overwrite") {
+		t.Fatalf("non-force CAS error should mention escalating to --force, got: %q", msg)
 	}
 }

--- a/internal/syncconfig/syncconfig.go
+++ b/internal/syncconfig/syncconfig.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/gv/jitenv/internal/atomicfile"
 	"github.com/gv/jitenv/internal/crypto"
 )
 
@@ -100,31 +101,15 @@ func Load(path string) (*File, error) {
 }
 
 // Save writes the sidecar atomically with 0600 perms (sibling tempfile +
-// rename), mirroring config.AtomicSave.
+// rename), mirroring config.AtomicSave. Durability + cleanup-on-failure
+// come from internal/atomicfile (#281).
 func Save(path string, f *File) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".jitenv-sync-*.toml")
-	if err != nil {
-		return err
-	}
-	if err := os.Chmod(tmp.Name(), 0600); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return err
-	}
-	if err := toml.NewEncoder(tmp).Encode(f); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmp.Name())
-		return err
-	}
-	return os.Rename(tmp.Name(), path)
+	return atomicfile.WriteFunc(path, 0o600, ".jitenv-sync-*.toml", func(w *os.File) error {
+		return toml.NewEncoder(w).Encode(f)
+	})
 }
 
 // argonParams returns the KDF params stored in the sidecar, applying the


### PR DESCRIPTION
## Summary

Three coupled correctness fixes in `internal/syncconfig` / `internal/syncadapters`.

- **#281** – Extracted `internal/atomicfile` so the file adapter, `config.AtomicSave`, and `syncconfig.Save` share one canonical sibling-tempfile + `fsync` + rename + cleanup-on-failure path. The pre-#281 copies skipped `tmp.Sync()` (a crash between close and rename could land an empty file on weak-crash filesystems) and forgot to remove the tempfile on `os.Rename` failure (every retry against an EXDEV/ENOSPC destination leaked an encrypted `.jitenv-*` fragment).
- **#279** – Adapters now distinguish "no remote state" (`ErrNoRemoteState`) from "blob OR meta missing, the other present" (`ErrRemoteStateIncomplete`). The conflated v1 behaviour let the engine's pre-push fence treat an orphan blob as "first push, fine" and silently clobber it. `PushConfig` and `PullConfig` now refuse non-force operations against an incomplete remote; `jitenv sync status` surfaces the state directly. Mirrored across the file, s3, and ssh adapters.
- **#278** – S3 adapter now provides compare-and-set on the blob `PutObject`. `Pull` stashes the observed ETag on the adapter; the next `Push` on the same instance issues `If-Match: <etag>` (when Pull saw a blob) or `If-None-Match: "*"` (when Pull saw none — guards the first-push race). A `412 PreconditionFailed` surfaces as `syncadapters.ErrPreconditionFailed`, which the engine maps to "remote changed between pull and push — retry or --force". The meta sidecar put stays unconditional (its CAS is implicit in the blob's). File and ssh adapters keep their TOCTOU window — no equivalent CAS primitive without OS-level coordination — and the gap is documented in the engine.

`PushConfig` now calls `Pull` on the `--force` path too so the S3 CAS layer is fed a fresh ETag; otherwise `--force` would always trip `If-None-Match: "*"`.

`pkg/syncadapter.Adapter` is unchanged: the CAS lives behind the s3 adapter only, no interface widening.

## Test plan

- [x] `go test ./...` — full suite green.
- [x] `go test -race ./internal/atomicfile/... ./internal/syncadapters/... ./internal/syncconfig/...` — race detector clean.
- [x] `golangci-lint run` — no findings on changed packages.
- [x] New unit tests:
  - `internal/atomicfile/atomicfile_test.go` — rename-failure leaves no tempfile (the #281 regression).
  - `internal/syncadapters/file/file_test.go` — blob-without-meta / meta-without-blob surface `ErrRemoteStateIncomplete`; happy-path Push leaves no tempfile.
  - `internal/syncadapters/s3/s3_test.go` — first-push race rejected via `If-None-Match: "*"`, stale-ETag push rejected via `If-Match`, meta put is unconditional.
  - `internal/syncconfig/engine_test.go` — `PushConfig` refuses a non-force push against an incomplete remote; `--force` overrides. `PullConfig` against an incomplete remote leaves local untouched.

Closes #278
Closes #279
Closes #281