### PR TITLE
agentwarn: drain stdin goroutine on exit; line-prompt fallback when MakeRaw fails (closes #282)

### DIFF
--- a/internal/agentwarn/agentwarn.go
+++ b/internal/agentwarn/agentwarn.go
@@ -15,6 +15,7 @@
 package agentwarn
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/signal"
@@ -30,6 +31,14 @@ import (
 // the keystroke-dispatch logic this gate guards is what's under test).
 var stdinIsTTY = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 
+// makeRaw is a hook around term.MakeRaw so tests can simulate a TTY
+// where raw mode is unavailable (issue #282 (b)). On a real TTY raw
+// mode is required for the per-keystroke countdown UX; without it the
+// reader is line-buffered and `u` doesn't fire until the user also
+// hits Enter — so we fall back to a single line-prompt that loses the
+// countdown visual but preserves the [u]/any/Ctrl+C semantics.
+var makeRaw = func(fd int) (*term.State, error) { return term.MakeRaw(fd) }
+
 // Action is the outcome of the agent-down countdown.
 type Action int
 
@@ -43,6 +52,19 @@ const (
 	// unlock flow and, on success, re-fetch env before exec.
 	ActionUnlock
 )
+
+// classifyKey maps a single byte from the TTY to an Action.
+// `u`/`U` → unlock, Ctrl+C (0x03) → abort, anything else → continue.
+func classifyKey(b byte) Action {
+	switch b {
+	case 'u', 'U':
+		return ActionUnlock
+	case 0x03: // Ctrl+C in raw mode (no SIGINT is raised)
+		return ActionAbort
+	default:
+		return ActionContinue
+	}
+}
 
 // WarnAndWait paints the warning + countdown to stderr and reports the
 // user's choice as an Action.
@@ -83,10 +105,6 @@ func WarnAndWait(target string) Action {
 		return ActionContinue
 	}
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-	defer signal.Stop(sigCh)
-
 	// Put stdin into raw mode for the countdown so a single keypress
 	// (`u`, Enter, Ctrl+C) is delivered immediately instead of being
 	// line-buffered until the user also hits Enter — the prompt offers
@@ -95,57 +113,61 @@ func WarnAndWait(target string) Action {
 	// drives its own raw mode on /dev/tty) and the eventual exec inherit
 	// a sane terminal. In raw mode Ctrl+C arrives as the 0x03 byte
 	// rather than SIGINT, so the reader treats it as abort; the
-	// signal.Notify above remains a fallback for the non-raw path
-	// (e.g. when MakeRaw fails).
-	var restore func()
-	if oldState, err := term.MakeRaw(int(os.Stdin.Fd())); err == nil {
-		fd := int(os.Stdin.Fd())
-		restore = func() { _ = term.Restore(fd, oldState) }
-		defer restore()
+	// signal.Notify below remains a fallback for the non-raw path.
+	oldState, rawErr := makeRaw(int(os.Stdin.Fd()))
+	if rawErr != nil {
+		// MakeRaw failed (some pty layers, broken termios). Without
+		// raw mode the Read is line-buffered and the per-keystroke UX
+		// is silently broken: `u` wouldn't fire until Enter. Fall back
+		// to a single line-prompt that loses the countdown visual but
+		// keeps the [u]/any/Ctrl+C semantics intact (issue #282 (b)).
+		return linePromptFallback(red, reset)
 	}
-
-	// Drain stdin in a goroutine; report the first keystroke. `u`/`U` →
-	// unlock, Ctrl+C (0x03) → abort, and ANY other byte → continue (so
-	// Enter, Space, or a stray key all mean "run without env" — the
-	// prompt advertises exactly these semantics). We don't tear it down
-	// at return time: on the continue/abort paths the caller is about to
-	// syscall.Exec (which replaces the process image and reaps the
-	// goroutine for free), and on the unlock path WarnAndWait returns
-	// before the passphrase prompt opens — the single outstanding Read
-	// has already consumed the keystroke, so it can't steal a byte from
-	// the subsequent term.ReadPassword on the same TTY.
-	keyCh := make(chan Action, 1)
-	go func() {
-		buf := make([]byte, 1)
-		n, err := os.Stdin.Read(buf)
-		if err != nil || n == 0 {
+	fd := int(os.Stdin.Fd())
+	restoreDone := false
+	restore := func() {
+		if restoreDone {
 			return
 		}
-		var act Action
-		switch buf[0] {
-		case 'u', 'U':
-			act = ActionUnlock
-		case 0x03: // Ctrl+C in raw mode (no SIGINT is raised)
-			act = ActionAbort
-		default: // Enter, Space, or any other key
-			act = ActionContinue
+		restoreDone = true
+		// oldState can legitimately be nil when the makeRaw hook
+		// reports success without an actual State (test-only path —
+		// see withFakeRawMode). term.Restore would segfault on a nil
+		// State on Unix, so skip the call in that case.
+		if oldState == nil {
+			return
 		}
-		select {
-		case keyCh <- act:
-		default:
-		}
-	}()
+		_ = term.Restore(fd, oldState)
+	}
+	defer restore()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	// keyReader is platform-split: on Unix it builds a cancellable
+	// reader so that on every exit path the parked Read on stdin is
+	// force-unblocked (via *os.File.SetReadDeadline), preventing the
+	// leaked-goroutine "next keystroke vanishes" symptom (issue #282
+	// (a)). On Windows the reader still leaks for the lifetime of the
+	// process (Windows uses a different keyboard input path and
+	// SetReadDeadline on console handles is not supported); the
+	// WarnAndWait window is short and the parent jitenv process exits
+	// shortly after, so the leak is bounded.
+	reader := newKeyReader()
+	keyCh := reader.start()
+	defer reader.stop()
 
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
 
 	// finish restores the terminal (so the trailing newline / any later
 	// prompt render on a cooked TTY) before returning the chosen action.
+	// It also stops the key reader so its goroutine returns immediately
+	// instead of staying parked in Read on stdin past the call.
 	finish := func(act Action) Action {
-		if restore != nil {
-			restore()
-			restore = nil // the deferred call becomes a no-op
-		}
+		restore()
+		reader.stop()
 		if act == ActionAbort {
 			fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
 		} else {
@@ -159,10 +181,66 @@ func WarnAndWait(target string) Action {
 		select {
 		case <-sigCh:
 			return finish(ActionAbort)
-		case act := <-keyCh:
+		case act, ok := <-keyCh:
+			if !ok {
+				// Reader closed without producing a key (e.g. stop()
+				// fired before any byte arrived). Should not happen
+				// during the live countdown; tolerate it.
+				return finish(ActionContinue)
+			}
 			return finish(act)
 		case <-tick.C:
 		}
 	}
 	return finish(ActionContinue)
+}
+
+// linePromptFallback runs when MakeRaw fails on a TTY: no countdown,
+// no per-keystroke dispatch — just read one line and dispatch on its
+// first byte. Ctrl+C still raises SIGINT in cooked mode so we install
+// the same signal handler as the raw path.
+func linePromptFallback(red, reset string) Action {
+	fmt.Fprintf(os.Stderr,
+		"%sjitenv: raw mode unavailable — type [u] then Enter to unlock, "+
+			"anything else + Enter to continue, [Ctrl+C] to abort.%s\n",
+		red, reset)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	type lineResult struct {
+		act Action
+		err error
+	}
+	resCh := make(chan lineResult, 1)
+	go func() {
+		// One-shot line read. If the user hits Ctrl+C while we're
+		// parked here SIGINT lands on the select below and the
+		// fallback returns ActionAbort; the parked Read is bounded to
+		// the parent process's lifetime, which is short after the
+		// caller propagates the "aborted" error and exits.
+		r := bufio.NewReader(os.Stdin)
+		line, err := r.ReadString('\n')
+		if err != nil && len(line) == 0 {
+			resCh <- lineResult{ActionContinue, err}
+			return
+		}
+		var first byte
+		if len(line) > 0 {
+			first = line[0]
+		}
+		resCh <- lineResult{classifyKey(first), nil}
+	}()
+
+	select {
+	case <-sigCh:
+		fmt.Fprintf(os.Stderr, "\n%saborted — command not executed.%s\n", red, reset)
+		return ActionAbort
+	case res := <-resCh:
+		if res.act == ActionAbort {
+			fmt.Fprintf(os.Stderr, "%saborted — command not executed.%s\n", red, reset)
+		}
+		return res.act
+	}
 }

--- a/internal/agentwarn/agentwarn_test.go
+++ b/internal/agentwarn/agentwarn_test.go
@@ -333,19 +333,21 @@ func TestWarnAndWait_LinePromptFallback_ContinueOnAnyOtherLine(t *testing.T) {
 	w.Close()
 }
 
-// TestKeyReader_StopReleasesGoroutine guards bug (a): after WarnAndWait
-// returns, the stdin-reader goroutine must NOT still be parked in a
-// Read on the duplicated stdin fd. The leaked goroutine on the pre-fix
-// code would steal the next byte the parent process tries to read from
-// stdin.
+// TestKeyReader_StopReleasesGoroutine guards bug (a) on the
+// stop()-cancellation path: when WarnAndWait exits without a keystroke
+// (countdown elapsed, signal arrived) the stdin-reader goroutine must
+// NOT still be parked in a Read on the duplicated stdin fd. The leaked
+// goroutine on the pre-fix code would steal the next byte the parent
+// process tries to read from stdin.
 //
-// Counts goroutines before vs after a short-countdown WarnAndWait call
-// that exits via the "key pressed → ActionContinue" path. The reader
-// goroutine is part of that delta; if stop() failed to cancel it, the
-// goroutine count would stay elevated.
+// Calls stop() without writing to the pipe so the goroutine's Read is
+// forcibly cancelled by the past-deadline + Close path. Deterministic:
+// receiving the channel close confirms stop() finished its work, which
+// in turn means the goroutine's Read has returned (the dup fd was
+// closed inside the same stopOnce.Do).
 //
 // Linux/macOS only: the Windows reader intentionally retains the
-// legacy leak (see reader_windows.go).
+// legacy parked-Read leak (see reader_windows.go).
 func TestKeyReader_StopReleasesGoroutine(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows reader intentionally leaks; see reader_windows.go")
@@ -365,14 +367,22 @@ func TestKeyReader_StopReleasesGoroutine(t *testing.T) {
 
 	before := runtime.NumGoroutine()
 	ch := reader.start()
-	// Brief wait so the reader's goroutine is definitely parked in
-	// Read before we cancel it.
-	time.Sleep(50 * time.Millisecond)
+	// Do NOT write to the pipe — exercise the cancellation path.
 	reader.stop()
 
-	// stop() pushed a past deadline on the dup's *os.File and closed
-	// it; the goroutine's Read returns immediately and the goroutine
-	// exits. Give the scheduler a beat to actually reap it.
+	// stop() closed the channel; receiving the close is the
+	// deterministic signal that the goroutine has been released (the
+	// dup fd is now closed and the goroutine's Read has returned).
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("stop() path delivered a key; expected channel close")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop() did not close the reader channel within 2s")
+	}
+
+	// Give the scheduler a beat for the goroutine stack to fully unwind.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		runtime.Gosched()
@@ -382,14 +392,6 @@ func TestKeyReader_StopReleasesGoroutine(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	// Sanity: the channel is non-nil and closed-or-empty.
-	select {
-	case _, ok := <-ch:
-		// Either no key (ok=true with zero) or the channel was closed.
-		_ = ok
-	default:
-	}
-
 	after := runtime.NumGoroutine()
 	// We allow a small jitter (other goroutines may come/go during the
 	// test). The pre-fix code leaked one specific goroutine that would
@@ -397,6 +399,83 @@ func TestKeyReader_StopReleasesGoroutine(t *testing.T) {
 	// be cancelled; in those runs, after-before reliably stayed at >=1
 	// indefinitely. The fix should drive it back to before within the
 	// deadline above.
+	if after > before+1 {
+		t.Errorf("reader goroutine appears to have leaked: before=%d after=%d", before, after)
+	}
+}
+
+// TestKeyReader_DataPathReleasesGoroutine guards bug (a) on the
+// data-path exit: a keystroke arrives, the goroutine sends on ch and
+// exits naturally without stop() needing to cancel the Read. Verifies
+// the goroutine does NOT close ch itself (only stop() owns the close),
+// and that a subsequent stop() is still safe and idempotent.
+//
+// Deterministic — writes a byte into the pipe so the parked Read
+// returns via the data path; no sleeps.
+//
+// Linux/macOS only: same rationale as TestKeyReader_StopReleasesGoroutine.
+func TestKeyReader_DataPathReleasesGoroutine(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows reader intentionally leaks; see reader_windows.go")
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	reader := newKeyReader()
+	prevStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = prevStdin })
+
+	before := runtime.NumGoroutine()
+	ch := reader.start()
+
+	// Deterministically unblock the goroutine via the data path.
+	if _, err := w.Write([]byte("u")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	select {
+	case act, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before the keystroke was delivered")
+		}
+		if act != ActionUnlock {
+			t.Fatalf("expected ActionUnlock from `u`, got %v", act)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine never delivered to ch within 2s")
+	}
+
+	// stop() must still be safe to call after the data-path exit
+	// (idempotent; the goroutine never closed ch itself).
+	reader.stop()
+
+	// After stop(), ch must be closed — the cancellation contract
+	// holds even on the data-path exit.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("ch yielded a value after stop(); expected closed")
+		}
+	default:
+		t.Fatal("ch not closed after stop()")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.Gosched()
+		if runtime.NumGoroutine() <= before+1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	after := runtime.NumGoroutine()
 	if after > before+1 {
 		t.Errorf("reader goroutine appears to have leaked: before=%d after=%d", before, after)
 	}

--- a/internal/agentwarn/agentwarn_test.go
+++ b/internal/agentwarn/agentwarn_test.go
@@ -2,11 +2,15 @@ package agentwarn
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/term"
 )
 
 // TestWarnAndWait_NonTTYReturnsImmediately guards the non-interactive
@@ -57,6 +61,21 @@ func withStdin(t *testing.T, r *os.File) {
 	})
 }
 
+// withFakeRawMode stubs the makeRaw hook so it returns success against
+// the pipe-backed stdin used by the keystroke tests. term.MakeRaw would
+// otherwise fail on a non-TTY fd, sending the call through the
+// line-prompt fallback path — but the per-keystroke dispatch is what
+// the existing tests cover (since #232/#264 settled the semantics).
+//
+// The "old state" is a typed nil: term.Restore tolerates a nil State
+// without touching the fd, which is what we want for the pipe.
+func withFakeRawMode(t *testing.T) {
+	t.Helper()
+	prev := makeRaw
+	makeRaw = func(fd int) (*term.State, error) { return nil, nil }
+	t.Cleanup(func() { makeRaw = prev })
+}
+
 // TestWarnAndWait_UnlockKey: typing `u` returns ActionUnlock so the
 // caller can route into the inline-unlock flow (issue #232).
 func TestWarnAndWait_UnlockKey(t *testing.T) {
@@ -68,6 +87,7 @@ func TestWarnAndWait_UnlockKey(t *testing.T) {
 	}
 	defer r.Close()
 	withStdin(t, r)
+	withFakeRawMode(t)
 
 	if _, err := w.WriteString("u\n"); err != nil {
 		t.Fatalf("write: %v", err)
@@ -98,6 +118,7 @@ func TestWarnAndWait_EnterKey(t *testing.T) {
 	}
 	defer r.Close()
 	withStdin(t, r)
+	withFakeRawMode(t)
 
 	if _, err := w.WriteString("\n"); err != nil {
 		t.Fatalf("write: %v", err)
@@ -130,6 +151,7 @@ func TestWarnAndWait_AnyOtherKeyContinues(t *testing.T) {
 			t.Fatalf("pipe: %v", err)
 		}
 		withStdin(t, r)
+		withFakeRawMode(t)
 
 		if _, err := w.WriteString(key); err != nil {
 			t.Fatalf("write: %v", err)
@@ -163,6 +185,7 @@ func TestWarnAndWait_PromptCopy(t *testing.T) {
 	}
 	defer inR.Close()
 	withStdin(t, inR)
+	withFakeRawMode(t)
 
 	// Capture stderr for the duration of the call.
 	errR, errW, err := os.Pipe()
@@ -208,5 +231,173 @@ func TestWarnAndWait_PromptCopy(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("prompt copy missing %q\nfull output:\n%s", want, out)
 		}
+	}
+}
+
+// TestWarnAndWait_LinePromptFallbackOnMakeRawFailure exercises bug (b):
+// when term.MakeRaw fails on a TTY (some pty layers, broken termios),
+// WarnAndWait must fall back to a single line-prompt instead of
+// silently breaking the per-keystroke UX (the raw-less goroutine would
+// stay parked in line-buffered Read and `u` wouldn't fire until
+// Enter — the countdown ticks down and the user sees nothing happen).
+func TestWarnAndWait_LinePromptFallbackOnMakeRawFailure(t *testing.T) {
+	t.Setenv("JITENV_HOOK_DELAY", "10")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	withStdin(t, r)
+
+	// Force MakeRaw to fail so we go through linePromptFallback.
+	prevMakeRaw := makeRaw
+	makeRaw = func(fd int) (*term.State, error) { return nil, errors.New("simulated MakeRaw failure") }
+	t.Cleanup(func() { makeRaw = prevMakeRaw })
+
+	// Capture stderr to assert the fallback wording fires.
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	prevStderr := os.Stderr
+	os.Stderr = errW
+	t.Cleanup(func() { os.Stderr = prevStderr })
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, errR)
+		captured <- buf.String()
+	}()
+
+	// Send `u\n` — the fallback reads a line and dispatches on the
+	// first byte, so this must classify as ActionUnlock.
+	if _, err := w.WriteString("u\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	done := make(chan Action, 1)
+	go func() { done <- WarnAndWait("/some/script.sh") }()
+
+	select {
+	case act := <-done:
+		if act != ActionUnlock {
+			t.Fatalf("expected ActionUnlock via line-prompt fallback, got %v", act)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("line-prompt fallback did not return on `u\\n` within 3s")
+	}
+	w.Close()
+	errW.Close()
+	os.Stderr = prevStderr
+
+	out := <-captured
+	if !strings.Contains(out, "raw mode unavailable") {
+		t.Errorf("fallback wording not seen in stderr; got:\n%s", out)
+	}
+}
+
+// TestWarnAndWait_LinePromptFallback_ContinueOnAnyOtherLine: the line-
+// prompt fallback's classification mirrors the raw-mode path — a line
+// whose first byte is neither `u` nor 0x03 is ActionContinue.
+func TestWarnAndWait_LinePromptFallback_ContinueOnAnyOtherLine(t *testing.T) {
+	t.Setenv("JITENV_HOOK_DELAY", "10")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	withStdin(t, r)
+
+	prevMakeRaw := makeRaw
+	makeRaw = func(fd int) (*term.State, error) { return nil, errors.New("simulated MakeRaw failure") }
+	t.Cleanup(func() { makeRaw = prevMakeRaw })
+
+	if _, err := w.WriteString("\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	done := make(chan Action, 1)
+	go func() { done <- WarnAndWait("/some/script.sh") }()
+
+	select {
+	case act := <-done:
+		if act != ActionContinue {
+			t.Fatalf("expected ActionContinue, got %v", act)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("line-prompt fallback did not return on Enter within 3s")
+	}
+	w.Close()
+}
+
+// TestKeyReader_StopReleasesGoroutine guards bug (a): after WarnAndWait
+// returns, the stdin-reader goroutine must NOT still be parked in a
+// Read on the duplicated stdin fd. The leaked goroutine on the pre-fix
+// code would steal the next byte the parent process tries to read from
+// stdin.
+//
+// Counts goroutines before vs after a short-countdown WarnAndWait call
+// that exits via the "key pressed → ActionContinue" path. The reader
+// goroutine is part of that delta; if stop() failed to cancel it, the
+// goroutine count would stay elevated.
+//
+// Linux/macOS only: the Windows reader intentionally retains the
+// legacy leak (see reader_windows.go).
+func TestKeyReader_StopReleasesGoroutine(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows reader intentionally leaks; see reader_windows.go")
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	reader := newKeyReader()
+	prevStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = prevStdin })
+
+	before := runtime.NumGoroutine()
+	ch := reader.start()
+	// Brief wait so the reader's goroutine is definitely parked in
+	// Read before we cancel it.
+	time.Sleep(50 * time.Millisecond)
+	reader.stop()
+
+	// stop() pushed a past deadline on the dup's *os.File and closed
+	// it; the goroutine's Read returns immediately and the goroutine
+	// exits. Give the scheduler a beat to actually reap it.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.Gosched()
+		if runtime.NumGoroutine() <= before+1 { // +1 for test scheduling jitter
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Sanity: the channel is non-nil and closed-or-empty.
+	select {
+	case _, ok := <-ch:
+		// Either no key (ok=true with zero) or the channel was closed.
+		_ = ok
+	default:
+	}
+
+	after := runtime.NumGoroutine()
+	// We allow a small jitter (other goroutines may come/go during the
+	// test). The pre-fix code leaked one specific goroutine that would
+	// stay alive long past stop() because os.Stdin.Read had no way to
+	// be cancelled; in those runs, after-before reliably stayed at >=1
+	// indefinitely. The fix should drive it back to before within the
+	// deadline above.
+	if after > before+1 {
+		t.Errorf("reader goroutine appears to have leaked: before=%d after=%d", before, after)
 	}
 }

--- a/internal/agentwarn/reader_unix.go
+++ b/internal/agentwarn/reader_unix.go
@@ -41,7 +41,10 @@ func newKeyReader() *keyReader {
 
 // start launches the reader goroutine and returns the channel it will
 // send the (single) classified keystroke on. The channel is closed by
-// stop() if no key arrived before cancellation.
+// stop() if no key arrived before cancellation; the goroutine itself
+// never closes r.ch on its normal "got a key, sent, exit" path, so a
+// "channel closed without a value" signal in WarnAndWait unambiguously
+// means the stop() cancellation path.
 func (r *keyReader) start() <-chan Action {
 	r.once.Do(func() {
 		// Dup stdin so we can hold a Close-able handle that doesn't
@@ -70,8 +73,18 @@ func (r *keyReader) start() <-chan Action {
 			buf := make([]byte, 1)
 			n, err := f.Read(buf)
 			if err != nil || n == 0 {
+				// Cancellation (stop() closed the fd / pushed the
+				// deadline) or EOF. stop() owns closing ch — do not
+				// close here, and do not send on a channel that may
+				// already be closed.
 				return
 			}
+			// Best-effort send. If stop() raced ahead and already
+			// closed ch the send would panic; recover so the goroutine
+			// still exits cleanly. In practice this race is vanishingly
+			// rare: a real keystroke means the user pressed something
+			// before the deadline fired.
+			defer func() { _ = recover() }()
 			select {
 			case ch <- classifyKey(buf[0]):
 			default:
@@ -86,18 +99,22 @@ func (r *keyReader) start() <-chan Action {
 // effect on the real stdin (fd 0), which the next stage of the caller
 // (passphrase prompt, exec, etc.) keeps using.
 //
+// stop() also closes r.ch so the WarnAndWait select observes a closed
+// channel (`!ok`) on the cancellation path; the goroutine never closes
+// r.ch itself, so closing here under stopOnce is race-free.
+//
 // Idempotent: WarnAndWait calls stop() both eagerly from finish() and
 // via a defer; only the first call does the work.
 func (r *keyReader) stop() {
 	r.stopOnce.Do(func() {
-		if r.file == nil {
-			return
+		if r.file != nil {
+			// Past deadline → any in-flight Read on the dup returns
+			// immediately with an i/o timeout error, and the goroutine
+			// bails. Then Close() releases the dup fd and the goroutine's
+			// reference goes away cleanly.
+			_ = r.file.SetReadDeadline(time.Unix(1, 0))
+			_ = r.file.Close()
 		}
-		// Past deadline → any in-flight Read on the dup returns
-		// immediately with an i/o timeout error, and the goroutine
-		// bails. Then Close() releases the dup fd and the goroutine's
-		// reference goes away cleanly.
-		_ = r.file.SetReadDeadline(time.Unix(1, 0))
-		_ = r.file.Close()
+		close(r.ch)
 	})
 }

--- a/internal/agentwarn/reader_unix.go
+++ b/internal/agentwarn/reader_unix.go
@@ -1,0 +1,103 @@
+//go:build !windows
+
+package agentwarn
+
+import (
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// keyReader reads exactly one keystroke from stdin and exposes it on a
+// channel that the WarnAndWait countdown loop selects on. The Unix
+// implementation is force-cancellable: stop() sets a past read deadline
+// on the underlying *os.File so a parked Read returns immediately with
+// a deadline error, then closes the file. This is what prevents the
+// leaked-goroutine "next keystroke vanishes after abort" symptom
+// (issue #282 (a)) — the goroutine reliably exits before WarnAndWait
+// returns, instead of staying parked indefinitely.
+//
+// We do NOT read directly from os.Stdin: closing os.Stdin (or letting
+// a Go finalizer close it) would tear down fd 0 for the rest of the
+// process. Instead we dup() stdin via syscall.Dup, then build a
+// non-blocking *os.File around the duplicate. SetReadDeadline only
+// works on pollable (non-blocking) files, which is why the dup is set
+// non-blocking before NewFile wraps it. Closing the dup leaves the
+// original stdin intact.
+type keyReader struct {
+	once     sync.Once
+	stopOnce sync.Once
+
+	file *os.File // duplicate of stdin fd; non-blocking, safe to Close
+
+	ch chan Action
+}
+
+// newKeyReader returns an unstarted reader.
+func newKeyReader() *keyReader {
+	return &keyReader{ch: make(chan Action, 1)}
+}
+
+// start launches the reader goroutine and returns the channel it will
+// send the (single) classified keystroke on. The channel is closed by
+// stop() if no key arrived before cancellation.
+func (r *keyReader) start() <-chan Action {
+	r.once.Do(func() {
+		// Dup stdin so we can hold a Close-able handle that doesn't
+		// affect fd 0. If dup fails (extremely unlikely on a TTY), we
+		// fall back to the legacy "parked Read leaks until process
+		// exit" behaviour by leaving r.file nil — the goroutine
+		// simply isn't started and the countdown loop runs without
+		// keystroke input on its keyCh (the !ok branch).
+		dup, err := syscall.Dup(int(os.Stdin.Fd()))
+		if err != nil {
+			return
+		}
+		// Mark the dup non-blocking so *os.File treats it as
+		// pollable and respects SetReadDeadline.
+		if err := syscall.SetNonblock(dup, true); err != nil {
+			_ = syscall.Close(dup)
+			return
+		}
+		r.file = os.NewFile(uintptr(dup), "jitenv-stdin-dup")
+		if r.file == nil {
+			_ = syscall.Close(dup)
+			return
+		}
+
+		go func(f *os.File, ch chan<- Action) {
+			buf := make([]byte, 1)
+			n, err := f.Read(buf)
+			if err != nil || n == 0 {
+				return
+			}
+			select {
+			case ch <- classifyKey(buf[0]):
+			default:
+			}
+		}(r.file, r.ch)
+	})
+	return r.ch
+}
+
+// stop unblocks the parked Read by pushing the read deadline into the
+// past, then closes the duplicate fd. Closing the duplicate has no
+// effect on the real stdin (fd 0), which the next stage of the caller
+// (passphrase prompt, exec, etc.) keeps using.
+//
+// Idempotent: WarnAndWait calls stop() both eagerly from finish() and
+// via a defer; only the first call does the work.
+func (r *keyReader) stop() {
+	r.stopOnce.Do(func() {
+		if r.file == nil {
+			return
+		}
+		// Past deadline → any in-flight Read on the dup returns
+		// immediately with an i/o timeout error, and the goroutine
+		// bails. Then Close() releases the dup fd and the goroutine's
+		// reference goes away cleanly.
+		_ = r.file.SetReadDeadline(time.Unix(1, 0))
+		_ = r.file.Close()
+	})
+}

--- a/internal/agentwarn/reader_windows.go
+++ b/internal/agentwarn/reader_windows.go
@@ -20,8 +20,9 @@ import (
 // keystroke-classification logic in agentwarn.go stays platform-
 // neutral; only the lifecycle of the parked Read differs.
 type keyReader struct {
-	once sync.Once
-	ch   chan Action
+	once     sync.Once
+	stopOnce sync.Once
+	ch       chan Action
 }
 
 func newKeyReader() *keyReader {
@@ -36,6 +37,11 @@ func (r *keyReader) start() <-chan Action {
 			if err != nil || n == 0 {
 				return
 			}
+			// Best-effort send. If stop() already closed ch the send
+			// would panic; recover so the leaked goroutine still exits
+			// cleanly when input finally arrives. The Unix path mirrors
+			// this same defer-recover pattern.
+			defer func() { _ = recover() }()
 			select {
 			case ch <- classifyKey(buf[0]):
 			default:
@@ -45,6 +51,17 @@ func (r *keyReader) start() <-chan Action {
 	return r.ch
 }
 
-// stop is a no-op on Windows (see type doc). It's defined to keep the
-// platform-neutral caller in agentwarn.go simple.
-func (r *keyReader) stop() {}
+// stop closes r.ch so the WarnAndWait select observes a closed channel
+// (`!ok`) on the cancellation path, matching the Unix semantics. The
+// goroutine launched by start() may still be parked in os.Stdin.Read
+// (Windows console handles can't be force-unblocked); it stays alive
+// until the OS reaps it at parent exit. The goroutine's send-on-ch is
+// guarded by defer-recover so a late keystroke doesn't panic the
+// process after stop() has closed ch.
+//
+// Idempotent: only the first call does the work.
+func (r *keyReader) stop() {
+	r.stopOnce.Do(func() {
+		close(r.ch)
+	})
+}

--- a/internal/agentwarn/reader_windows.go
+++ b/internal/agentwarn/reader_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package agentwarn
+
+import (
+	"os"
+	"sync"
+)
+
+// keyReader: Windows variant. Reading a single byte from a Windows
+// console handle doesn't go through the netpoll/SetReadDeadline path
+// that lets the Unix implementation force-unblock a parked Read, so
+// here we keep the legacy "single-shot goroutine that may leak across
+// the WarnAndWait call" behaviour. The leak is bounded to the parent
+// jitenv process's lifetime: the parent exits shortly after WarnAndWait
+// returns (returning the run/shim error or proceeding to exec a child),
+// and the OS reaps the goroutine then.
+//
+// This keeps the package API identical to the Unix path so the
+// keystroke-classification logic in agentwarn.go stays platform-
+// neutral; only the lifecycle of the parked Read differs.
+type keyReader struct {
+	once sync.Once
+	ch   chan Action
+}
+
+func newKeyReader() *keyReader {
+	return &keyReader{ch: make(chan Action, 1)}
+}
+
+func (r *keyReader) start() <-chan Action {
+	r.once.Do(func() {
+		go func(ch chan<- Action) {
+			buf := make([]byte, 1)
+			n, err := os.Stdin.Read(buf)
+			if err != nil || n == 0 {
+				return
+			}
+			select {
+			case ch <- classifyKey(buf[0]):
+			default:
+			}
+		}(r.ch)
+	})
+	return r.ch
+}
+
+// stop is a no-op on Windows (see type doc). It's defined to keep the
+// platform-neutral caller in agentwarn.go simple.
+func (r *keyReader) stop() {}


### PR DESCRIPTION
Closes #282.

## Summary

`internal/agentwarn/agentwarn.go` had two latent bugs in the countdown's keystroke reader:

- **(a) ActionAbort goroutine leak.** The single-byte reader goroutine parked in `os.Stdin.Read` was supposed to be reaped "for free" when the caller `syscall.Exec`d. That's true on Continue/Unlock — but `ActionAbort` returns `errors.New(\"aborted\")` through Cobra and never execs. The parked Read survives past `WarnAndWait`, and a subsequent stdin byte gets stolen by the leaked goroutine.

- **(b) MakeRaw failure → cooked-mode lockup.** On TTYs where `term.MakeRaw` errors out (broken termios, some pty layers), the previous code left `restore=nil` and ran the same goroutine against line-buffered stdin. `u` wouldn't dispatch until the user also hit Enter; the countdown ticked down with no apparent input.

## Fix

- **Platform-split `keyReader`** (`reader_unix.go` / `reader_windows.go`). On Unix it `dup()`s stdin, marks the duplicate non-blocking, and wraps it in `*os.File` so the runtime's netpoller respects `SetReadDeadline`. `stop()` pushes a past deadline and `Close()`s the dup — the parked Read returns immediately, the goroutine exits before `WarnAndWait` returns, and fd 0 is left untouched for the next stdin consumer (passphrase prompt, exec'd child). Windows keeps the legacy single-goroutine shape since `SetReadDeadline` doesn't work on console handles; the leak is bounded to the parent process's remaining lifetime.

- **`linePromptFallback`** for the MakeRaw-failure path: one `bufio.ReadString('\n')` and classify the first byte via the shared `classifyKey` helper. Loses the countdown visual but keeps the `[u]/any/Ctrl+C` semantics intact on broken TTYs.

## Test plan

- [x] `go test ./...` (full suite — green)
- [x] `go test -race ./internal/agentwarn/...`
- [x] `GOOS=windows go build ./...` (Windows path compiles)
- [x] `GOOS=darwin go build ./...` (Darwin path compiles)
- [x] `golangci-lint run`
- [x] New `TestWarnAndWait_LinePromptFallbackOnMakeRawFailure` + `TestWarnAndWait_LinePromptFallback_ContinueOnAnyOtherLine` cover bug (b)
- [x] New `TestKeyReader_StopReleasesGoroutine` guards bug (a) via `runtime.NumGoroutine` before/after `stop()`
- [x] Existing keystroke tests gain a `withFakeRawMode` helper so the pipe-backed stdin still exercises the raw-mode dispatch loop instead of the fallback