### PR TITLE
syncadapters/s3: retry on transient client init + symmetric credential validation (closes #283, #284)

### DIFF
--- a/internal/syncadapters/s3/s3.go
+++ b/internal/syncadapters/s3/s3.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -38,6 +39,13 @@ import (
 )
 
 const typeName = "s3"
+
+// clientInitBackoff is the minimum interval between client()
+// reconstruction attempts after a failed build. Short enough that a
+// transient (IMDS hiccup, partial DNS) recovers in the same operator
+// session; long enough that a persistently-broken config (wrong region,
+// missing IAM) doesn't hammer the AWS config loader on every Push/Pull.
+const clientInitBackoff = 5 * time.Second
 
 // Well-known canned-group grantee URIs. A bucket ACL that grants READ (or
 // FULL_CONTROL) to either of these is effectively public, so Validate
@@ -72,11 +80,22 @@ type adapter struct {
 	// client on demand).
 	newClient func(ctx context.Context) (api, error)
 
-	// once guards lazy construction of cli so concurrent Push/Pull are
-	// safe (the syncadapter.Adapter contract requires concurrency safety).
-	once   sync.Once
-	cli    api
-	cliErr error
+	// now is a test seam for the client-init backoff clock. Production
+	// uses time.Now; tests override it to advance the clock without
+	// real sleeps.
+	now func() time.Time
+
+	// mu guards lazy construction of cli so concurrent Push/Pull are
+	// safe (the syncadapter.Adapter contract requires concurrency
+	// safety). Unlike a sync.Once, a cached error is NOT pinned for the
+	// adapter's lifetime: client() retries on every call where cli is
+	// nil, throttled to clientInitBackoff between attempts so a
+	// persistently-broken config doesn't hammer the AWS config loader
+	// (#283).
+	mu        sync.Mutex
+	cli       api
+	cliErr    error
+	lastErrAt time.Time
 
 	// etagMu guards lastBlobETag / lastSeenAt, which together carry the
 	// compare-and-set token from the most recent successful Pull into
@@ -121,11 +140,20 @@ func New(cfg map[string]any) (syncadapter.Adapter, error) {
 	endpointOverride := asString(cfg["endpoint_override"])
 	usePathStyle := asBool(cfg["use_path_style"])
 
-	if accessKeyID != "" && secretAccessKey == "" {
-		return nil, errors.New("s3 adapter: access_key_id is set but secret_access_key is empty")
+	// Symmetric credential validation (#284): either both halves are
+	// set (use these explicit static creds) or both are empty (fall
+	// back to the AWS default chain). Half-set in either direction is
+	// almost always a config typo — the original code rejected
+	// id-without-secret but silently ignored secret-without-id, which
+	// led to the SDK quietly falling back to a different identity than
+	// the user intended.
+	hasID := accessKeyID != ""
+	hasSecret := secretAccessKey != ""
+	if hasID != hasSecret {
+		return nil, errors.New("s3 adapter: access_key_id and secret_access_key must be set together")
 	}
 
-	a := &adapter{bucket: bucket, key: key, kmsKey: kmsKey}
+	a := &adapter{bucket: bucket, key: key, kmsKey: kmsKey, now: time.Now}
 	a.newClient = func(ctx context.Context) (api, error) {
 		opts := []func(*config.LoadOptions) error{}
 		if region != "" {
@@ -157,13 +185,33 @@ func (a *adapter) Name() string { return typeName }
 func (a *adapter) metaKey() string { return a.key + ".meta.json" }
 
 // client returns the cached S3 client, building it on first use. The
-// sync.Once makes concurrent first calls race-free; a construction error
-// is cached too so a failed build is not retried mid-flight.
+// mutex makes concurrent first calls race-free. Unlike a sync.Once, a
+// construction error is NOT pinned for the adapter's lifetime: a
+// transient failure (IMDS hiccup, DNS blip during EC2 instance-role
+// lookup) recovers on the next call, throttled to clientInitBackoff
+// between attempts so a persistently-broken config doesn't hammer the
+// AWS config loader (#283).
 func (a *adapter) client(ctx context.Context) (api, error) {
-	a.once.Do(func() {
-		a.cli, a.cliErr = a.newClient(ctx)
-	})
-	return a.cli, a.cliErr
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cli != nil {
+		return a.cli, nil
+	}
+	// Throttle retries: a recent failure stays cached until the backoff
+	// expires. The very first call (lastErrAt zero) is never throttled.
+	if !a.lastErrAt.IsZero() && a.now().Sub(a.lastErrAt) < clientInitBackoff {
+		return nil, a.cliErr
+	}
+	cli, err := a.newClient(ctx)
+	if err != nil {
+		a.cliErr = err
+		a.lastErrAt = a.now()
+		return nil, err
+	}
+	a.cli = cli
+	a.cliErr = nil
+	a.lastErrAt = time.Time{}
+	return a.cli, nil
 }
 
 // Validate confirms the bucket is reachable and refuses a bucket that is

--- a/internal/syncadapters/s3/s3_test.go
+++ b/internal/syncadapters/s3/s3_test.go
@@ -8,8 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -338,6 +341,31 @@ func TestS3NewRequiresBucketAndKey(t *testing.T) {
 	if _, err := New(map[string]any{"bucket": "b", "key": "k", "access_key_id": "AKIA"}); err == nil {
 		t.Fatal("expected access_key_id without secret_access_key to be rejected")
 	}
+	// Symmetric half-set rejection (#284): secret_access_key without
+	// access_key_id used to fall through silently into the default
+	// credential chain, hiding a user config typo behind whatever
+	// identity the SDK picked up instead.
+	_, err := New(map[string]any{"bucket": "b", "key": "k", "secret_access_key": "wJalr"})
+	if err == nil {
+		t.Fatal("expected secret_access_key without access_key_id to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must be set together") {
+		t.Fatalf("expected symmetric-pair error message, got %q", err.Error())
+	}
+	// Both-empty is the supported "use the default credential chain"
+	// configuration and must still construct.
+	if _, err := New(map[string]any{"bucket": "b", "key": "k"}); err != nil {
+		t.Fatalf("both-empty creds (default chain) must construct, got %v", err)
+	}
+	// Both-set is the supported explicit-static configuration.
+	if _, err := New(map[string]any{
+		"bucket":            "b",
+		"key":               "k",
+		"access_key_id":     "AKIA",
+		"secret_access_key": "wJalr",
+	}); err != nil {
+		t.Fatalf("both-set creds must construct, got %v", err)
+	}
 }
 
 // TestS3ClientConcurrentInitNoRace exercises the lazy client() init from
@@ -362,4 +390,135 @@ func TestS3ClientConcurrentInitNoRace(t *testing.T) {
 	}
 	close(start)
 	wg.Wait()
+}
+
+// TestS3ClientRetriesAfterTransientFailure: a one-shot newClient
+// failure (mirroring a brief IMDS hiccup) must not pin the adapter
+// dead. After the backoff window elapses, the next client() call
+// rebuilds successfully (#283).
+func TestS3ClientRetriesAfterTransientFailure(t *testing.T) {
+	fs := newFakeS3()
+	a := newFakeAdapter(t, fs, nil)
+
+	// Drive newClient to fail the first call and succeed thereafter.
+	var calls atomic.Int32
+	transient := errors.New("simulated IMDS unreachable")
+	a.newClient = func(context.Context) (api, error) {
+		if calls.Add(1) == 1 {
+			return nil, transient
+		}
+		return fs, nil
+	}
+
+	// Use a virtual clock so the test doesn't sleep for real.
+	var nowT time.Time
+	a.now = func() time.Time { return nowT }
+	nowT = time.Unix(1_700_000_000, 0)
+
+	// First call: hits the transient failure, error is cached.
+	if _, err := a.client(context.Background()); !errors.Is(err, transient) {
+		t.Fatalf("first call: expected transient error, got %v", err)
+	}
+	// Second call within the backoff window: must return the cached
+	// error WITHOUT re-invoking newClient.
+	nowT = nowT.Add(clientInitBackoff / 2)
+	if _, err := a.client(context.Background()); !errors.Is(err, transient) {
+		t.Fatalf("within-backoff call: expected cached transient error, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("within-backoff call must not re-invoke newClient, calls=%d", got)
+	}
+	// Past the backoff: next call re-invokes newClient and recovers.
+	nowT = nowT.Add(clientInitBackoff)
+	cli, err := a.client(context.Background())
+	if err != nil {
+		t.Fatalf("post-backoff call: expected recovery, got %v", err)
+	}
+	if cli == nil {
+		t.Fatal("post-backoff call: expected non-nil client")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("post-backoff call must re-invoke newClient exactly once, calls=%d", got)
+	}
+	// Once cached, subsequent calls reuse the client and never touch
+	// newClient again — the success path is sticky.
+	if _, err := a.client(context.Background()); err != nil {
+		t.Fatalf("post-recovery call: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("post-recovery call must not re-invoke newClient, calls=%d", got)
+	}
+}
+
+// TestS3ClientConcurrentTransientFailure: many goroutines hammer a
+// failing newClient. The mutex must serialize them so newClient is
+// called at most once per backoff window (not once per goroutine), and
+// every caller must observe the same error (#283).
+func TestS3ClientConcurrentTransientFailure(t *testing.T) {
+	fs := newFakeS3()
+	a := newFakeAdapter(t, fs, nil)
+
+	transient := errors.New("simulated IMDS unreachable")
+	var calls atomic.Int32
+	a.newClient = func(context.Context) (api, error) {
+		calls.Add(1)
+		return nil, transient
+	}
+	// Freeze the clock so the backoff window covers every concurrent
+	// call: the FIRST caller takes the build path, every later caller
+	// finds lastErrAt set within the window and returns the cached err.
+	frozen := time.Unix(1_700_000_000, 0)
+	a.now = func() time.Time { return frozen }
+
+	const n = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := a.client(context.Background()); !errors.Is(err, transient) {
+				t.Errorf("expected transient error, got %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// With the clock frozen inside the backoff window, every caller
+	// after the first must take the cached-error short-circuit. Exactly
+	// one newClient call should have been made.
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 newClient call across %d concurrent callers, got %d", n, got)
+	}
+}
+
+// TestS3ValidateRecoversAfterClientInitFailure: the documented user
+// scenario from #283 — a transient client-build failure must not pin
+// Validate dead for the adapter's lifetime.
+func TestS3ValidateRecoversAfterClientInitFailure(t *testing.T) {
+	fs := newFakeS3()
+	a := newFakeAdapter(t, fs, nil)
+
+	var calls atomic.Int32
+	transient := errors.New("simulated IMDS unreachable")
+	a.newClient = func(context.Context) (api, error) {
+		if calls.Add(1) == 1 {
+			return nil, transient
+		}
+		return fs, nil
+	}
+	var nowT time.Time
+	a.now = func() time.Time { return nowT }
+	nowT = time.Unix(1_700_000_000, 0)
+
+	if err := a.Validate(context.Background()); !errors.Is(err, transient) {
+		t.Fatalf("first Validate: expected transient error, got %v", err)
+	}
+	// Step past the backoff so the next attempt rebuilds.
+	nowT = nowT.Add(clientInitBackoff + time.Second)
+	if err := a.Validate(context.Background()); err != nil {
+		t.Fatalf("Validate after backoff: expected recovery, got %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- **#283** — Replace `sync.Once` with a mutex-guarded lazy init in `client()` so a transient `config.LoadDefaultConfig` failure (e.g. an EC2 IMDS hiccup during instance-role lookup) no longer pins the adapter dead for its lifetime. Retries are throttled to a 5s backoff between attempts so a persistently-broken config doesn't hammer the AWS config loader.
- **#284** — Make credential validation in `New()` symmetric: error on either `access_key_id`-without-secret OR `secret_access_key`-without-id. The reverse used to fall through silently into the default credential chain, hiding a user config typo behind whatever identity the SDK happened to pick up.

## Test plan

- [x] `go test ./internal/syncadapters/s3/... -race -v` — all pass, including the three new tests (`TestS3ClientRetriesAfterTransientFailure`, `TestS3ClientConcurrentTransientFailure`, `TestS3ValidateRecoversAfterClientInitFailure`) and the extended `TestS3NewRequiresBucketAndKey`.
- [x] `go test ./...` — full suite passes.
- [x] `go vet ./...` and `golangci-lint run ./...` — clean.
- [x] Virtual-clock seam (`a.now`) keeps tests sub-millisecond — no real sleeps.

Closes #283
Closes #284