### PR TITLE
chpwd+shell: NUL-frame anchors sidecar; clear sidecar on Load-fail (closes #285, #286)

### DIFF
--- a/internal/chpwd/chpwd.go
+++ b/internal/chpwd/chpwd.go
@@ -123,7 +123,16 @@ func Run(args []string) (bool, error) {
 		debugLog("desiredCommands error: %v", err)
 		// Config missing or malformed: leave the wrapper dir alone
 		// so a momentary parse error doesn't tear down a working
-		// state. Returning nil keeps the shell hook quiet.
+		// state. But DO clear the match-anchors sidecar (#286) — if
+		// we leave it stale, the bash/zsh in-shell pre-filter (#260)
+		// keeps trusting yesterday's anchors and forks `is-mapped`
+		// for every stale-matching path (which then exits 2 →
+		// silently no env), AND any mapping the user just added in
+		// the broken edit stays invisible until the next cd. An
+		// empty sidecar correctly short-circuits the pre-filter
+		// while the config is broken. Returning nil keeps the shell
+		// hook quiet.
+		writeAnchors(anchorsPath(paths, pid), nil)
 		return false, nil
 	}
 	debugLog("config reports wanted=%v", wanted)
@@ -219,25 +228,34 @@ func anchorsPath(paths agent.Paths, pid int) string {
 	return filepath.Join(filepath.Dir(paths.ShellWrapDir(pid)), "match-anchors")
 }
 
-// writeAnchors (re)writes the match-anchors sidecar from idx. Format is
-// one tab-separated record per line: `E\t<abs-path>` for an exact path
-// mapping, `P\t<literal-prefix>` for a glob. An empty idx (no path/glob
-// mappings) yields an empty file, which tells the hook to never fork
-// is-mapped. Best-effort: a write failure just means the hook keeps its
-// previous (possibly stale) view until the next reconcile.
+// writeAnchors (re)writes the match-anchors sidecar from idx. Records are
+// NUL-framed pairs (#285): `E\x00<abs-path>\x00` for an exact path
+// mapping, `P\x00<literal-prefix>\x00` for a glob. NUL is the one byte
+// that can't appear in a Unix path, so paths containing TAB or newline
+// (legal on Linux/macOS) round-trip intact through the bash/zsh readers
+// — before this, a TAB in the path silently truncated the anchor and
+// bypassed env injection, and a malicious filename could craft bogus
+// anchors that intercept unrelated commands.
+//
+// An empty (or nil) idx yields an empty file, which tells the in-shell
+// pre-filter (#260) to never fork `is-mapped`. Best-effort: a write
+// failure just means the hook keeps its previous view until the next
+// reconcile.
 func writeAnchors(path string, idx *config.Index) {
 	var b strings.Builder
 	if idx != nil {
 		exact, prefixes := idx.Anchors()
 		for _, e := range exact {
-			b.WriteString("E\t")
+			b.WriteByte('E')
+			b.WriteByte(0)
 			b.WriteString(e)
-			b.WriteByte('\n')
+			b.WriteByte(0)
 		}
 		for _, p := range prefixes {
-			b.WriteString("P\t")
+			b.WriteByte('P')
+			b.WriteByte(0)
 			b.WriteString(p)
-			b.WriteByte('\n')
+			b.WriteByte(0)
 		}
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {

--- a/internal/chpwd/chpwd_test.go
+++ b/internal/chpwd/chpwd_test.go
@@ -3,9 +3,11 @@
 package chpwd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -154,5 +156,133 @@ func TestRunUnlinksInjectionMarker(t *testing.T) {
 	}
 	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
 		t.Errorf("injection marker still exists after chpwd run: stat err=%v", err)
+	}
+}
+
+// TestWriteAnchorsNULFraming asserts the on-disk format of the match-anchors
+// sidecar (#285): `<kind>\0<val>\0` per record, with NUL framing so paths
+// containing TAB / newline (legal on Linux/macOS) round-trip intact instead
+// of being silently truncated by the shell reader.
+func TestWriteAnchorsNULFraming(t *testing.T) {
+	tmp := t.TempDir()
+	anchorsFile := filepath.Join(tmp, "match-anchors")
+
+	// Build an Index that contains a path with a TAB embedded — the
+	// previous TAB-framed format would have written this as
+	// `E\t/with\ttab\n`, which a bash reader would read back as just
+	// `/with` (the `tab` segment becoming a stray field).
+	tabbed := "/projects/My\tProject/bin/tool"
+	prefix := "/legit/prefix/"
+	mappings := []config.Mapping{
+		{Path: tabbed, Vars: []config.VarRef{{Name: "FOO", Source: "s", Ref: "x"}}},
+		{Glob: prefix + "**", Vars: []config.VarRef{{Name: "BAR", Source: "s", Ref: "y"}}},
+	}
+	idx := config.NewIndex(mappings)
+
+	writeAnchors(anchorsFile, idx)
+
+	got, err := os.ReadFile(anchorsFile)
+	if err != nil {
+		t.Fatalf("read anchors: %v", err)
+	}
+
+	// Format: `E\0<path>\0P\0<prefix>\0`.
+	want := []byte("E\x00" + tabbed + "\x00P\x00" + prefix + "\x00")
+	if !bytes.Equal(got, want) {
+		t.Errorf("anchors framing wrong:\n  got=%q\n want=%q", got, want)
+	}
+
+	// Sanity-check there's no raw TAB framing or newline framing left.
+	if bytes.Contains(got, []byte("E\t")) || bytes.Contains(got, []byte("P\t")) {
+		t.Errorf("anchors file still contains legacy TAB framing: %q", got)
+	}
+	if i := bytes.IndexByte(got, '\n'); i >= 0 {
+		t.Errorf("anchors file contains newline at %d (NUL framing should leave none): %q", i, got)
+	}
+
+	// And confirm the original TAB-containing path is present verbatim
+	// (i.e. not truncated at the TAB the way the old reader did).
+	if !bytes.Contains(got, []byte(tabbed)) {
+		t.Errorf("TAB-containing path was mangled by writeAnchors: %q", got)
+	}
+}
+
+// TestWriteAnchorsNilEmitsEmptyFile asserts that a nil Index produces an
+// empty sidecar (not a missing one) so the bash/zsh fast-path correctly
+// short-circuits when no anchors are wanted. This is the substrate of the
+// #286 fix below (clear-sidecar-on-Load-fail) — `writeAnchors(path, nil)`
+// must produce a valid empty-anchor file.
+func TestWriteAnchorsNilEmitsEmptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	anchorsFile := filepath.Join(tmp, "match-anchors")
+	// Pre-populate with stale anchors so we can prove it's overwritten,
+	// not just left alone.
+	if err := os.WriteFile(anchorsFile, []byte("E\x00/stale/path\x00"), 0o600); err != nil {
+		t.Fatalf("seed stale: %v", err)
+	}
+
+	writeAnchors(anchorsFile, nil)
+
+	got, err := os.ReadFile(anchorsFile)
+	if err != nil {
+		t.Fatalf("read anchors: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("writeAnchors(nil) should empty the file, got %q", got)
+	}
+}
+
+// TestRunClearsAnchorsOnConfigError is the #286 regression: when the
+// config is corrupt (Load-fail), Run must overwrite any pre-existing
+// match-anchors sidecar with an empty one, so the bash/zsh in-shell
+// pre-filter (#260) stops trusting yesterday's anchors. Without this
+// fix the hook keeps forking `is-mapped` for every stale-matching path
+// AND newly-added mappings stay invisible until the next cd.
+func TestRunClearsAnchorsOnConfigError(t *testing.T) {
+	tmp := t.TempDir()
+	runtimeDir := filepath.Join(tmp, "runtime")
+	cfgPath := filepath.Join(tmp, "config.toml")
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	t.Setenv("JITENV_CONFIG", cfgPath)
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a syntactically broken TOML config — config.Load should fail.
+	if err := os.WriteFile(cfgPath, []byte("this is = not valid toml [[[\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pid := os.Getpid()
+	paths, _ := agent.DefaultPaths()
+	wrapDir := paths.ShellWrapDir(pid)
+	shellDir := filepath.Dir(wrapDir)
+	if err := os.MkdirAll(shellDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate stale anchors from a prior good load.
+	staleAnchors := filepath.Join(shellDir, "match-anchors")
+	stale := []byte("E\x00/stale/yesterday\x00P\x00/old/prefix/\x00")
+	if err := os.WriteFile(staleAnchors, stale, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force the Load-fail path: pwd different from oldpwd so the
+	// short-circuit doesn't fire before we get to desiredCommandsFor.
+	if _, err := Run([]string{strconv.Itoa(pid), tmp, filepath.Join(tmp, "other")}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got, err := os.ReadFile(staleAnchors)
+	if err != nil {
+		t.Fatalf("read anchors after broken-config Run: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("anchors sidecar not cleared on config Load-fail (#286):\n  got=%q", got)
+	}
+	// Also confirm no leftover content from the stale write.
+	if strings.Contains(string(got), "stale") || strings.Contains(string(got), "yesterday") {
+		t.Errorf("stale anchor content leaked through Load-fail path: %q", got)
 	}
 }

--- a/internal/shell/hook_anchor_prefilter_test.go
+++ b/internal/shell/hook_anchor_prefilter_test.go
@@ -166,3 +166,49 @@ printf '__DONE__\n' >&2
 		t.Errorf("command under a glob's literal prefix was filtered out (should fork is-mapped to confirm):\n%s", underPhase)
 	}
 }
+
+// TestHookAnchorPrefilter_TabInPathRoundtrips is the #285 regression: a
+// `path` mapping whose target contains a literal TAB (legal on Linux and
+// macOS filesystems) must round-trip through the anchors sidecar intact,
+// so the in-shell pre-filter still recognises it as an exact anchor. The
+// previous TAB-framed format silently truncated the path at the TAB, so a
+// command at the real path resolved to an unrecognised anchor and ran
+// without env injection. NUL framing fixes that.
+func TestHookAnchorPrefilter_TabInPathRoundtrips(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	runtimeDir := filepath.Join(dir, "runtime")
+	_ = os.MkdirAll(runtimeDir, 0o700)
+
+	// A path with an embedded TAB. Created on the host fs — Linux/macOS
+	// accept TAB in filenames; the test skips if the fs disallows it.
+	tabbed := filepath.Join(dir, "tools", "with\ttab", "probe")
+	if err := os.MkdirAll(filepath.Dir(tabbed), 0o755); err != nil {
+		t.Skipf("filesystem rejected TAB in path: %v", err)
+	}
+	if err := os.WriteFile(tabbed, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Skipf("filesystem rejected TAB-containing file: %v", err)
+	}
+
+	cfgPath := writeConfigWithMappings(t, dir, []config.Mapping{
+		{Path: tabbed, Vars: []config.VarRef{{Name: "FOO", Source: "n", Ref: "x"}}},
+	})
+
+	// Run the exact tabbed path. Pre-filter should recognise it as an
+	// exact-anchor hit and fork `is-mapped` (the `candidate cmd=…` log
+	// line is the marker — it's printed immediately before the fork).
+	// We bash-quote the path explicitly so the shell sees the TAB byte.
+	quoted := fmt.Sprintf("$'%s'", strings.ReplaceAll(tabbed, "\t", `\t`))
+	out := runHookDebug(t, bin, cfgPath, runtimeDir, fmt.Sprintf(`
+printf '__RUN__\n' >&2
+%s
+printf '__DONE__\n' >&2
+`, quoted))
+
+	if !strings.Contains(out, "candidate cmd=") {
+		t.Errorf("TAB-containing path failed to match its exact anchor (#285):\n%s", out)
+	}
+}

--- a/internal/shell/snippets/bash.sh
+++ b/internal/shell/snippets/bash.sh
@@ -107,8 +107,12 @@ __jitenv_load_anchors() {
     __JITENV_BARENAME_ACTIVE=0
     [[ -r "$__JITENV_ANCHORS_FILE" ]] || return 0
     local kind val
-    # IFS=tab so values (absolute paths / prefixes) keep any spaces.
-    while IFS=$'\t' read -r kind val; do
+    # NUL-framed pairs (#285): `<kind>\0<val>\0`. `read -d ''` reads up to
+    # the next NUL, so we pair-wise read kind and val. NUL is the one byte
+    # that can't appear in a Unix path, so paths containing TAB or newline
+    # (legal on Linux/macOS) survive verbatim — the previous TAB framing
+    # truncated such paths and silently bypassed env injection.
+    while IFS= read -rd '' kind && IFS= read -rd '' val; do
         case "$kind" in
             E) __JITENV_EXACT["$val"]=1 ;;
             P) __JITENV_PREFIX+=("$val") ;;

--- a/internal/shell/snippets/zsh.sh
+++ b/internal/shell/snippets/zsh.sh
@@ -89,8 +89,14 @@ __jitenv_load_anchors() {
     __JITENV_PREFIX=()
     __JITENV_BARENAME_ACTIVE=0
     [[ -r "$__JITENV_ANCHORS_FILE" ]] || return 0
+    # NUL-framed pairs (#285): `<kind>\0<val>\0`. `read -d ''` sets the
+    # delimiter to NUL (the first byte of the empty arg's storage), so we
+    # pair-wise read kind then val. NUL is the one byte that can't appear
+    # in a Unix path, so paths containing TAB or newline (legal on
+    # Linux/macOS) survive verbatim — the previous TAB framing truncated
+    # such anchors and silently bypassed env injection.
     local kind val
-    while IFS=$'\t' read -r kind val; do
+    while IFS= read -rd '' kind && IFS= read -rd '' val; do
         case "$kind" in
             E) __JITENV_EXACT[$val]=1 ;;
             P) __JITENV_PREFIX+=("$val") ;;


### PR DESCRIPTION
## Summary

Two related fixes to the per-shell `match-anchors` sidecar that the bash/zsh in-shell pre-filter (#260) reads on every prompt.

- **#285 — anchors framing.** `writeAnchors` emitted `<kind>\t<path>\n` rows that the shell readers split with `IFS=$'\t' read -r kind val`. A path containing a literal TAB (legal on Linux/macOS) was silently truncated at the first TAB — the anchor didn't match the real path, the mapped command ran without env injection, and a malicious filename could craft bogus anchors to intercept unrelated commands. Switch to NUL framing (`<kind>\0<path>\0`); NUL is the one byte that can never appear in a Unix path. Bash reads pairwise with `IFS= read -rd ''`; zsh uses the same pattern.
- **#286 — Load-fail leaves stale anchors.** When `desiredCommandsFor` errored (corrupt config, missing file), Run returned early and skipped `writeAnchors`, leaving yesterday's sidecar in place. The pre-filter then forked `is-mapped` (→ exit 2 → silent no-inject) for every stale-matching path AND any mapping the user just added in the broken edit stayed invisible until the next `cd`. Now clear the sidecar on the err path so the hook's "no anchors → bail" branch fires correctly while the config is broken.

Closes #285
Closes #286

## Migration

Existing TAB-framed anchor files on disk get rewritten in the new NUL format on the next reconcile (any `cd` or config edit). No explicit migration step needed.

## Test plan

- [x] `go test ./internal/chpwd/` — three new tests: `TestWriteAnchorsNULFraming`, `TestWriteAnchorsNilEmitsEmptyFile`, `TestRunClearsAnchorsOnConfigError`.
- [x] `go test ./internal/shell/` — new `TestHookAnchorPrefilter_TabInPathRoundtrips` exercises the bash hook reader end-to-end with a TAB-in-path mapping.
- [x] `go test ./...` — full suite green.
- [x] `go vet ./...` clean, `golangci-lint run` clean on touched packages.
- [x] Manual: `printf 'E\0/path/with\ttab/x\0P\0/prefix/\0' | bash NUL-read pattern` yields `[/path/with<TAB>tab/x]` verbatim (no truncation).