### PR TITLE
config: cap pre-id-migration.bak retention (closes #288)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,16 @@ type Meta struct {
 	Salt           string `toml:"salt"`               // base64
 	Verify         string `toml:"verify"`             // enc:v1:...
 	NameMap        string `toml:"name_map,omitempty"` // enc:v2: sealed JSON (#248)
+	// MigratedAt records when the pre-#248 → opaque-ID migration ran,
+	// as an RFC3339 UTC timestamp. Set by MigrateToOpaqueIDs immediately
+	// before it writes the migrated config; consumed by the AtomicSave
+	// retention sweep that auto-removes the verbatim pre-id-migration
+	// backup once the rollback window has elapsed (#288). Empty on
+	// configs that were never migrated and on legacy configs migrated
+	// by a binary that predates this field — in both cases the sweep
+	// leaves the backup alone, so the user-visible behaviour is the
+	// pre-#288 status quo (keep the .bak until the user removes it).
+	MigratedAt string `toml:"migrated_at,omitempty"`
 }
 
 type AgentConfig struct {

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -141,21 +141,36 @@ func DeriveKeyFromMeta(c *Config, passphrase []byte) ([]byte, error) {
 // path. Streams the TOML encoder directly into the tempfile so a large
 // config never has to buffer in RAM; durability + cleanup-on-failure
 // come from internal/atomicfile (#281).
+//
+// On every successful save the pre-id-migration backup sibling
+// (.pre-id-migration.bak) is swept if Meta.MigratedAt is past the
+// configured rollback window (#288). The sweep is best-effort and
+// gated on Meta.MigratedAt being a parseable RFC3339 stamp, so
+// configs migrated by a binary that predates the field keep the
+// pre-#288 "leave the .bak alone" behaviour.
 func atomicSave(path string, c *Config) error {
-	return atomicfile.WriteFunc(path, 0o600, ".jitenv-*.toml", func(f *os.File) error {
+	if err := atomicfile.WriteFunc(path, 0o600, ".jitenv-*.toml", func(f *os.File) error {
 		return toml.NewEncoder(f).Encode(c)
-	})
+	}); err != nil {
+		return err
+	}
+	sweepMigrationBackupIfExpired(path, c.Meta)
+	return nil
 }
 
 // AtomicSave is the exported variant for callers outside this package
 // (e.g. the TUI). It writes c to a sibling tempfile then renames over
 // path (mode 0600).
 //
-// Unlike earlier behavior (#248), AtomicSave no longer consumes the
-// pre-id-migration backup. The verbatim pre-#248 backup written by
-// MigrateToOpaqueIDs persists on disk until the user removes it
-// themselves (#269) — saving the config no longer silently deletes the
-// only rollback escape hatch.
+// Unlike earlier behavior (#248), AtomicSave does not unconditionally
+// consume the pre-id-migration backup. The verbatim pre-#248 backup
+// written by MigrateToOpaqueIDs persists on disk for the rollback
+// window (default 30 days, override via
+// JITENV_MIGRATION_BACKUP_RETENTION_DAYS) so the user keeps an escape
+// hatch; once the window has elapsed AtomicSave removes the backup so
+// it does NOT ride along in dotfile tarballs / rsyncs (#288). The user
+// can still delete it manually at any time via the on-screen rm
+// command in MigrationNotice (#269).
 func AtomicSave(path string, c *Config) error {
 	return atomicSave(path, c)
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/gv/jitenv/internal/lockfile"
 )
@@ -150,9 +152,18 @@ func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
 		return false, fmt.Errorf("migrate: re-encrypt under opaque IDs: %w (original left untouched; backup at %s)", err, backupPath)
 	}
 
+	// Stamp the migration timestamp into Meta so the AtomicSave
+	// retention sweep (#288) knows when the rollback window started.
+	// RFC3339 / UTC is human-readable, sorts lexicographically, and is
+	// unambiguous across time zones. Recorded BEFORE save so it lands
+	// on disk with the migrated config.
+	c.Meta.MigratedAt = time.Now().UTC().Format(time.RFC3339)
+
 	// Write via the unexported atomicSave (AtomicSave is identical now,
 	// but keep the internal call explicit). The verbatim backup created
-	// above stays on disk as the rollback escape hatch (#269).
+	// above stays on disk as the rollback escape hatch (#269); the
+	// AtomicSave retention sweep removes it once Meta.MigratedAt is
+	// older than the configured window (#288).
 	if err := atomicSave(path, c); err != nil {
 		return false, fmt.Errorf("migrate: save migrated config: %w (original left untouched; backup at %s)", err, backupPath)
 	}
@@ -198,11 +209,91 @@ func writeVerbatimBackup(src, dst string) error {
 }
 
 // removeMigrationBackup unlinks the pre-migration backup sibling for
-// path, if present. As of #269 nothing in the save path calls this —
-// the backup is intentionally left on disk for the user to remove. The
-// helper is retained for callers that want to explicitly delete the
-// backup (and is exercised by tests). Best-effort: a failure to remove
-// is non-fatal, so the error is swallowed.
+// path, if present. As of #288 the AtomicSave path wires this in via
+// sweepMigrationBackupIfExpired once the rollback window
+// (Meta.MigratedAt + DefaultMigrationBackupRetention) has elapsed,
+// closing the long-tail data-exfil hazard where the .bak rode along
+// in dotfile tarballs / rsyncs (#288). Best-effort: a failure to
+// remove is non-fatal, so the error is swallowed.
 func removeMigrationBackup(path string) {
 	_ = os.Remove(path + MigrationBackupSuffix)
+}
+
+// MigrationBackupRetentionEnv lets the user override the default
+// rollback window for the pre-id-migration backup. Value is parsed as
+// an integer number of days; 0 means "remove on the next save",
+// negative means "never auto-remove" (preserves the pre-#288
+// behaviour for users who explicitly want to keep the .bak
+// indefinitely). A malformed value falls back to the default.
+const MigrationBackupRetentionEnv = "JITENV_MIGRATION_BACKUP_RETENTION_DAYS"
+
+// DefaultMigrationBackupRetention is the rollback window after which
+// AtomicSave auto-removes the pre-id-migration backup (#288). 30 days
+// is the rollback window most users would want — long enough to catch
+// a migration regression that surfaces after a few weeks of normal
+// use, short enough that a dotfile tarball taken months later does
+// NOT carry the verbatim pre-#248 secrets.
+const DefaultMigrationBackupRetention = 30 * 24 * time.Hour
+
+// migrationBackupRetention returns the effective retention window,
+// honouring JITENV_MIGRATION_BACKUP_RETENTION_DAYS. A negative value
+// disables the sweep entirely (returned as a negative Duration); 0
+// triggers immediate removal on the next save.
+func migrationBackupRetention() time.Duration {
+	raw, ok := os.LookupEnv(MigrationBackupRetentionEnv)
+	if !ok || raw == "" {
+		return DefaultMigrationBackupRetention
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return DefaultMigrationBackupRetention
+	}
+	return time.Duration(n) * 24 * time.Hour
+}
+
+// sweepMigrationBackupIfExpired removes the verbatim pre-id-migration
+// backup sibling of path when Meta.MigratedAt is past the configured
+// rollback window. Called from atomicSave on every save (#288) so the
+// backup gradually ages out of any config directory the user is
+// actively touching, rather than persisting indefinitely as a silent
+// secret-exfil hazard (it rode along in `tar czf ~/.config/jitenv`
+// and `rsync ~/.config/jitenv` flows).
+//
+// Behaviour matrix:
+//   - retention <  0: sweep disabled, no-op (operator opt-out).
+//   - meta.MigratedAt empty: no recorded migration, no-op. Backwards
+//     compat with configs migrated by a binary that predates this
+//     field — those users keep manual ownership of the .bak.
+//   - meta.MigratedAt unparseable: treat as if it were empty
+//     (defensive — never delete a backup based on a malformed
+//     timestamp).
+//   - backup missing: no-op (idempotent; the common steady-state
+//     after the first sweep).
+//   - now - migratedAt >= retention: best-effort os.Remove. Errors
+//     are swallowed — a failed remove is no worse than the pre-#288
+//     status quo where the user removes it themselves.
+//
+// The sweep never touches Meta.MigratedAt: keeping the timestamp on
+// disk is harmless and lets a future tool report "this config
+// migrated on <date>" without parsing the .bak.
+func sweepMigrationBackupIfExpired(path string, meta Meta) {
+	retention := migrationBackupRetention()
+	if retention < 0 {
+		return
+	}
+	if meta.MigratedAt == "" {
+		return
+	}
+	migratedAt, err := time.Parse(time.RFC3339, meta.MigratedAt)
+	if err != nil {
+		return
+	}
+	if time.Since(migratedAt) < retention {
+		return
+	}
+	backup := path + MigrationBackupSuffix
+	if _, err := os.Stat(backup); err != nil {
+		return
+	}
+	_ = os.Remove(backup)
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -183,10 +183,11 @@ func TestMigrateToOpaqueIDs_ValidateStructure(t *testing.T) {
 }
 
 // TestAtomicSave_PreservesMigrationBackup verifies that, as of #269,
-// AtomicSave no longer consumes the pre-migration backup: the verbatim
-// backup written by the migration survives subsequent config-modifying
-// saves so the user keeps a rollback escape hatch until they delete it
-// themselves.
+// AtomicSave no longer unconditionally consumes the pre-migration
+// backup: a freshly-migrated config (Meta.MigratedAt = now) keeps the
+// verbatim backup across subsequent saves so the user has an in-window
+// rollback escape hatch. Post-#288 the retention sweep eventually
+// removes it; that path is exercised by the *Retention* tests below.
 func TestAtomicSave_PreservesMigrationBackup(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
@@ -203,7 +204,9 @@ func TestAtomicSave_PreservesMigrationBackup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	// Two saves to be sure nothing in the save path removes it.
+	// Two saves to be sure nothing in the save path removes the
+	// in-window backup (Meta.MigratedAt was stamped seconds ago, so
+	// the retention sweep is a no-op).
 	if err := AtomicSave(path, c); err != nil {
 		t.Fatalf("save: %v", err)
 	}
@@ -211,13 +214,176 @@ func TestAtomicSave_PreservesMigrationBackup(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 	if _, err := os.Stat(backup); err != nil {
-		t.Fatalf("backup must be preserved across AtomicSave (#269), stat err=%v", err)
+		t.Fatalf("in-window backup must be preserved across AtomicSave (#269), stat err=%v", err)
 	}
 
 	// removeMigrationBackup remains the explicit way to delete it.
 	removeMigrationBackup(path)
 	if _, err := os.Stat(backup); !os.IsNotExist(err) {
 		t.Fatalf("removeMigrationBackup should unlink the backup, stat err=%v", err)
+	}
+}
+
+// TestAtomicSave_RemovesExpiredMigrationBackup asserts the #288
+// retention sweep: when Meta.MigratedAt is older than the configured
+// rollback window, the next AtomicSave removes the .pre-id-migration.bak
+// so it stops riding along in dotfile tarballs / rsyncs of the config
+// directory.
+func TestAtomicSave_RemovesExpiredMigrationBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	backup := path + MigrationBackupSuffix
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("backup should exist immediately after migration: %v", err)
+	}
+
+	// Backdate Meta.MigratedAt to 31 days ago — one day past the
+	// default 30-day rollback window — and persist it via a normal
+	// load → mutate → AtomicSave round trip so the sweep runs.
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	c.Meta.MigratedAt = time.Now().Add(-31 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(backup); !os.IsNotExist(err) {
+		t.Fatalf("expired backup must be auto-removed by AtomicSave (#288), stat err=%v", err)
+	}
+
+	// A subsequent save with the backup already gone is a no-op (the
+	// sweep tolerates a missing file).
+	c2, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := AtomicSave(path, c2); err != nil {
+		t.Fatalf("save after sweep: %v", err)
+	}
+}
+
+// TestAtomicSave_KeepsInWindowMigrationBackup pins the boundary
+// behaviour: a backup whose recorded migration timestamp is INSIDE
+// the rollback window must survive AtomicSave. This is the user's
+// rollback escape hatch — sweeping it early would defeat #269.
+func TestAtomicSave_KeepsInWindowMigrationBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	backup := path + MigrationBackupSuffix
+
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// Backdate to 29 days ago — still inside the default 30-day window.
+	c.Meta.MigratedAt = time.Now().Add(-29 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("in-window backup must survive AtomicSave: %v", err)
+	}
+}
+
+// TestAtomicSave_MigrationBackupRetentionEnvOverride exercises the
+// JITENV_MIGRATION_BACKUP_RETENTION_DAYS knob: setting it to 0
+// shortens the window to "remove on the very next save", which is the
+// fastest user-visible way to drain a stale backup.
+func TestAtomicSave_MigrationBackupRetentionEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	backup := path + MigrationBackupSuffix
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("backup should exist immediately after migration: %v", err)
+	}
+
+	t.Setenv(MigrationBackupRetentionEnv, "0")
+
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// Meta.MigratedAt is "just now", but retention=0 means
+	// time.Since(MigratedAt) >= 0 is true → sweep on the next save.
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(backup); !os.IsNotExist(err) {
+		t.Fatalf("retention=0 must sweep on the next save (#288), stat err=%v", err)
+	}
+}
+
+// TestAtomicSave_MigrationBackupRetentionEnvDisable asserts the
+// "never auto-remove" escape hatch: a negative retention value
+// disables the sweep entirely, restoring the pre-#288 "user owns the
+// .bak" semantics for operators who explicitly want it.
+func TestAtomicSave_MigrationBackupRetentionEnvDisable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	backup := path + MigrationBackupSuffix
+
+	t.Setenv(MigrationBackupRetentionEnv, "-1")
+
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// Even with an obviously-expired stamp, retention<0 must not
+	// touch the backup.
+	c.Meta.MigratedAt = time.Now().Add(-365 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("retention<0 must not sweep, stat err=%v", err)
+	}
+}
+
+// TestAtomicSave_MissingMigratedAtPreservesBackup pins the
+// backwards-compat behaviour: a config that has a backup on disk but
+// no Meta.MigratedAt (because it was migrated by a binary that
+// predates the #288 stamp) MUST keep the backup. We never delete a
+// backup we can't date.
+func TestAtomicSave_MissingMigratedAtPreservesBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	backup := path + MigrationBackupSuffix
+
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// Simulate a pre-#288 on-disk state by clearing MigratedAt before
+	// saving. With an empty stamp the sweep MUST be a no-op even
+	// when retention=0 (an empty stamp is "I don't know when").
+	c.Meta.MigratedAt = ""
+	t.Setenv(MigrationBackupRetentionEnv, "0")
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("empty Meta.MigratedAt must preserve the backup: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #288