### PR TITLE
config: date migration backup filenames so a stale .bak doesn't block retries (#304)

### DIFF
--- a/internal/cli/bag_import.go
+++ b/internal/cli/bag_import.go
@@ -133,10 +133,10 @@ func runBagImport(cmd *cobra.Command, opts importOpts) error {
 	defer lockKey(key)()
 
 	// Dry-run must be byte-for-byte side-effect-free: no opaque-ID
-	// migration (which would write the migrated config + a
-	// .pre-id-migration.bak), no save, and no TTY prompts. We decrypt the
-	// config IN MEMORY ONLY to read the target bag's existing keys, then
-	// report what WOULD change. A legacy (pre-#248) config decrypts under
+	// migration (which would write the migrated config + a dated
+	// *.pre-id-migration.*.bak, #304), no save, and no TTY prompts. We
+	// decrypt the config IN MEMORY ONLY to read the target bag's existing
+	// keys, then report what WOULD change. A legacy (pre-#248) config decrypts under
 	// its name-based AADs into a name-keyed cfg.Secrets — exactly the
 	// shape bagUpsert's collision check needs — so no in-memory migration
 	// is required for the report either.

--- a/internal/cli/bag_import_test.go
+++ b/internal/cli/bag_import_test.go
@@ -381,9 +381,8 @@ func TestBagImport_DryRun_LegacyConfig_NoSideEffects(t *testing.T) {
 	if !bytes.Equal(before, after) {
 		t.Errorf("dry-run must not modify a legacy config on disk")
 	}
-	if _, err := os.Stat(cfgPath + config.MigrationBackupSuffix); !os.IsNotExist(err) {
-		t.Errorf("dry-run must not create a %s backup (stat err: %v)",
-			config.MigrationBackupSuffix, err)
+	if bak := config.MigrationBackupPath(cfgPath); bak != "" {
+		t.Errorf("dry-run must not create a migration backup, found: %s", bak)
 	}
 }
 
@@ -430,12 +429,16 @@ func TestBagImport_DryRun_OnCollisionAsk_NoTTY(t *testing.T) {
 // name the absolute backup path and warn that the backup holds secrets.
 func TestMigrationNoticeEmittedOnce(t *testing.T) {
 	cfgPath := newLegacyImportTestConfig(t, "prod", "A", "old")
-	backup := cfgPath + config.MigrationBackupSuffix
 
 	// First import triggers the migration → notice fires once.
 	_, errOut, err := runImport(t, "B=2\n", "prod", "--stdin")
 	if err != nil {
 		t.Fatalf("first import: %v", err)
+	}
+	// The dated backup is discoverable only after the migration ran.
+	backup := config.MigrationBackupPath(cfgPath)
+	if backup == "" {
+		t.Fatal("expected a dated migration backup after the first import")
 	}
 	const marker = "upgraded config to opaque-ID format (#248)"
 	if n := strings.Count(errOut, marker); n != 1 {

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -142,8 +142,8 @@ func DeriveKeyFromMeta(c *Config, passphrase []byte) ([]byte, error) {
 // config never has to buffer in RAM; durability + cleanup-on-failure
 // come from internal/atomicfile (#281).
 //
-// On every successful save the pre-id-migration backup sibling
-// (.pre-id-migration.bak) is swept if Meta.MigratedAt is past the
+// On every successful save any dated pre-id-migration backup sibling
+// (*.pre-id-migration.*.bak, #304) is swept if Meta.MigratedAt is past the
 // configured rollback window (#288). The sweep is best-effort and
 // gated on Meta.MigratedAt being a parseable RFC3339 stamp, so
 // configs migrated by a binary that predates the field keep the

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -52,6 +52,18 @@ func migrationBackupGlob(cfgPath, kind string) string {
 	return cfgPath + ".pre-" + kind + "-migration.*.bak"
 }
 
+// legacyMigrationBackupPath returns the pre-#304 FIXED-name backup
+// sibling for cfgPath: <cfgPath>.pre-<kind>-migration.bak. Binaries
+// before #304 wrote the backup to this single, undated path. The dated
+// glob (migrationBackupGlob) deliberately does NOT match it (the dated
+// form always has a timestamp segment between "migration." and ".bak"),
+// so the retention sweep would otherwise never reach a backup left by an
+// older binary, re-opening the #288 data-exfil hazard. The sweep removes
+// this path explicitly as a best-effort cleanup for upgraded installs.
+func legacyMigrationBackupPath(cfgPath, kind string) string {
+	return cfgPath + ".pre-" + kind + "-migration.bak"
+}
+
 // listMigrationBackups returns the dated backup siblings of cfgPath for
 // the given kind, in no particular order. A glob error or no matches
 // yields an empty slice.
@@ -105,13 +117,18 @@ func MigrationBackupPath(cfgPath string) string {
 func MigrationNotice(cfgPath string) string {
 	bak := MigrationBackupPath(cfgPath)
 	if bak == "" {
-		// No backup discoverable (e.g. it was already swept). Fall back
-		// to naming the config so the message is still coherent.
-		if abs, err := filepath.Abs(cfgPath); err == nil {
-			bak = abs
-		} else {
-			bak = cfgPath
-		}
+		// No dated backup discoverable (e.g. it was already swept by the
+		// #288 retention path). Emit a coherent notice that does NOT name
+		// the live config as the backup location — naming cfgPath here
+		// would point the rollback/rm instructions at the user's live
+		// config, which is worse than admitting the path is unknown.
+		return "jitenv: upgraded config to opaque-ID format (#248).\n" +
+			"A verbatim backup of the pre-upgrade config was written, but its\n" +
+			"location could not be determined (it may already have been removed\n" +
+			"by the retention sweep, #288). If a *.pre-id-migration.*.bak file\n" +
+			"is still present next to your config, it is that backup.\n" +
+			"Note: such a backup contains your secret values sealed under the old\n" +
+			"scheme — keep it local; do not check it in or sync it."
 	}
 	return "jitenv: upgraded config to opaque-ID format (#248).\n" +
 		"A verbatim backup of the pre-upgrade config has been written to:\n" +
@@ -289,6 +306,9 @@ func removeMigrationBackup(path string) {
 	for _, m := range listMigrationBackups(path, migrationBackupKind) {
 		_ = os.Remove(m)
 	}
+	// Best-effort cleanup of a pre-#304 fixed-name backup too (#304),
+	// which the dated glob does not match.
+	_ = os.Remove(legacyMigrationBackupPath(path, migrationBackupKind))
 }
 
 // MigrationBackupRetentionEnv lets the user override the default
@@ -371,4 +391,10 @@ func sweepMigrationBackupIfExpired(path string, meta Meta) {
 	for _, m := range listMigrationBackups(path, migrationBackupKind) {
 		_ = os.Remove(m)
 	}
+	// Also sweep a legacy fixed-name backup left by a pre-#304 binary
+	// (#304): it is not matched by the dated glob above, so without this
+	// it would persist past the rollback window and keep re-creating the
+	// #288 exfil hazard. Gated by the same Meta.MigratedAt expiry check
+	// the dated backups passed above; best-effort, errors swallowed.
+	_ = os.Remove(legacyMigrationBackupPath(path, migrationBackupKind))
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -19,15 +19,79 @@ import (
 // same on-disk config (see #275 / #166).
 const MigrationLockSuffix = ".tui.lock"
 
-// MigrationBackupPath returns the absolute path of the verbatim
-// pre-#248 backup sibling for the given config path. Used by the
-// user-facing migration notice so the message names the exact file.
+// migrationBackupKind is the migration-kind token embedded in dated
+// backup filenames (config.toml.pre-id-migration.<when>.bak). It names
+// the opaque-ID migration (#248). A future migration would use a
+// different kind so its backups never collide with these.
+const migrationBackupKind = "id"
+
+// migrationBackupTimeLayout is the filesystem-safe UTC timestamp format
+// used in dated backup filenames. It is RFC3339-like but uses dashes in
+// the time component because colons are not valid in filenames on
+// Windows (e.g. 2026-06-11T15-30-00Z).
+const migrationBackupTimeLayout = "2006-01-02T15-04-05Z"
+
+// backupPath builds the verbatim pre-migration backup sibling for
+// cfgPath, dating it with when so each migration call (including a retry
+// after a partial failure) lands on its own unique filename rather than
+// colliding on a fixed suffix (#304). Example output:
+//
+//	/home/u/.config/jitenv/config.toml.pre-id-migration.2026-06-11T15-30-00Z.bak
+//
+// when is passed in by the caller (rather than read from time.Now here)
+// so the migration stays testable with an injected clock.
+func backupPath(cfgPath, kind string, when time.Time) string {
+	return cfgPath + ".pre-" + kind + "-migration." + when.UTC().Format(migrationBackupTimeLayout) + ".bak"
+}
+
+// migrationBackupGlob returns the doublestar-free filepath.Glob pattern
+// matching every dated backup of the given kind for cfgPath. Both the
+// notice (most-recent discovery) and the retention sweep use it so they
+// agree on which files are pre-migration backups.
+func migrationBackupGlob(cfgPath, kind string) string {
+	return cfgPath + ".pre-" + kind + "-migration.*.bak"
+}
+
+// listMigrationBackups returns the dated backup siblings of cfgPath for
+// the given kind, in no particular order. A glob error or no matches
+// yields an empty slice.
+func listMigrationBackups(cfgPath, kind string) []string {
+	matches, err := filepath.Glob(migrationBackupGlob(cfgPath, kind))
+	if err != nil {
+		return nil
+	}
+	return matches
+}
+
+// MigrationBackupPath returns the absolute path of the most-recent
+// (by mtime) verbatim pre-#248 backup sibling for the given config
+// path, or "" if no dated backup exists. Used by the user-facing
+// migration notice so the message names the exact file that was just
+// written (the just-written backup is, by construction, the newest).
+//
+// Discovery-by-glob (rather than recomputing a fixed path) is what lets
+// dated backups (#304) coexist: a retry or a future migration adds a new
+// dated file without the notice losing track of the current one.
 func MigrationBackupPath(cfgPath string) string {
-	bak := cfgPath + MigrationBackupSuffix
-	if abs, err := filepath.Abs(bak); err == nil {
+	matches := listMigrationBackups(cfgPath, migrationBackupKind)
+	var newest string
+	var newestMod time.Time
+	for _, m := range matches {
+		fi, err := os.Stat(m)
+		if err != nil {
+			continue
+		}
+		if newest == "" || fi.ModTime().After(newestMod) {
+			newest, newestMod = m, fi.ModTime()
+		}
+	}
+	if newest == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(newest); err == nil {
 		return abs
 	}
-	return bak
+	return newest
 }
 
 // MigrationNotice is the one-shot, user-facing message printed after the
@@ -40,6 +104,15 @@ func MigrationBackupPath(cfgPath string) string {
 // the SAME text via this helper so the copy stays consistent.
 func MigrationNotice(cfgPath string) string {
 	bak := MigrationBackupPath(cfgPath)
+	if bak == "" {
+		// No backup discoverable (e.g. it was already swept). Fall back
+		// to naming the config so the message is still coherent.
+		if abs, err := filepath.Abs(cfgPath); err == nil {
+			bak = abs
+		} else {
+			bak = cfgPath
+		}
+	}
 	return "jitenv: upgraded config to opaque-ID format (#248).\n" +
 		"A verbatim backup of the pre-upgrade config has been written to:\n" +
 		"  " + bak + "\n" +
@@ -50,12 +123,6 @@ func MigrationNotice(cfgPath string) string {
 		"Note: the backup contains your secret values sealed under the old\n" +
 		"scheme — keep it local; do not check it in or sync it."
 }
-
-// MigrationBackupSuffix is appended to the config path for the verbatim
-// pre-migration backup written by MigrateToOpaqueIDs. The backup is left
-// in place after migration and is never removed automatically (#269) —
-// the user deletes it themselves once they've verified the upgrade.
-const MigrationBackupSuffix = ".pre-id-migration.bak"
 
 // MigrateToOpaqueIDs upgrades a legacy name-keyed config (pre-#248) to
 // the opaque-ID on-disk shape: source/bag/bag-key names move into the
@@ -69,9 +136,10 @@ const MigrationBackupSuffix = ".pre-id-migration.bak"
 //
 // Flow (DECIDED in #248):
 //  1. Detect old shape; short-circuit if already migrated.
-//  2. Copy the file verbatim to a sibling backup. If the backup already
-//     exists, abort with a conflict error (it may be a prior half-
-//     migration) — never overwrite it.
+//  2. Copy the file verbatim to a DATED sibling backup (#304). Each call
+//     stamps the filename with the current UTC time, so a retry after a
+//     partial failure lands on a fresh name and proceeds rather than
+//     colliding on a fixed suffix. The original is never overwritten.
 //  3. Decrypt under the OLD (name-based) AADs. On a legacy config the
 //     map keys are names, so DecryptInPlace's AAD derivation reproduces
 //     the old name-based context exactly, and translation is a no-op.
@@ -133,8 +201,12 @@ func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
 		return false, nil
 	}
 
-	backupPath := path + MigrationBackupSuffix
-	if err := writeVerbatimBackup(path, backupPath); err != nil {
+	// Date the backup filename so a leftover backup from a prior
+	// (possibly half-completed) run does not block this one (#304). The
+	// timestamp is captured once here; the migration itself takes no
+	// other dependency on the wall clock until Meta.MigratedAt below.
+	bak := backupPath(path, migrationBackupKind, time.Now())
+	if err := writeVerbatimBackup(path, bak); err != nil {
 		return false, err
 	}
 
@@ -143,13 +215,13 @@ func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
 	// reproduces the pre-#248 context. There is no name_map yet, so the
 	// ID→name translation step is a no-op and c stays name-keyed.
 	if err := DecryptInPlace(c, key); err != nil {
-		return false, fmt.Errorf("migrate: decrypt legacy config: %w (original left untouched; backup at %s)", err, backupPath)
+		return false, fmt.Errorf("migrate: decrypt legacy config: %w (original left untouched; backup at %s)", err, bak)
 	}
 
 	// Re-seal under the new ID-based AADs + build the sealed name_map.
 	// c.Meta.NameMap is empty here, so EncryptInPlace mints fresh IDs.
 	if err := EncryptInPlace(c, key); err != nil {
-		return false, fmt.Errorf("migrate: re-encrypt under opaque IDs: %w (original left untouched; backup at %s)", err, backupPath)
+		return false, fmt.Errorf("migrate: re-encrypt under opaque IDs: %w (original left untouched; backup at %s)", err, bak)
 	}
 
 	// Stamp the migration timestamp into Meta so the AtomicSave
@@ -165,30 +237,26 @@ func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
 	// AtomicSave retention sweep removes it once Meta.MigratedAt is
 	// older than the configured window (#288).
 	if err := atomicSave(path, c); err != nil {
-		return false, fmt.Errorf("migrate: save migrated config: %w (original left untouched; backup at %s)", err, backupPath)
+		return false, fmt.Errorf("migrate: save migrated config: %w (original left untouched; backup at %s)", err, bak)
 	}
 	return true, nil
 }
 
-// writeVerbatimBackup copies src to dst byte-for-byte at mode 0600. It
-// refuses to overwrite an existing backup: a leftover backup signals a
-// prior interrupted migration, and clobbering it would discard the only
-// pristine copy of the user's original config.
+// writeVerbatimBackup copies src to dst byte-for-byte at mode 0600.
+//
+// As of #304 dst is a DATED, per-call filename, so a leftover backup
+// from a prior run no longer collides here and there is no pre-existence
+// check to abort the migration. O_EXCL is kept purely as defense in
+// depth against the absurd same-second collision (two migrations of the
+// same config within one second resolving to the same timestamp) — it
+// never fires in normal operation.
 func writeVerbatimBackup(src, dst string) error {
-	if _, err := os.Stat(dst); err == nil {
-		return fmt.Errorf("migration backup %s already exists; refusing to overwrite (it may be a prior interrupted migration — inspect it, then remove it to retry)", dst)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("stat backup path %s: %w", dst, err)
-	}
-
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
 
-	// O_EXCL so a backup that appears between the Stat and the Open
-	// (TOCTOU) still aborts rather than truncating.
 	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	if err != nil {
 		if errors.Is(err, os.ErrExist) {
@@ -208,15 +276,19 @@ func writeVerbatimBackup(src, dst string) error {
 	return nil
 }
 
-// removeMigrationBackup unlinks the pre-migration backup sibling for
-// path, if present. As of #288 the AtomicSave path wires this in via
-// sweepMigrationBackupIfExpired once the rollback window
+// removeMigrationBackup unlinks every dated pre-migration backup
+// sibling for path, if any. As of #288 the AtomicSave path wires this in
+// via sweepMigrationBackupIfExpired once the rollback window
 // (Meta.MigratedAt + DefaultMigrationBackupRetention) has elapsed,
 // closing the long-tail data-exfil hazard where the .bak rode along
-// in dotfile tarballs / rsyncs (#288). Best-effort: a failure to
+// in dotfile tarballs / rsyncs (#288). Since #304 backups are dated, so
+// a single migration may have left more than one (e.g. a retry after a
+// partial failure) — all of them are removed. Best-effort: a failure to
 // remove is non-fatal, so the error is swallowed.
 func removeMigrationBackup(path string) {
-	_ = os.Remove(path + MigrationBackupSuffix)
+	for _, m := range listMigrationBackups(path, migrationBackupKind) {
+		_ = os.Remove(m)
+	}
 }
 
 // MigrationBackupRetentionEnv lets the user override the default
@@ -269,9 +341,14 @@ func migrationBackupRetention() time.Duration {
 //     timestamp).
 //   - backup missing: no-op (idempotent; the common steady-state
 //     after the first sweep).
-//   - now - migratedAt >= retention: best-effort os.Remove. Errors
-//     are swallowed — a failed remove is no worse than the pre-#288
-//     status quo where the user removes it themselves.
+//   - now - migratedAt >= retention: best-effort os.Remove of every
+//     dated backup (#304). Errors are swallowed — a failed remove is
+//     no worse than the pre-#288 status quo where the user removes it
+//     themselves.
+//
+// The expiry decision is keyed off Meta.MigratedAt (when the config was
+// migrated), not the individual backup mtimes, so every dated backup
+// from that migration ages out together once the window elapses.
 //
 // The sweep never touches Meta.MigratedAt: keeping the timestamp on
 // disk is harmless and lets a future tool report "this config
@@ -291,9 +368,7 @@ func sweepMigrationBackupIfExpired(path string, meta Meta) {
 	if time.Since(migratedAt) < retention {
 		return
 	}
-	backup := path + MigrationBackupSuffix
-	if _, err := os.Stat(backup); err != nil {
-		return
+	for _, m := range listMigrationBackups(path, migrationBackupKind) {
+		_ = os.Remove(m)
 	}
-	_ = os.Remove(backup)
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -88,7 +88,7 @@ func TestMigrateToOpaqueIDs_Golden(t *testing.T) {
 	}
 
 	// Backup written verbatim.
-	backup := path + MigrationBackupSuffix
+	backup := MigrationBackupPath(path)
 	if _, err := os.Stat(backup); err != nil {
 		t.Fatalf("expected backup at %s: %v", backup, err)
 	}
@@ -139,27 +139,128 @@ func TestMigrateToOpaqueIDs_Golden(t *testing.T) {
 	}
 }
 
-// TestMigrateToOpaqueIDs_BackupConflict asserts a pre-existing backup
-// aborts the migration (it may be a prior interrupted run).
-func TestMigrateToOpaqueIDs_BackupConflict(t *testing.T) {
+// TestMigrateToOpaqueIDs_StaleBackupIgnored asserts the #304 contract:
+// a leftover dated backup from a prior run does NOT block a fresh
+// migration. The migration writes its own dated backup and proceeds; the
+// stale file is left untouched.
+func TestMigrateToOpaqueIDs_StaleBackupIgnored(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	key := writeLegacyConfig(t, path)
 
-	// Plant a stale backup.
-	if err := os.WriteFile(path+MigrationBackupSuffix, []byte("stale"), 0600); err != nil {
-		t.Fatalf("plant backup: %v", err)
+	// Plant a stale dated backup from a (simulated) earlier run.
+	stale := backupPath(path, migrationBackupKind, time.Now().Add(-time.Hour))
+	if err := os.WriteFile(stale, []byte("stale"), 0600); err != nil {
+		t.Fatalf("plant stale backup: %v", err)
 	}
-	if _, err := MigrateToOpaqueIDs(path, key); err == nil {
-		t.Fatal("migration must abort when a backup already exists")
+
+	migrated, err := MigrateToOpaqueIDs(path, key)
+	if err != nil {
+		t.Fatalf("migration must not abort on a stale dated backup: %v", err)
 	}
-	// Original untouched (still legacy).
+	if !migrated {
+		t.Fatal("expected migration to proceed past the stale backup")
+	}
+
+	// The config is now migrated.
 	c, err := Load(path)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if !NeedsIDMigration(c) {
-		t.Fatal("original config must be left untouched (still legacy) on backup conflict")
+	if NeedsIDMigration(c) {
+		t.Fatal("config should be migrated despite the stale backup")
+	}
+
+	// The stale backup is untouched and still holds its sentinel bytes.
+	got, err := os.ReadFile(stale)
+	if err != nil {
+		t.Fatalf("stale backup should still exist: %v", err)
+	}
+	if string(got) != "stale" {
+		t.Fatalf("stale backup was modified: %q", got)
+	}
+
+	// A fresh dated backup was written too, distinct from the stale one.
+	backups := listMigrationBackups(path, migrationBackupKind)
+	if len(backups) != 2 {
+		t.Fatalf("expected stale + fresh backup (2), got %d: %v", len(backups), backups)
+	}
+}
+
+// TestMigrateToOpaqueIDs_RetryProducesDistinctBackups asserts that two
+// migration runs (e.g. a retry path) each produce their own dated backup
+// without colliding. Both backups coexist on disk; neither blocks the
+// other (#304).
+func TestMigrateToOpaqueIDs_RetryProducesDistinctBackups(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	// First migration: legacy -> opaque IDs, writes backup #1.
+	key := writeLegacyConfig(t, path)
+	if migrated, err := MigrateToOpaqueIDs(path, key); err != nil || !migrated {
+		t.Fatalf("first migrate: migrated=%v err=%v", migrated, err)
+	}
+	first := listMigrationBackups(path, migrationBackupKind)
+	if len(first) != 1 {
+		t.Fatalf("expected 1 backup after first migration, got %d", len(first))
+	}
+
+	// Re-plant a legacy config at the same path (simulates a fresh
+	// migration needing to run again over a config at this location) and
+	// migrate again. The new dated backup must NOT collide with the first.
+	// Sleep a second so the timestamp (1s granularity) differs.
+	// Remove the (now-migrated) config so InitNew can re-seed it; the
+	// dated backup from migration #1 stays on disk to prove coexistence.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove migrated config: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	key2 := writeLegacyConfig(t, path)
+	if migrated, err := MigrateToOpaqueIDs(path, key2); err != nil || !migrated {
+		t.Fatalf("second migrate: migrated=%v err=%v", migrated, err)
+	}
+
+	all := listMigrationBackups(path, migrationBackupKind)
+	if len(all) != 2 {
+		t.Fatalf("expected 2 distinct dated backups after two migrations, got %d: %v", len(all), all)
+	}
+	if all[0] == all[1] {
+		t.Fatalf("the two backups must have distinct filenames: %v", all)
+	}
+}
+
+// TestMigrationBackupPath_MostRecent verifies MigrationBackupPath returns
+// the newest (by mtime) dated backup, and "" when none exist (#304).
+func TestMigrationBackupPath_MostRecent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if got := MigrationBackupPath(path); got != "" {
+		t.Fatalf("MigrationBackupPath with no backups should be empty, got %q", got)
+	}
+
+	now := time.Now()
+	older := backupPath(path, migrationBackupKind, now.Add(-2*time.Hour))
+	newer := backupPath(path, migrationBackupKind, now.Add(-1*time.Hour))
+	for _, p := range []string{older, newer} {
+		if err := os.WriteFile(p, []byte("x"), 0600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	// Force mtimes so the newer-named file is genuinely newer on disk.
+	if err := os.Chtimes(older, now.Add(-2*time.Hour), now.Add(-2*time.Hour)); err != nil {
+		t.Fatalf("chtimes older: %v", err)
+	}
+	if err := os.Chtimes(newer, now.Add(-1*time.Hour), now.Add(-1*time.Hour)); err != nil {
+		t.Fatalf("chtimes newer: %v", err)
+	}
+
+	got := MigrationBackupPath(path)
+	if !filepath.IsAbs(got) {
+		t.Fatalf("MigrationBackupPath must be absolute, got %q", got)
+	}
+	if filepath.Base(got) != filepath.Base(newer) {
+		t.Fatalf("expected most-recent backup %q, got %q", filepath.Base(newer), filepath.Base(got))
 	}
 }
 
@@ -195,7 +296,7 @@ func TestAtomicSave_PreservesMigrationBackup(t *testing.T) {
 	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	backup := path + MigrationBackupSuffix
+	backup := MigrationBackupPath(path)
 	if _, err := os.Stat(backup); err != nil {
 		t.Fatalf("backup should exist immediately after migration: %v", err)
 	}
@@ -236,7 +337,7 @@ func TestAtomicSave_RemovesExpiredMigrationBackup(t *testing.T) {
 	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	backup := path + MigrationBackupSuffix
+	backup := MigrationBackupPath(path)
 	if _, err := os.Stat(backup); err != nil {
 		t.Fatalf("backup should exist immediately after migration: %v", err)
 	}
@@ -278,7 +379,7 @@ func TestAtomicSave_KeepsInWindowMigrationBackup(t *testing.T) {
 	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	backup := path + MigrationBackupSuffix
+	backup := MigrationBackupPath(path)
 
 	c, err := Load(path)
 	if err != nil {
@@ -305,7 +406,7 @@ func TestAtomicSave_MigrationBackupRetentionEnvOverride(t *testing.T) {
 	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	backup := path + MigrationBackupSuffix
+	backup := MigrationBackupPath(path)
 	if _, err := os.Stat(backup); err != nil {
 		t.Fatalf("backup should exist immediately after migration: %v", err)
 	}
@@ -337,7 +438,7 @@ func TestAtomicSave_MigrationBackupRetentionEnvDisable(t *testing.T) {
 	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	backup := path + MigrationBackupSuffix
+	backup := MigrationBackupPath(path)
 
 	t.Setenv(MigrationBackupRetentionEnv, "-1")
 
@@ -368,7 +469,7 @@ func TestAtomicSave_MissingMigratedAtPreservesBackup(t *testing.T) {
 	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	backup := path + MigrationBackupSuffix
+	backup := MigrationBackupPath(path)
 
 	c, err := Load(path)
 	if err != nil {
@@ -459,12 +560,18 @@ func TestMigrationNotice_ContentAndPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 
+	// Plant a dated backup so the notice has a concrete file to name.
+	written := backupPath(path, migrationBackupKind, time.Now())
+	if err := os.WriteFile(written, []byte("x"), 0600); err != nil {
+		t.Fatalf("plant backup: %v", err)
+	}
+
 	bak := MigrationBackupPath(path)
 	if !filepath.IsAbs(bak) {
 		t.Fatalf("MigrationBackupPath must be absolute, got %q", bak)
 	}
-	if filepath.Base(bak) != "config.toml"+MigrationBackupSuffix {
-		t.Fatalf("backup basename = %q", filepath.Base(bak))
+	if filepath.Base(bak) != filepath.Base(written) {
+		t.Fatalf("backup basename = %q, want %q", filepath.Base(bak), filepath.Base(written))
 	}
 
 	notice := MigrationNotice(path)

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -586,3 +586,78 @@ func TestMigrationNotice_ContentAndPath(t *testing.T) {
 		}
 	}
 }
+
+// TestAtomicSave_RemovesExpiredLegacyMigrationBackup pins the #304
+// regression: a user who migrated with a pre-#304 binary has a FIXED-name
+// .pre-id-migration.bak (no embedded timestamp). The dated glob the sweep
+// uses does not match it, so without explicit handling the #288 retention
+// sweep would never fire for that file and it would persist indefinitely,
+// re-opening the data-exfil hazard. Once Meta.MigratedAt is past the
+// rollback window, AtomicSave must remove the legacy fixed-name backup too.
+func TestAtomicSave_RemovesExpiredLegacyMigrationBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// Remove the dated backup the migration just wrote and plant a legacy
+	// fixed-name backup in its place to simulate a pre-#304 on-disk state.
+	for _, m := range listMigrationBackups(path, migrationBackupKind) {
+		if err := os.Remove(m); err != nil {
+			t.Fatalf("clear dated backup: %v", err)
+		}
+	}
+	legacy := legacyMigrationBackupPath(path, migrationBackupKind)
+	if err := os.WriteFile(legacy, []byte("legacy backup contents"), 0o600); err != nil {
+		t.Fatalf("plant legacy backup: %v", err)
+	}
+
+	// Backdate Meta.MigratedAt past the default 30-day window and save.
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	c.Meta.MigratedAt = time.Now().Add(-31 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("expired legacy fixed-name backup must be swept (#304), stat err=%v", err)
+	}
+}
+
+// TestAtomicSave_KeepsInWindowLegacyMigrationBackup is the boundary
+// counterpart: a legacy fixed-name backup whose recorded migration
+// timestamp is still inside the rollback window must survive AtomicSave,
+// preserving the user's rollback escape hatch (#269) for upgraded installs.
+func TestAtomicSave_KeepsInWindowLegacyMigrationBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+	if _, err := MigrateToOpaqueIDs(path, key); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	for _, m := range listMigrationBackups(path, migrationBackupKind) {
+		if err := os.Remove(m); err != nil {
+			t.Fatalf("clear dated backup: %v", err)
+		}
+	}
+	legacy := legacyMigrationBackupPath(path, migrationBackupKind)
+	if err := os.WriteFile(legacy, []byte("legacy backup contents"), 0o600); err != nil {
+		t.Fatalf("plant legacy backup: %v", err)
+	}
+
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// 29 days ago — still inside the default 30-day window.
+	c.Meta.MigratedAt = time.Now().Add(-29 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	if err := AtomicSave(path, c); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(legacy); err != nil {
+		t.Fatalf("in-window legacy fixed-name backup must survive AtomicSave: %v", err)
+	}
+}

--- a/internal/run/inline_unlock_migrate_e2e_test.go
+++ b/internal/run/inline_unlock_migrate_e2e_test.go
@@ -138,12 +138,16 @@ func TestRunInlineUnlock_MigratesLegacyConfig(t *testing.T) {
 		t.Fatalf("child did not exit;\noutput=%s", readAll())
 	}
 
-	// The .pre-id-migration.bak must have been written by the inline
-	// unlock — this is the #269 rollback escape hatch the user can
-	// reach via the backup notice.
-	backup := cfgPath + config.MigrationBackupSuffix
+	// The dated pre-id-migration backup must have been written by the
+	// inline unlock — this is the #269 rollback escape hatch the user can
+	// reach via the backup notice. Discovered via MigrationBackupPath
+	// since the filename is dated (#304).
+	backup := config.MigrationBackupPath(cfgPath)
+	if backup == "" {
+		t.Fatalf("inline-unlock did not write a pre-migration backup near %s", cfgPath)
+	}
 	if _, err := os.Stat(backup); err != nil {
-		t.Fatalf("inline-unlock did not write the pre-migration backup at %s: %v", backup, err)
+		t.Fatalf("discovered backup %s not statable: %v", backup, err)
 	}
 
 	// And the on-disk config is now in the migrated (opaque-ID) shape:

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -207,8 +207,9 @@ func fetchAfterUnlock(ctx context.Context, abs string) (map[string]string, bool,
 	}
 	// Surface the one-shot opaque-ID migration backup notice (#275): a
 	// user whose first jitenv interaction post-#248 upgrade is an inline
-	// unlock via the agent-down countdown otherwise never sees the
-	// .pre-id-migration.bak rollback hint (#269).
+	// unlock via the agent-down countdown otherwise never sees the dated
+	// pre-id-migration backup (*.pre-id-migration.*.bak, #304) rollback
+	// hint (#269).
 	if res.Migrated {
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, config.MigrationNotice(res.CfgPath))

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -528,7 +528,8 @@ func fetchAfterUnlock(cmd string) (map[string]string, error) {
 	// Surface the one-shot opaque-ID migration backup notice (#275): a
 	// user whose first jitenv interaction post-#248 upgrade is an inline
 	// unlock from the cwd_glob shim's agent-down countdown otherwise
-	// never sees the .pre-id-migration.bak rollback hint (#269).
+	// never sees the dated pre-id-migration backup
+	// (*.pre-id-migration.*.bak, #304) rollback hint (#269).
 	if res.Migrated {
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, config.MigrationNotice(res.CfgPath))

--- a/internal/unlock/unlock.go
+++ b/internal/unlock/unlock.go
@@ -67,8 +67,9 @@ func Spawn(cfgPath string) (Result, error) {
 	// Lifting this here from `jitenv unlock` ensures every key-holding
 	// entry point — including the inline-unlock prompt fired from the
 	// agent-down countdown in run/shim (#232) — runs the migration by
-	// construction, so the user always sees the .pre-id-migration.bak
-	// and the post-migration backup notice (#275). config.MigrateToOpaqueIDs
+	// construction, so the user always sees the dated pre-id-migration
+	// backup (*.pre-id-migration.*.bak, #304) and the post-migration
+	// backup notice (#275). config.MigrateToOpaqueIDs
 	// takes its own internal lock against `jitenv config` and concurrent
 	// migrations, so this call is safe to make from every caller.
 	migrated, err := config.MigrateToOpaqueIDs(resolved, key)


### PR DESCRIPTION
## Summary

`MigrateToOpaqueIDs` wrote its pre-migration backup to a fixed sibling path (`config.toml.pre-id-migration.bak`) and `writeVerbatimBackup` refused to overwrite it. A leftover backup from a prior run therefore blocked **every** path that needs migration (inline unlock, `unlock`, `clone`, `bag import`, the TUI):

- a retry after a partial failure that occurred **after** the backup was written hit "backup already exists; refusing to overwrite" and aborted;
- a future migration (or a second migration kind) reusing the suffix collided.

This PR dates the backup filename so each migration call lands on its own file:

```
config.toml.pre-id-migration.2026-06-11T15-30-00Z.bak
```

## Changes

- **`backupPath(cfgPath, kind, when time.Time)`** builds a per-call dated filename. The timestamp is UTC with a dash-separated time component (`2006-01-02T15-04-05Z`) so it is filesystem-safe on Windows (no colons). The clock is injected by the caller, keeping the migration logic testable.
- **`MigrationBackupPath`** now discovers the most-recent dated backup via glob + max mtime (returns `""` when none exist), rather than recomputing a fixed path.
- **`MigrationNotice`** names the discovered (just-written, i.e. newest) backup; it falls back to the config path if none is discoverable (e.g. already swept).
- **`writeVerbatimBackup`** drops the pre-existence abort — the dated name guarantees uniqueness. `O_EXCL` is retained purely as defense-in-depth against an absurd same-second collision.
- The #288 retention machinery (`sweepMigrationBackupIfExpired`, `removeMigrationBackup`) now globs and removes **every** dated backup, keyed off `Meta.MigratedAt`, so all backups from a migration age out together. (No new GC inside AtomicSave; #269 retention semantics unchanged.)

## Tests

- Replaced `TestMigrateToOpaqueIDs_BackupConflict` (asserted abort-on-existing-backup) with `TestMigrateToOpaqueIDs_StaleBackupIgnored` (a stale dated backup is left untouched and a fresh one is written) and `TestMigrateToOpaqueIDs_RetryProducesDistinctBackups` (two migrations produce two distinct files).
- Added `TestMigrationBackupPath_MostRecent` (returns newest by mtime; empty when none).
- Switched hardcoded `MigrationBackupSuffix` references in `internal/cli/bag_import_test.go` and `internal/run/inline_unlock_migrate_e2e_test.go` to discovery via `MigrationBackupPath`.
- `TestAtomicSave_PreservesMigrationBackup` and the #288 retention tests still pass.

`go test ./...`, `go vet ./...`, `gofmt`, and `golangci-lint run` are all green.

## Out of scope

Retention/sweep policy rework, encrypting the backup, new migration kinds, GC inside AtomicSave (#269 forbids it).

Closes #304