### PR TITLE
config: fix jitenv config TUI self-deadlock on .tui.lock during opaque-ID migration

### DIFF
--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -206,11 +206,36 @@ func MigrateToOpaqueIDs(path string, key []byte) (migrated bool, err error) {
 	}
 	defer lock.Close()
 
+	return MigrateToOpaqueIDsLocked(path, key)
+}
+
+// MigrateToOpaqueIDsLocked is the locked core of MigrateToOpaqueIDs: it
+// performs the opaque-ID migration ASSUMING THE CALLER ALREADY HOLDS the
+// path + MigrationLockSuffix flock. It does NOT acquire that lock itself.
+//
+// This split exists for the `jitenv config` TUI path (#306): the parent
+// `jitenv` process takes an exclusive flock on config.toml.tui.lock and
+// holds it for the whole TUI session while exec'ing the child jitenv-tui.
+// The child cannot re-acquire the same sibling (a fresh, O_CLOEXEC,
+// non-inherited fd flock(LOCK_EX|LOCK_NB) on the same inode returns
+// EWOULDBLOCK), so calling the self-locking MigrateToOpaqueIDs there
+// self-deadlocks and bricks the TUI for legacy configs. The TUI calls
+// THIS variant instead, trusting the parent's lock.
+//
+// Every other entry point (inline unlock, agent spawn, clone, bag
+// import) does NOT hold .tui.lock and MUST call the self-locking
+// MigrateToOpaqueIDs, not this one.
+//
+// The re-check-under-lock (Load + NeedsIDMigration) is preserved here so
+// both entry points are safe against another process having finished the
+// migration in the window between the caller's lock acquire and this
+// call. Returns (false, nil) when the config no longer needs migrating.
+func MigrateToOpaqueIDsLocked(path string, key []byte) (migrated bool, err error) {
 	// Re-check under the lock: another process may have just finished
 	// the migration while we waited (or were probing). This makes the
 	// function safe to call from multiple key-holding entry points
 	// without an explicit external guard.
-	c, err = Load(path)
+	c, err := Load(path)
 	if err != nil {
 		return false, err
 	}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -553,6 +553,79 @@ func TestMigrateToOpaqueIDs_LegacyContendsOnLock(t *testing.T) {
 	}
 }
 
+// TestMigrateToOpaqueIDsLocked_MigratesUnderHeldLock is the #306
+// regression: the `jitenv config` parent holds an exclusive flock on
+// config.toml.tui.lock for the whole TUI session and exec's the child
+// jitenv-tui while still holding it. The child cannot re-acquire that
+// same sibling (a fresh O_CLOEXEC fd's flock(LOCK_EX|LOCK_NB) on the same
+// inode returns EWOULDBLOCK), so calling the self-locking
+// MigrateToOpaqueIDs there self-deadlocks and bricks the TUI for legacy
+// configs. The locked-core variant trusts the caller's lock, so the
+// migration must succeed even with the lock already held.
+func TestMigrateToOpaqueIDsLocked_MigratesUnderHeldLock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	key := writeLegacyConfig(t, path)
+
+	// Sanity: pre-migration it's legacy and needs migration.
+	pre, err := Load(path)
+	if err != nil {
+		t.Fatalf("load pre: %v", err)
+	}
+	if !NeedsIDMigration(pre) {
+		t.Fatal("legacy config should need migration")
+	}
+
+	// Simulate the parent `jitenv config` process holding .tui.lock for
+	// the whole TUI session (config.go:198). The self-locking
+	// MigrateToOpaqueIDs would EWOULDBLOCK here (see
+	// TestMigrateToOpaqueIDs_LegacyContendsOnLock); the locked core must
+	// not.
+	heldF, err := lockfile.Acquire(path + MigrationLockSuffix)
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+	t.Cleanup(func() { _ = heldF.Close() })
+
+	migrated, err := MigrateToOpaqueIDsLocked(path, key)
+	if err != nil {
+		t.Fatalf("locked migration must succeed under a held .tui.lock: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migrated=true for a legacy config")
+	}
+
+	// On disk: migrated to the opaque-ID shape, no longer needs migrating.
+	post, err := Load(path)
+	if err != nil {
+		t.Fatalf("load post: %v", err)
+	}
+	if NeedsIDMigration(post) {
+		t.Fatal("post-migration config should NOT need migration")
+	}
+	if post.Meta.NameMap == "" {
+		t.Fatal("post-migration config missing sealed name_map")
+	}
+
+	// Values still decrypt to the original plaintext under the new AADs.
+	if err := DecryptInPlace(post, key); err != nil {
+		t.Fatalf("decrypt post: %v", err)
+	}
+	if post.Secrets["stripe"]["SECRET_KEY"] != "sk_live_x" {
+		t.Fatalf("stripe secret not preserved: %v", post.Secrets["stripe"]["SECRET_KEY"])
+	}
+
+	// Locked core is idempotent too: a re-run on the migrated config (lock
+	// still held) is a clean no-op.
+	migrated2, err := MigrateToOpaqueIDsLocked(path, key)
+	if err != nil {
+		t.Fatalf("second locked migrate: %v", err)
+	}
+	if migrated2 {
+		t.Fatal("second locked migration should be a no-op")
+	}
+}
+
 // TestMigrationNotice_ContentAndPath verifies the shared notice copy
 // names the ABSOLUTE backup path, includes the rollback rm command, and
 // carries the one-line "this holds secrets — don't sync" warning (#269).

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -215,8 +215,12 @@ func loadOrInit(cfgPath string) (*config.Config, []byte, bool, error) {
 		return nil, nil, false, err
 	}
 	// One-shot opaque-ID migration (#248). Runs under the TUI lock held
-	// by `jitenv config`, so it can't race the agent-spawn migration.
-	migrated, err := config.MigrateToOpaqueIDs(cfgPath, key)
+	// by the parent `jitenv config` process (config.go acquires
+	// config.toml.tui.lock and holds it for the whole TUI session while
+	// exec'ing this child). We therefore call the LOCKED core variant:
+	// re-acquiring that same sibling here would self-deadlock and brick
+	// the TUI for legacy configs (#306).
+	migrated, err := config.MigrateToOpaqueIDsLocked(cfgPath, key)
 	if err != nil {
 		zero(key)
 		return nil, nil, false, err


### PR DESCRIPTION
## Summary

`jitenv config` against a legacy (pre-#248, no `[_meta].name_map`) config — the exact state right after upgrading from a pre-opaque-ID release — failed immediately after the passphrase prompt and never opened the TUI:

```
jitenv-tui: another jitenv session is editing .../config.toml — close it, then retry
```

This was a self-inflicted `flock` conflict, not a stale lock. Two code paths take the same `.tui.lock` sibling:

1. The `jitenv` parent acquires an exclusive `flock` on `config.toml.tui.lock` and holds it for the whole TUI session, exec'ing `jitenv-tui` as a child while still holding it (`internal/cli/config.go:198`).
2. The child `jitenv-tui`, on a legacy config, ran the opaque-ID migration, which acquired the **same** sibling (`internal/config/migrate.go`, called from `internal/tui/tui.go:219`).

The child's lock fd is a fresh open-file-description — the parent's fd is `O_CLOEXEC`, not inherited across exec — so `flock(LOCK_EX|LOCK_NB)` on the same inode returned `EWOULDBLOCK` and the migration aborted before `writeVerbatimBackup` / `atomicSave`. The config stayed legacy and every subsequent `jitenv config` repeated the failure (permanent brick). Deleting `.tui.lock` did not help — the parent re-creates and re-holds it before the child migrates.

## Fix

Split `MigrateToOpaqueIDs` into:
- the existing **self-locking** public wrapper (acquire `.tui.lock`, then delegate), and
- a new **`MigrateToOpaqueIDsLocked(path, key)`** core that SKIPS the `lockfile.Acquire` and trusts the caller already holds `path + MigrationLockSuffix`.

The re-check-under-lock logic (`Load` + `NeedsIDMigration`) lives in the locked core so both entry points stay safe against a racing finisher.

`internal/tui/tui.go` `loadOrInit` (the `jitenv config` TUI path — runs under the parent's lock) now calls the locked variant. All other callers (inline unlock, agent spawn, clone, bag import) keep calling the self-locking `MigrateToOpaqueIDs` since they do **not** hold `.tui.lock`. `internal/cli/config.go` is unchanged.

## Tests

Added `TestMigrateToOpaqueIDsLocked_MigratesUnderHeldLock` (regression for this bug): acquires `.tui.lock` first (simulating the parent), then asserts the locked variant migrates successfully (`migrated=true`, `NeedsIDMigration==false`, name_map present, secrets preserved, idempotent re-run). The existing `TestMigrateToOpaqueIDs_LegacyContendsOnLock` still pins that the **self-locking** path correctly contends on a held lock.

`go test ./...` green; `golangci-lint run` clean.

Closes #306
