### PR TITLE
ci(chocolatey): don't fail the release when choco push is moderation-blocked

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -190,9 +190,25 @@ jobs:
         env:
           PKG_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          choco push "dist-choco/jitenv.${env:PKG_VERSION}.nupkg" --source https://push.chocolatey.org/ --api-key $env:CHOCO_KEY
-          if ($LASTEXITCODE -ne 0) { throw "choco push failed ($LASTEXITCODE)" }
-          Write-Host "Pushed jitenv ${env:PKG_VERSION} to chocolatey.org (pending moderation)."
+          $out = choco push "dist-choco/jitenv.${env:PKG_VERSION}.nupkg" --source https://push.chocolatey.org/ --api-key $env:CHOCO_KEY 2>&1
+          $code = $LASTEXITCODE
+          $out | ForEach-Object { Write-Host $_ }
+          if ($code -eq 0) {
+            Write-Host "Pushed jitenv ${env:PKG_VERSION} to chocolatey.org (pending moderation)."
+            exit 0
+          }
+          # A 403/409 here is a chocolatey.org moderation condition CI can't
+          # resolve: the community repo refuses a new version while an earlier
+          # one is still pending its (manual) new-package review, returning a
+          # bodyless 403. Don't fail the whole release for it — the .nupkg is
+          # already uploaded as an artifact. Re-run this job once the pending
+          # version is approved. Genuine errors still hard-fail.
+          $text = ($out | Out-String)
+          if ($text -match '403|Forbidden|409|Conflict') {
+            Write-Host "::warning::choco push was refused (exit $code) — likely chocolatey.org moderation blocking a new version while an earlier one is pending review. The .nupkg artifact is uploaded; re-run this job after the pending version is approved. Not failing the release."
+            exit 0
+          }
+          throw "choco push failed ($code)"
 
       - name: Note when key absent
         if: ${{ env.CHOCO_KEY == '' }}


### PR DESCRIPTION
## Problem

The `chocolatey` workflow has been failing on releases (latest: v0.14.0). Everything succeeds — version resolution, token rendering, `choco pack`, artifact upload — **only the final `choco push` fails**, with a bare:

```
[NuGet]   PUT https://push.chocolatey.org/api/v2/package/
[NuGet]   Forbidden ... 403 (Forbidden)
```

This is **not** a workflow bug or an API-key problem (reproduced with a freshly-rotated key, and `--verbose` confirmed chocolatey returns a bodyless 403). The `jitenv` package has never been approved on the chocolatey.org community repo, and **v0.13.0 is still pending its manual new-package moderation review**. The community repo refuses a newer version while an earlier one is pending, so v0.14.0's push is rejected — a condition CI cannot resolve.

## Change

Treat a 403/409 from `choco push` as a loud `::warning::` instead of a hard failure, so the release pipeline stops going red for an out-of-CI-control moderation state. The `.nupkg` is still uploaded as an artifact on every run. Genuine push errors (anything other than 403/409) still hard-fail.

## To actually publish

Out of band, on chocolatey.org: get **v0.13.0** through moderation (confirm validation/verification are green, respond to moderator comments), then re-run this job for the newer tag:

```
gh workflow run chocolatey.yml -f tag=v0.14.0
```

https://claude.ai/code/session_0198zyXQthRQV3nLCGkBAC1S