### PR TITLE
fix: rename re-seals name_map; accurate TUI edit verbs + quit guard (#313, #314)

### DIFF
--- a/internal/config/encrypt.go
+++ b/internal/config/encrypt.go
@@ -37,20 +37,36 @@ func EncryptInPlace(c *Config, key []byte) error {
 	//    doesn't rotate the name_map nonce (idempotency).
 	//
 	//    Prefer c.IDMap (the live, post-decrypt dictionary the TUI mutates
-	//    on rename) over the sealed Meta.NameMap, which goes stale the
-	//    moment a name is changed in memory. Carrying the dictionary is
-	//    what makes a rename keep the source/bag/key ID STABLE (#248):
+	//    on rename) over the sealed Meta.NameMap for ID STABILITY (#248):
 	//    the TUI rewrites IDMap[id]=newName, so the new name maps back to
 	//    the SAME id here rather than minting a fresh one.
+	//
+	//    The re-seal decision, however, must NOT compare against c.IDMap.
+	//    The TUI applies a rename to c.IDMap in memory BEFORE this runs, so
+	//    by the time we get here c.IDMap already encodes the new name; the
+	//    rebuilt nm would then be content-equal to it and the re-seal would
+	//    be (wrongly) skipped, leaving the STALE sealed name_map on disk and
+	//    silently reverting the rename on the next load (#314). So we open
+	//    the sealed-on-disk dictionary separately as sealedPrev and gate the
+	//    re-seal on whether nm differs from THAT — the actual on-disk truth.
 	prev := c.IDMap
+	var err error
 	if prev == nil {
-		var err error
 		prev, err = openNameMap(key, c.Meta.NameMap)
 		if err != nil {
 			return err
 		}
 	}
-	var err error
+	// sealedPrev is whatever the existing sealed envelope decodes to (the
+	// on-disk truth). It is used ONLY to decide whether a re-seal is needed,
+	// so a no-op save still produces byte-identical output (no nonce churn).
+	sealedPrev := &NameMap{}
+	if c.Meta.NameMap != "" {
+		sealedPrev, err = openNameMap(key, c.Meta.NameMap)
+		if err != nil {
+			return err
+		}
+	}
 
 	nm := &NameMap{
 		Sources: map[string]string{},
@@ -222,7 +238,7 @@ func EncryptInPlace(c *Config, key []byte) error {
 	//    its content changed vs. the prior one — otherwise leave the
 	//    existing envelope untouched so a no-op save produces byte-
 	//    identical output (no nonce churn).
-	if c.Meta.NameMap == "" || !nameMapEqual(prev, nm) {
+	if c.Meta.NameMap == "" || !nameMapEqual(sealedPrev, nm) {
 		sealed, err := sealNameMap(key, nm)
 		if err != nil {
 			return err

--- a/internal/config/encrypt_test.go
+++ b/internal/config/encrypt_test.go
@@ -136,6 +136,101 @@ func TestEncryptInPlace_VarsIdempotent(t *testing.T) {
 	}
 }
 
+// TestEncryptInPlace_RenameReSealsNameMap is the #314 regression: the
+// TUI applies a rename to the live c.IDMap BEFORE EncryptInPlace runs, so
+// the re-seal decision must NOT compare the rebuilt dictionary against
+// c.IDMap (it would always look "unchanged" and skip the re-seal, leaving
+// the stale sealed name_map on disk). It must compare against the
+// sealed-on-disk dictionary instead.
+func TestEncryptInPlace_RenameReSealsNameMap(t *testing.T) {
+	key := newTestKey(t)
+	c := &Config{
+		Version: Version,
+		Secrets: map[string]map[string]string{
+			"db": {"pass": "s3cret"},
+		},
+	}
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+
+	// Locate the stable bag ID and capture the sealed envelope.
+	var bagID string
+	for id, n := range c.IDMap.Bags {
+		if n == "db" {
+			bagID = id
+		}
+	}
+	if bagID == "" {
+		t.Fatal("no bag ID minted for 'db'")
+	}
+	sealedBefore := c.Meta.NameMap
+
+	// Simulate the TUI rename: mutate Secrets + the live IDMap in place,
+	// exactly as references.renameIDMapKey/Bag do, BEFORE the next encrypt.
+	c.Secrets["db"]["password"] = c.Secrets["db"]["pass"]
+	delete(c.Secrets["db"], "pass")
+	for kid, n := range c.IDMap.Keys[bagID] {
+		if n == "pass" {
+			c.IDMap.Keys[bagID][kid] = "password"
+		}
+	}
+
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("re-encrypt: %v", err)
+	}
+	if c.Meta.NameMap == sealedBefore {
+		t.Fatal("rename did not re-seal Meta.NameMap (#314): stale envelope kept")
+	}
+
+	// Round-trip: the decrypted name must be the NEW one.
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt2: %v", err)
+	}
+	if _, ok := c.Secrets["db"]["password"]; !ok {
+		t.Fatalf("rename reverted: keys=%v", c.Secrets["db"])
+	}
+	if _, ok := c.Secrets["db"]["pass"]; ok {
+		t.Fatal("stale key name 'pass' resurfaced (#314)")
+	}
+	if c.Secrets["db"]["password"] != "s3cret" {
+		t.Fatalf("value lost across rename: %q", c.Secrets["db"]["password"])
+	}
+}
+
+// TestEncryptInPlace_NoOpDoesNotReSeal guards the optimization the #314
+// fix preserves: a re-encrypt with no name changes must leave Meta.NameMap
+// byte-identical (no nonce churn from a needless re-seal).
+func TestEncryptInPlace_NoOpDoesNotReSeal(t *testing.T) {
+	key := newTestKey(t)
+	c := &Config{
+		Version: Version,
+		Sources: map[string]SourceConfig{
+			"aws": {Type: "aws", Params: map[string]any{"region": "us-east-1"}},
+		},
+		Secrets: map[string]map[string]string{
+			"db": {"pass": "s3cret"},
+		},
+	}
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	sealed := c.Meta.NameMap
+	if err := DecryptInPlace(c, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	// Re-encrypt with no edits at all.
+	if err := EncryptInPlace(c, key); err != nil {
+		t.Fatalf("re-encrypt: %v", err)
+	}
+	if c.Meta.NameMap != sealed {
+		t.Fatal("no-op re-encrypt rotated Meta.NameMap (nonce churn)")
+	}
+}
+
 // TestDecryptInPlace_RejectsTransplantedVarEnvelope is the #235 AAD
 // regression: a var-field envelope sealed at one slot must fail to
 // decrypt when moved to another slot.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -90,7 +90,7 @@ func (r *rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		r.width, r.height = msg.Width, msg.Height
 	case tea.KeyMsg:
 		if msg.Type == tea.KeyCtrlC {
-			return r, tea.Quit
+			return r, r.quitOrConfirm()
 		}
 		// Global Ctrl+S persists the in-memory cfg to disk from any
 		// screen. Per-screen Update funcs never see this key, so they
@@ -112,6 +112,13 @@ func (r *rootModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		r.flashErr = true
 		return r, nil
 	case popMsg:
+		// Popping the last screen means the user is leaving the TUI. Guard
+		// against silently dropping unsaved edits: if dirty, re-push the
+		// current screen and surface a Save/Discard/Cancel prompt instead
+		// of quitting (#313). When clean, quit immediately as before.
+		if len(r.stack) == 1 && r.dirty {
+			return r, r.quitOrConfirm()
+		}
 		r.pop()
 		if len(r.stack) == 0 {
 			return r, tea.Quit
@@ -190,6 +197,24 @@ func (r *rootModel) View() string {
 	}
 
 	return renderApp(r.width, r.height, r.top().View(), status)
+}
+
+// quitOrConfirm returns a command that quits immediately when there are
+// no unsaved edits, or — when r.dirty — pushes a Save/Discard/Cancel
+// confirm prompt and returns nil so the TUI stays open (#313). If a quit
+// confirm is already on top (the user hit Ctrl+C while the prompt was
+// showing), it quits unconditionally so the prompt can't trap them.
+func (r *rootModel) quitOrConfirm() tea.Cmd {
+	if !r.dirty {
+		return tea.Quit
+	}
+	if len(r.stack) > 0 {
+		if _, ok := r.top().(*quitConfirmScreen); ok {
+			return tea.Quit
+		}
+	}
+	r.push(newQuitConfirmScreen(r))
+	return nil
 }
 
 func (r *rootModel) push(s screen) { r.stack = append(r.stack, s) }

--- a/internal/tui/quit_confirm.go
+++ b/internal/tui/quit_confirm.go
@@ -1,0 +1,87 @@
+package tui
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// quitConfirmScreen is the unsaved-changes guard shown when the user
+// tries to leave the TUI (Ctrl+C, or ESC out of the last screen) while
+// r.dirty is true (#313). It offers a three-way choice:
+//
+//   - Save    → write to disk, then quit (only after the save succeeds)
+//   - Discard → quit immediately, dropping the in-memory edits
+//   - Cancel  → return to the prior screen, leaving edits intact
+//
+// It wraps confirmScreen for the rendering/keys and adds the save-then-
+// quit wiring so the choices read clearly. It is a distinct type so the
+// root model can detect a re-entrant Ctrl+C and quit unconditionally
+// rather than stacking another prompt.
+type quitConfirmScreen struct {
+	*confirmScreen
+}
+
+const (
+	quitChoiceSave    = "Save"
+	quitChoiceDiscard = "Discard"
+	quitChoiceCancel  = "Cancel"
+)
+
+func newQuitConfirmScreen(r *rootModel) *quitConfirmScreen {
+	q := &quitConfirmScreen{}
+	q.confirmScreen = newConfirmScreen(
+		r,
+		"You have unsaved changes. Save before exiting?",
+		func(choice string) tea.Cmd {
+			switch choice {
+			case quitChoiceSave:
+				// Save, then quit only if the save succeeds. On error the
+				// errorMsg flashes and the user stays on the prompt.
+				return saveAndQuitCmd(r)
+			case quitChoiceDiscard:
+				return tea.Quit
+			default: // Cancel
+				return emit(popMsg{})
+			}
+		},
+		quitChoiceSave, quitChoiceDiscard, quitChoiceCancel,
+	)
+	return q
+}
+
+func (q *quitConfirmScreen) Title() string { return "unsaved changes" }
+
+// Update delegates to the embedded confirmScreen but returns q itself so
+// the stack keeps the *quitConfirmScreen type (the embedded method would
+// otherwise return the inner *confirmScreen, defeating the re-entrant
+// Ctrl+C detection in rootModel.quitOrConfirm).
+func (q *quitConfirmScreen) Update(msg tea.Msg) (screen, tea.Cmd) {
+	_, cmd := q.confirmScreen.Update(msg)
+	return q, cmd
+}
+
+// saveAndQuitCmd runs the same persistence path as saveCmd but quits the
+// program once the write succeeds. A validation/encrypt/write failure
+// surfaces as an errorMsg flash and does NOT quit, so the user can fix
+// the problem (or choose Discard) instead of losing their edits to a
+// half-applied save.
+func saveAndQuitCmd(r *rootModel) tea.Cmd {
+	return func() tea.Msg {
+		out := cloneForSave(r.cfg)
+		if err := out.Validate(); err != nil {
+			return errorMsg(fmt.Sprintf("validate: %v", err))
+		}
+		if err := encryptForSave(out, r.key); err != nil {
+			return errorMsg(fmt.Sprintf("encrypt: %v", err))
+		}
+		if err := config.AtomicSave(r.cfgPath, out); err != nil {
+			return errorMsg(fmt.Sprintf("save: %v", err))
+		}
+		r.cfg.IDMap = out.IDMap
+		_ = pingAgentReload()
+		return tea.Quit()
+	}
+}

--- a/internal/tui/quit_confirm_test.go
+++ b/internal/tui/quit_confirm_test.go
@@ -1,0 +1,185 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/gv/jitenv/internal/config"
+	_ "github.com/gv/jitenv/internal/sources/builtin"
+)
+
+// TestKvEditVerb checks the in-memory edit verbs are accurate and never
+// claim persistence (#313): "saved" must not appear.
+func TestKvEditVerb(t *testing.T) {
+	cases := []struct {
+		name        string
+		existingKey string
+		key         string
+		want        string
+	}{
+		{"new key", "", "TOKEN", "added key TOKEN"},
+		{"rename", "old", "new", "renamed key to new"},
+		{"value edit", "TOKEN", "TOKEN", "edited key TOKEN"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := kvEditVerb(tc.existingKey, tc.key)
+			if got != tc.want {
+				t.Fatalf("kvEditVerb(%q,%q) = %q, want %q", tc.existingKey, tc.key, got, tc.want)
+			}
+			if got == "saved" || got == "saved key "+tc.key {
+				t.Fatalf("verb must not claim persistence: %q (#313)", got)
+			}
+		})
+	}
+}
+
+func newTestRoot() *rootModel {
+	r := &rootModel{cfg: &config.Config{Version: config.Version}, width: 80, height: 24}
+	r.push(newMenuScreen(r))
+	return r
+}
+
+// TestQuitGuard_CleanQuitsImmediately: Ctrl+C with no unsaved edits quits
+// without a prompt.
+func TestQuitGuard_CleanQuitsImmediately(t *testing.T) {
+	r := newTestRoot()
+	r.dirty = false
+	_, cmd := r.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if !isQuit(cmd) {
+		t.Fatal("clean Ctrl+C should quit immediately")
+	}
+	if _, ok := r.top().(*quitConfirmScreen); ok {
+		t.Fatal("no confirm prompt should be pushed when clean")
+	}
+}
+
+// TestQuitGuard_DirtyShowsConfirm: Ctrl+C while dirty shows the prompt
+// instead of quitting.
+func TestQuitGuard_DirtyShowsConfirm(t *testing.T) {
+	r := newTestRoot()
+	r.dirty = true
+	_, cmd := r.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if isQuit(cmd) {
+		t.Fatal("dirty Ctrl+C must not quit unconditionally")
+	}
+	if _, ok := r.top().(*quitConfirmScreen); !ok {
+		t.Fatalf("expected quitConfirmScreen on top, got %T", r.top())
+	}
+}
+
+// TestQuitGuard_LastPopDirtyShowsConfirm: ESC-ing out of the last screen
+// while dirty surfaces the prompt rather than quitting.
+func TestQuitGuard_LastPopDirtyShowsConfirm(t *testing.T) {
+	r := newTestRoot()
+	r.dirty = true
+	_, cmd := r.Update(popMsg{})
+	if isQuit(cmd) {
+		t.Fatal("dirty last-screen pop must not quit unconditionally")
+	}
+	if _, ok := r.top().(*quitConfirmScreen); !ok {
+		t.Fatalf("expected quitConfirmScreen on top, got %T", r.top())
+	}
+}
+
+// TestQuitGuard_DiscardQuits: choosing Discard quits immediately.
+func TestQuitGuard_DiscardQuits(t *testing.T) {
+	r := newTestRoot()
+	r.dirty = true
+	r.Update(tea.KeyMsg{Type: tea.KeyCtrlC}) // push confirm
+	q, ok := r.top().(*quitConfirmScreen)
+	if !ok {
+		t.Fatalf("expected quitConfirmScreen, got %T", r.top())
+	}
+	cmd := q.onChoose(quitChoiceDiscard)
+	if !isQuit(cmd) {
+		t.Fatal("Discard should quit")
+	}
+}
+
+// TestQuitGuard_CancelReturns: choosing Cancel pops back to the prior
+// screen (emits popMsg) and does not quit.
+func TestQuitGuard_CancelReturns(t *testing.T) {
+	r := newTestRoot()
+	r.dirty = true
+	r.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	q := r.top().(*quitConfirmScreen)
+	cmd := q.onChoose(quitChoiceCancel)
+	if isQuit(cmd) {
+		t.Fatal("Cancel must not quit")
+	}
+	if _, ok := cmd().(popMsg); !ok {
+		t.Fatal("Cancel should emit popMsg to return to the prior screen")
+	}
+	// Drive the popMsg through the root: the confirm screen is removed.
+	r.Update(popMsg{})
+	if _, ok := r.top().(*quitConfirmScreen); ok {
+		t.Fatal("Cancel should have removed the confirm screen")
+	}
+}
+
+// TestQuitGuard_ReentrantCtrlCQuits: pressing Ctrl+C again while the
+// confirm prompt is showing quits (so the prompt can't trap the user).
+func TestQuitGuard_ReentrantCtrlCQuits(t *testing.T) {
+	r := newTestRoot()
+	r.dirty = true
+	r.Update(tea.KeyMsg{Type: tea.KeyCtrlC}) // push confirm
+	if _, ok := r.top().(*quitConfirmScreen); !ok {
+		t.Fatalf("expected quitConfirmScreen, got %T", r.top())
+	}
+	_, cmd := r.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if !isQuit(cmd) {
+		t.Fatal("re-entrant Ctrl+C on the prompt should quit")
+	}
+}
+
+// TestSaveAndQuitCmd_Quits: a successful save-and-quit returns tea.Quit.
+func TestSaveAndQuitCmd_Quits(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/config.toml"
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+	c.Secrets = map[string]map[string]string{"db": {"pass": "s3cret"}}
+
+	r := &rootModel{cfgPath: path, cfg: c, key: key, dirty: true, width: 80, height: 24}
+	msg := saveAndQuitCmd(r)()
+	if _, ok := msg.(errorMsg); ok {
+		t.Fatalf("save failed: %v", msg)
+	}
+	// tea.Quit() returns a tea.QuitMsg.
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Fatalf("expected QuitMsg after a successful save, got %T", msg)
+	}
+	// And the file actually round-trips.
+	reloaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := config.DecryptInPlace(reloaded, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if reloaded.Secrets["db"]["pass"] != "s3cret" {
+		t.Fatalf("save-and-quit did not persist: %v", reloaded.Secrets)
+	}
+}
+
+// isQuit reports whether running cmd yields a tea.QuitMsg.
+func isQuit(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	_, ok := cmd().(tea.QuitMsg)
+	return ok
+}

--- a/internal/tui/rename_id_test.go
+++ b/internal/tui/rename_id_test.go
@@ -105,9 +105,251 @@ func TestRenameKeepsSourceIDStable(t *testing.T) {
 	if _, ok := out2.Sources[awsIDBefore]; !ok {
 		t.Fatalf("on-disk source map should still key on the stable ID %q; got keys %v", awsIDBefore, mapKeys(out2.Sources))
 	}
+	if err := config.AtomicSave(path, out2); err != nil {
+		t.Fatalf("save2: %v", err)
+	}
+
+	// The round-trip assertion that catches #314: a third Load + Decrypt
+	// must surface the NEW name for the stable ID, not the pre-rename one.
+	// Before the fix, EncryptInPlace compared the rebuilt dictionary
+	// against the already-mutated in-memory IDMap, found them equal, and
+	// skipped re-sealing — so the stale sealed name_map ("aws") survived.
+	final, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload2: %v", err)
+	}
+	if err := config.DecryptInPlace(final, key); err != nil {
+		t.Fatalf("decrypt2: %v", err)
+	}
+	if _, ok := final.Sources["aws-staging"]; !ok {
+		t.Fatalf("rename reverted on reload: want source %q, got %v", "aws-staging", mapKeys(final.Sources))
+	}
+	if _, ok := final.Sources["aws"]; ok {
+		t.Fatal("stale source name 'aws' resurfaced after reload (#314)")
+	}
+	if sourceIDForName(final, "aws-staging") != awsIDBefore {
+		t.Fatalf("ID churned across the rename round-trip: before=%q after=%q",
+			awsIDBefore, sourceIDForName(final, "aws-staging"))
+	}
 }
 
 func mapKeys(m map[string]config.SourceConfig) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// bagIDForName / keyIDForName mirror sourceIDForName for the other two
+// dictionary namespaces.
+func bagIDForName(c *config.Config, name string) string {
+	if c.IDMap == nil {
+		return ""
+	}
+	for id, n := range c.IDMap.Bags {
+		if n == name {
+			return id
+		}
+	}
+	return ""
+}
+
+func keyIDForName(c *config.Config, bagID, keyName string) string {
+	if c.IDMap == nil {
+		return ""
+	}
+	for kid, n := range c.IDMap.Keys[bagID] {
+		if n == keyName {
+			return kid
+		}
+	}
+	return ""
+}
+
+// saveDecrypt re-saves a (decrypted) config under key, reloads it, and
+// decrypts in place — the exact Load → DecryptInPlace → rename → save →
+// Load → DecryptInPlace cycle the issues call for.
+func saveDecrypt(t *testing.T, path string, c *config.Config, key []byte) *config.Config {
+	t.Helper()
+	out := cloneForSave(c)
+	if err := encryptForSave(out, key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if err := config.AtomicSave(path, out); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Carry the freshly-built dictionary forward like saveCmd does, so a
+	// follow-up rename reuses stable IDs.
+	c.IDMap = out.IDMap
+	reloaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if err := config.DecryptInPlace(reloaded, key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	return reloaded
+}
+
+// TestRenameBagSurvivesRoundTrip is the bag-rename arm of #314: renaming
+// a secret bag must round-trip the NEW name (under a stable bag ID).
+func TestRenameBagSurvivesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+
+	c.Secrets = map[string]map[string]string{
+		"db": {"host": "localhost", "pass": "s3cret"},
+	}
+
+	reloaded := saveDecrypt(t, path, c, key)
+	bagIDBefore := bagIDForName(reloaded, "db")
+	if bagIDBefore == "" || !config.IsBagID(bagIDBefore) {
+		t.Fatalf("expected an opaque bag ID for 'db', got %q", bagIDBefore)
+	}
+
+	// TUI bag-rename flow (secrets_screen.go).
+	reloaded.Secrets["database"] = reloaded.Secrets["db"]
+	delete(reloaded.Secrets, "db")
+	rewriteLocalBagRefs(reloaded, "db", "database")
+	renameIDMapBag(reloaded, "db", "database")
+
+	final := saveDecrypt(t, path, reloaded, key)
+	if _, ok := final.Secrets["database"]; !ok {
+		t.Fatalf("bag rename reverted on reload: got %v", secretBagNames(final))
+	}
+	if _, ok := final.Secrets["db"]; ok {
+		t.Fatal("stale bag name 'db' resurfaced after reload (#314)")
+	}
+	if bagIDForName(final, "database") != bagIDBefore {
+		t.Fatalf("bag ID churned across rename: before=%q after=%q",
+			bagIDBefore, bagIDForName(final, "database"))
+	}
+	if final.Secrets["database"]["pass"] != "s3cret" {
+		t.Fatalf("value lost across bag rename: got %q", final.Secrets["database"]["pass"])
+	}
+}
+
+// TestRenameKeySurvivesRoundTrip is the bag-key-rename arm of #314 — the
+// case in the original repro.
+func TestRenameKeySurvivesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+
+	c.Secrets = map[string]map[string]string{
+		"db": {"host": "localhost", "pass": "s3cret"},
+	}
+
+	reloaded := saveDecrypt(t, path, c, key)
+	bagID := bagIDForName(reloaded, "db")
+	keyIDBefore := keyIDForName(reloaded, bagID, "pass")
+	if keyIDBefore == "" || !config.IsKeyID(keyIDBefore) {
+		t.Fatalf("expected an opaque key ID for 'pass', got %q", keyIDBefore)
+	}
+
+	// TUI key-rename flow (kvEditScreen.commit).
+	reloaded.Secrets["db"]["password"] = reloaded.Secrets["db"]["pass"]
+	delete(reloaded.Secrets["db"], "pass")
+	rewriteLocalKeyRefs(reloaded, "db", "pass", "password")
+	renameIDMapKey(reloaded, "db", "pass", "password")
+
+	final := saveDecrypt(t, path, reloaded, key)
+	if _, ok := final.Secrets["db"]["password"]; !ok {
+		t.Fatalf("key rename reverted on reload: got keys %v", keyNames(final.Secrets["db"]))
+	}
+	if _, ok := final.Secrets["db"]["pass"]; ok {
+		t.Fatal("stale key name 'pass' resurfaced after reload (#314)")
+	}
+	if keyIDForName(final, bagIDForName(final, "db"), "password") != keyIDBefore {
+		t.Fatalf("key ID churned across rename: before=%q", keyIDBefore)
+	}
+	if final.Secrets["db"]["password"] != "s3cret" {
+		t.Fatalf("value lost across key rename: got %q", final.Secrets["db"]["password"])
+	}
+}
+
+// TestNoOpSaveKeepsNameMapStable guards the optimization the #314 fix had
+// to preserve: a no-op save (no rename, no structural change) must NOT
+// rotate the sealed name_map. (Value envelopes themselves do rotate on a
+// TUI save because the in-memory config holds plaintext values that are
+// re-sealed each save — that is by design; the byte-identity guarantee is
+// specifically about the name_map dictionary not churning.) The config-
+// level byte-identity of EncryptInPlace on an already-sealed config is
+// asserted in config.TestEncryptInPlace_NoOpDoesNotReSeal.
+func TestNoOpSaveKeepsNameMapStable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pw := []byte("hunter2")
+	if err := config.InitNew(path, pw); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	c, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	key, err := config.DeriveKeyFromMeta(c, pw)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	defer zero(key)
+
+	c.Sources = map[string]config.SourceConfig{
+		"aws": {Type: "aws", Params: map[string]any{"region": "us-east-1"}},
+	}
+	c.Secrets = map[string]map[string]string{
+		"db": {"host": "localhost", "pass": "s3cret"},
+	}
+
+	// First save establishes the sealed name_map.
+	reloaded := saveDecrypt(t, path, c, key)
+	nameMap1 := reloaded.Meta.NameMap
+
+	// Second save with NO structural edits. The name_map envelope must be
+	// byte-identical (no re-seal → no nonce churn).
+	out := cloneForSave(reloaded)
+	if err := encryptForSave(out, key); err != nil {
+		t.Fatalf("encrypt2: %v", err)
+	}
+	if out.Meta.NameMap != nameMap1 {
+		t.Fatalf("no-op save rotated the sealed name_map (nonce churn)\nbefore: %s\nafter:  %s", nameMap1, out.Meta.NameMap)
+	}
+}
+
+func secretBagNames(c *config.Config) []string {
+	out := make([]string, 0, len(c.Secrets))
+	for k := range c.Secrets {
+		out = append(out, k)
+	}
+	return out
+}
+
+func keyNames(m map[string]string) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)

--- a/internal/tui/secrets_screen.go
+++ b/internal/tui/secrets_screen.go
@@ -619,7 +619,31 @@ func (s *kvEditScreen) commit() tea.Cmd {
 			bag[key] = val
 		}
 	}
-	return tea.Sequence(emit(popMsg{}), emit(dirtyMsg{}), emit(secretChangedMsg{}), emit(statusMsg("saved key "+key)))
+	// kvEditVerb gives an accurate, persistence-neutral status verb. The
+	// word "saved" is reserved for the post-AtomicSave flash (model.go
+	// savedMsg) — using it here would lie about durability, since nothing
+	// is written to disk until the user presses Ctrl+S (#313).
+	return tea.Sequence(
+		emit(popMsg{}),
+		emit(dirtyMsg{}),
+		emit(secretChangedMsg{}),
+		emit(statusMsg(kvEditVerb(s.existingKey, key))),
+	)
+}
+
+// kvEditVerb returns the status-line verb for an in-memory key edit:
+// "added key X" for a brand-new key, "renamed key to X" when the key name
+// changed, and "edited key X" for a same-name value change. It never says
+// "saved" — that word means "written to disk" (#313).
+func kvEditVerb(existingKey, key string) string {
+	switch {
+	case existingKey == "":
+		return "added key " + key
+	case key != existingKey:
+		return "renamed key to " + key
+	default:
+		return "edited key " + key
+	}
 }
 
 func (s *kvEditScreen) View() string {

--- a/internal/tui/sources_screen.go
+++ b/internal/tui/sources_screen.go
@@ -536,7 +536,10 @@ func (s *sourceParamsScreen) save() tea.Cmd {
 		sc.Params[k] = v
 	}
 	s.root.cfg.Sources[s.name] = sc
-	verb := "saved"
+	// This commits to the in-memory cfg only; nothing is written to disk
+	// until Ctrl+S. Use an accurate verb — "saved" is reserved for the
+	// post-AtomicSave flash (#313).
+	verb := "edited"
 	if s.creating {
 		verb = "added"
 	}


### PR DESCRIPTION
## Summary

Fixes the silent bag-key (and source/bag) rename data-loss reported in #313 / #314.

**#314 — config layer (the real data loss).** `EncryptInPlace` skipped re-sealing `Meta.NameMap` when the rebuilt dictionary was content-equal to the *prior* one, but the prior was read from the live `c.IDMap` — which the TUI rename mutates *before* save. So the rebuilt dict always looked unchanged, the re-seal was skipped, and the stale sealed `name_map` (old name) was written to disk; the rename reverted on the next load. Fix: open the **sealed-on-disk** dictionary separately as `sealedPrev` and gate the re-seal on `nameMapEqual(sealedPrev, nm)`. `c.IDMap` still drives ID stability (#248), so opaque IDs don't churn. The no-op-save optimization is preserved (no name_map nonce churn when nothing changed).

**#313 — TUI messaging + quit guard.**
- `kvEditScreen.commit` flashed `"saved key X"` for an in-memory-only edit. Now uses an accurate, persistence-neutral verb via `kvEditVerb`: `added key X` / `renamed key to X` / `edited key X`. The audit also caught a second site (`sourceParamsScreen` flashed `"saved source X"`); that now flashes `added`/`edited`. The word "saved" is once again exclusive to the post-`AtomicSave` flash.
- New quit-time guard: when `r.dirty`, Ctrl+C and the last-screen ESC/pop show a 3-way **Save / Discard / Cancel** prompt (`quitConfirmScreen`) instead of dropping edits. Save persists then quits (only on success); Discard quits; Cancel returns. A re-entrant Ctrl+C on the prompt quits so it can't trap the user. Clean (non-dirty) quit is unchanged — instant.

## Tests
- `config.TestEncryptInPlace_RenameReSealsNameMap` — re-seal regression (fails without the fix).
- `config.TestEncryptInPlace_NoOpDoesNotReSeal` — name_map byte-identity on no-op re-encrypt.
- `tui.TestRenameKeepsSourceIDStable` strengthened with a full Load→Decrypt→rename→save→Load→Decrypt round trip asserting the NEW name comes back under the stable ID.
- `tui.TestRenameBagSurvivesRoundTrip`, `tui.TestRenameKeySurvivesRoundTrip` — one per rename kind.
- `tui.TestNoOpSaveKeepsNameMapStable` — name_map idempotency through the TUI save path.
- `tui.TestKvEditVerb` — verb accuracy (never "saved").
- `tui` quit-confirm flow tests — shown when dirty / Discard quits / Save persists+quits / Cancel returns / re-entrant Ctrl+C quits / clean quit is instant.

All `go build ./...`, `go test ./...`, and `golangci-lint run` pass.

Closes #313
Closes #314

https://claude.ai/code/session_01WqzQLKnkzsDKSppUtbkTvr