### PR TITLE
fix(clone): store token as plaintext so save funnel seals it under ID AAD

### DIFF
--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -172,18 +172,18 @@ func runClone(cmd *cobra.Command, args []string, tokenStdin bool, bagOverride st
 		created = true
 	}
 
-	// Build the bag entry. EncryptField wraps the cleartext under
-	// the AAD that binds it to (bag, key) so a transplanted
-	// envelope is rejected on decrypt (security #110).
+	// Build the bag entry. Store the token as PLAINTEXT in the
+	// in-memory Config and let saveAndReencrypt → EncryptInPlace seal
+	// it under the opaque-ID AAD (SecretAAD(bagID, keyID), post-#248) —
+	// exactly how `bag import` and the TUI populate secrets. Do NOT
+	// pre-encrypt here: a value that already looks like an envelope is
+	// passed through unchanged by EncryptInPlace, so a name-based AAD
+	// would survive and fail authentication on the next reload (#318).
 	if created {
-		envelope, err := crypto.EncryptField(key, string(token), config.SecretAAD(finalBag, "token"))
-		if err != nil {
-			return fmt.Errorf("encrypt token: %w", err)
-		}
 		if cfg.Secrets == nil {
 			cfg.Secrets = map[string]map[string]string{}
 		}
-		cfg.Secrets[finalBag] = map[string]string{"token": envelope}
+		cfg.Secrets[finalBag] = map[string]string{"token": string(token)}
 	}
 
 	// Wire the cwd_glob mapping. The literal-value GIT_ASKPASS

--- a/internal/cli/mutation_coverage_test.go
+++ b/internal/cli/mutation_coverage_test.go
@@ -36,7 +36,6 @@ import (
 	"testing"
 
 	"github.com/gv/jitenv/internal/config"
-	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/gitauth"
 	_ "github.com/gv/jitenv/internal/sources/builtin"
 )
@@ -63,20 +62,18 @@ func loadDecrypt(t *testing.T, path string) *config.Config {
 // (saveAndReencrypt) on a clone-shaped mutation and asserts every piece
 // survives a reload + decrypt. This is the round-trip clone_test.go lacked.
 //
-// SKIPPED pending #318: this audit DISCOVERED a real #314-class production
-// bug while writing the test. `runClone` pre-encrypts the PAT under a
-// NAME-based AAD (config.SecretAAD(bagName, "token")), then hands the
+// Regression guard for #318: `runClone` used to pre-encrypt the PAT under a
+// NAME-based AAD (config.SecretAAD(bagName, "token")), then hand the
 // already-envelope value to EncryptInPlace, which passes envelopes through
-// unchanged (encrypt.go ~179). The on-disk artifact therefore stays sealed
+// unchanged (encrypt.go ~179). The on-disk artifact therefore stayed sealed
 // under the name AAD, but DecryptInPlace reads secrets under the opaque-ID
-// AAD (decrypt.go ~53, post-#248), so the token fails authentication on
-// reload: "chacha20poly1305: message authentication failed". Per the #316
-// constraints this PR is tests-only and must NOT touch production crypto,
-// so the test is parked as a ready regression that will go green once #318
-// fixes runClone to store the token as plaintext (sealed by the funnel like
-// every other bag value). Remove the Skip when #318 lands.
+// AAD (decrypt.go ~53, post-#248), so the token failed authentication on
+// reload: "chacha20poly1305: message authentication failed". The fix stores
+// the token as PLAINTEXT in cfg.Secrets and lets the save funnel seal it
+// under the correct ID AAD like every other bag value. This test replicates
+// that corrected mutation and asserts the token survives save → reload →
+// decrypt; a regression to pre-encryption would fail the round-trip below.
 func TestCloneSaveFunnelRoundTrip(t *testing.T) {
-	t.Skip("blocked on #318: jitenv clone seals the token bag under a name-based AAD that EncryptInPlace passes through, so it fails to decrypt on reload (production bug; do not fix in tests-only #316)")
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
 	if err := config.InitNew(cfgPath, []byte(testPassphrase)); err != nil {
@@ -107,14 +104,10 @@ func TestCloneSaveFunnelRoundTrip(t *testing.T) {
 	)
 
 	// Replicate the post-git-clone mutation runClone builds (clone.go
-	// ~178-210): pre-encrypt the token into a fresh bag, append the
-	// cwd_glob mapping with a literal-Value GIT_ASKPASS var, ensure a
-	// local source exists.
-	envelope, err := crypto.EncryptField(key, token, config.SecretAAD(bagName, "token"))
-	if err != nil {
-		t.Fatalf("encrypt token: %v", err)
-	}
-	cfg.Secrets = map[string]map[string]string{bagName: {"token": envelope}}
+	// ~175-210): store the token as PLAINTEXT into a fresh bag (the save
+	// funnel seals it under the ID AAD), append the cwd_glob mapping with
+	// a literal-Value GIT_ASKPASS var, ensure a local source exists.
+	cfg.Secrets = map[string]map[string]string{bagName: {"token": token}}
 	cfg.Mappings = append(cfg.Mappings, config.Mapping{
 		CwdGlob:  repoGlob,
 		Commands: []string{"git"},


### PR DESCRIPTION
Closes #318

## Root cause

`runClone` (`internal/cli/clone.go`) pre-encrypted the PAT under a **name-based** AAD (`config.SecretAAD(finalBag, "token")`) and stored the envelope in `cfg.Secrets`. `saveAndReencrypt` then called `config.EncryptInPlace`, which treats any value that is already an envelope (`crypto.IsEnvelope(v)`) as final and passes it through unchanged — so the token was never re-sealed under the opaque-ID AAD (`SecretAAD(bagID, keyID)`, post-#248).

On the next `Load` + `DecryptInPlace`, decryption reads secrets under the ID coordinates, which don't match the name-based AAD the token was sealed with, failing with `chacha20poly1305: message authentication failed`. A freshly-cloned repo's stored PAT could not be decrypted by the agent, so `JITENV_GIT_TOKEN` injection silently broke for clone-created bags.

## Fix

Store the token as **plaintext** in `cfg.Secrets[finalBag]["token"]` and let `saveAndReencrypt` → `EncryptInPlace` seal it under the correct ID-based AAD — exactly how `bag import` and the TUI populate secrets (plaintext in memory, sealed by the save funnel). The pre-`crypto.EncryptField` step is removed.

Secret hygiene: the token `[]byte` is already `defer zeroBytes(token)`'d, and `saveAndReencrypt` (`EncryptInPlace` + `AtomicSave`) is the only thing that writes the config in this path, so the plaintext never hits disk and is never logged.

## Tests

Un-skips `TestCloneSaveFunnelRoundTrip` in `internal/cli/mutation_coverage_test.go` (the parked #318 regression guard) and adjusts its mutation to match the corrected production behavior (plaintext token). It now drives a real save → reload → `DecryptInPlace` round-trip on the clone path. Verified that reinstating the old pre-encryption in the test reproduces the exact `message authentication failed` failure, so the test genuinely catches a regression.

`go build ./...`, `go test ./...`, and `golangci-lint run` all pass.

## Scope check

Audited the other `crypto.EncryptField` call sites (`internal/syncconfig/params.go`, `internal/syncconfig/syncconfig.go`): both are part of syncconfig's own self-consistent encrypt/decrypt funnel (same AAD on both sides) and do not feed pre-built envelopes into config's `EncryptInPlace`, so they don't hit the passthrough trap. No additional broken sites found; no scope expansion.

https://claude.ai/code/session_01WqzQLKnkzsDKSppUtbkTvr