### PR TITLE
chore(website): refresh version pins for v0.14.1

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -72,7 +72,7 @@ echo "$DATABASE_URL"       # empty in your shell &mdash; it never saw the value<
 
     <p>
       Stable release:
-      <strong><!-- VERSION:start -->v0.14.0<!-- VERSION:end --></strong>.
+      <strong><!-- VERSION:start -->v0.14.1<!-- VERSION:end --></strong>.
       Pre-built, cosign-signed binaries are published on every tag by
       goreleaser.
     </p>
@@ -144,7 +144,7 @@ make install</code></pre>
       <a href="https://github.com/Galvill/jitenv/tree/main/web"><code>/web</code></a>.
     </p>
     <p class="version-footer">
-      Docs current as of <!-- VERSION:asof:start -->v0.14.0<!-- VERSION:asof:end -->.
+      Docs current as of <!-- VERSION:asof:start -->v0.14.1<!-- VERSION:asof:end -->.
     </p>
   </div>
 </footer>

--- a/web/quickstart.md
+++ b/web/quickstart.md
@@ -3,7 +3,7 @@
 From zero to "my deploy script has its env vars" in about a minute.
 
 Current stable release:
-<!-- VERSION:start -->v0.14.0<!-- VERSION:end -->.
+<!-- VERSION:start -->v0.14.1<!-- VERSION:end -->.
 
 ## 1. Install
 
@@ -14,12 +14,12 @@ ship on every tag via goreleaser.
 
 ```sh
 # Debian / Ubuntu
-curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.14.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
-sudo dpkg -i jitenv_<!-- ARTIFACT_VERSION:start -->0.14.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
+curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.14.1<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
+sudo dpkg -i jitenv_<!-- ARTIFACT_VERSION:start -->0.14.1<!-- ARTIFACT_VERSION:end -->_linux_amd64.deb
 
 # Fedora / RHEL / openSUSE
-curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.14.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.rpm
-sudo rpm -i jitenv_<!-- ARTIFACT_VERSION:start -->0.14.0<!-- ARTIFACT_VERSION:end -->_linux_amd64.rpm
+curl -LO https://github.com/Galvill/jitenv/releases/latest/download/jitenv_<!-- ARTIFACT_VERSION:start -->0.14.1<!-- ARTIFACT_VERSION:end -->_linux_amd64.rpm
+sudo rpm -i jitenv_<!-- ARTIFACT_VERSION:start -->0.14.1<!-- ARTIFACT_VERSION:end -->_linux_amd64.rpm
 ```
 
 `amd64` and `arm64` are both published; swap the arch in the filename.
@@ -133,4 +133,4 @@ leaving the command.
 - [tui.md](tui.md) — full TUI walkthrough.
 - [source-plugins.md](source-plugins.md) — adding a new secret backend.
 
-<!-- VERSION:asof:start -->_Docs current as of v0.14.0._<!-- VERSION:asof:end -->
+<!-- VERSION:asof:start -->_Docs current as of v0.14.1._<!-- VERSION:asof:end -->


### PR DESCRIPTION
Automated by the website-update workflow on the v0.14.1 release.

Refreshes only the marker-bounded version spans under web/ (see internal/rendocs); hand-written narrative is untouched. Review the diff and squash-merge.

The required "build / test / lint" check runs on this PR per the protect-main ruleset.