### PR TITLE
feat(release): add Scoop + winget Windows install channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Cross-repo pushes for the Scoop bucket + winget fork; the
+          # default GITHUB_TOKEN can't push to other repositories.
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -180,6 +180,40 @@ scoops:
     license: MIT
     skip_upload: "auto"
 
+winget:
+  - name: jitenv
+    publisher: Galvill
+    publisher_url: "https://github.com/Galvill"
+    author: Gal Villaret
+    short_description: "Just-in-time environment variable loader, scoped to per-command process trees"
+    description: |
+      jitenv loads environment variables on demand from pluggable sources
+      when configured executables are run, keeping secrets out of the parent
+      shell. Linux, macOS, and Windows.
+    license: MIT
+    license_url: "https://github.com/Galvill/jitenv/blob/main/LICENSE"
+    copyright: "© 2026 Gal Villaret"
+    homepage: "https://github.com/Galvill/jitenv"
+    release_notes_url: "https://github.com/Galvill/jitenv/releases/tag/{{ .Tag }}"
+    tags:
+      - secrets
+      - cli
+      - environment-variables
+      - shell-hook
+    package_identifier: Galvill.jitenv
+    repository:
+      owner: Galvill
+      name: winget-pkgs
+      branch: "jitenv-{{ .Version }}"
+      token: "{{ .Env.RELEASE_PAT }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+    skip_upload: "auto"
+
 checksum:
   name_template: SHA256SUMS
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -159,6 +159,27 @@ nfpms:
 # downloads the windows .zip this release uploads and SHA256-verifies
 # it. See that workflow and packaging/chocolatey/ for the details.
 
+# Scoop and winget (below) ARE goreleaser pipes — unlike
+# Chocolatey. Their "publish" step is just committing a manifest file
+# (Scoop -> the Galvill/scoop-jitenv bucket) or opening a PR (winget ->
+# microsoft/winget-pkgs), pure git work that runs fine on this ubuntu
+# release runner. They consume the windows .zip + SHA256SUMS produced
+# above in this same run, so there's no async ordering problem like the
+# darwin cask. Cross-repo pushes need the RELEASE_PAT secret (the default
+# GITHUB_TOKEN can't push to other repos); release.yml passes it through.
+# skip_upload: "auto" skips prereleases/snapshots, matching Chocolatey.
+scoops:
+  - repository:
+      owner: Galvill
+      name: scoop-jitenv
+      branch: main
+      token: "{{ .Env.RELEASE_PAT }}"
+    directory: bucket
+    homepage: "https://github.com/Galvill/jitenv"
+    description: "Just-in-time environment variable loader, scoped to per-command process trees"
+    license: MIT
+    skip_upload: "auto"
+
 checksum:
   name_template: SHA256SUMS
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -268,10 +268,14 @@ release:
     brew install Galvill/jitenv/jitenv
     ```
 
-    Windows users can install via Chocolatey:
+    Windows users can install via Chocolatey, Scoop, or winget:
 
     ```powershell
     choco install jitenv
+    # or
+    scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv; scoop install jitenv
+    # or
+    winget install Galvill.jitenv
     ```
 
     macOS binaries are Apple Developer ID code-signed and notarized.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,45 @@ is not yet Authenticode-signed (tracked in
 or right-click → Properties → Unblock, clears it. PowerShell 7+ is
 required for the hook.
 
+### Scoop (Windows)
+
+```powershell
+scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
+scoop install jitenv
+```
+
+Adds a dedicated [Scoop](https://scoop.sh) bucket and installs from it.
+Scoop shims `jitenv.exe`, `jitenv-hook.exe`, and `jitenv-tui.exe` onto
+`%PATH%`; `scoop update jitenv` picks up new releases. After install,
+activate the PowerShell hook **once**:
+
+```powershell
+jitenv hook install
+# open a new pwsh tab — the hook is live
+```
+
+### winget (Windows)
+
+```powershell
+winget install Galvill.jitenv
+```
+
+Published to the [winget-pkgs](https://github.com/microsoft/winget-pkgs)
+community repository as `Galvill.jitenv`. `winget upgrade Galvill.jitenv`
+picks up new releases. After install, activate the PowerShell hook
+**once**:
+
+```powershell
+jitenv hook install
+# open a new pwsh tab — the hook is live
+```
+
+As with Chocolatey, the first run of `jitenv.exe` may trip SmartScreen
+because the binary is not yet Authenticode-signed (tracked in
+[#39](https://github.com/Galvill/jitenv/issues/39)) — `Unblock-File`,
+or right-click → Properties → Unblock, clears it. PowerShell 7+ is
+required for the hook.
+
 ## Commands
 
 ```

--- a/docs/superpowers/plans/2026-06-24-scoop-winget-install-channels.md
+++ b/docs/superpowers/plans/2026-06-24-scoop-winget-install-channels.md
@@ -1,0 +1,361 @@
+# Scoop + winget Install Channels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Scoop and winget-pkgs as Windows install channels, published automatically on each stable release via GoReleaser native pipes.
+
+**Architecture:** Add `scoops:` and `winget:` blocks to the existing `.goreleaser.yaml`, run by the existing `release.yml` job on `ubuntu-latest`. The Scoop pipe commits `bucket/jitenv.json` to `Galvill/scoop-jitenv`; the winget pipe pushes manifests to the `Galvill/winget-pkgs` fork and auto-opens a PR to `microsoft/winget-pkgs`. Both consume the Windows `.zip` archives + `SHA256SUMS` produced earlier in the same run. Chocolatey is unchanged (it stays a separate Windows workflow because `choco` is Windows-only).
+
+**Tech Stack:** GoReleaser v2 (`~> v2`, action v6), GitHub Actions, Scoop, winget.
+
+## Global Constraints
+
+- GoReleaser config schema version: `version: 2` (validated with `goreleaser check`). Local/CI toolchain is GoReleaser **v2.15.4**.
+- Cross-repo pushes require the **`RELEASE_PAT`** repo secret (`contents:write` + `pull-requests:write` on `Galvill/scoop-jitenv` and `Galvill/winget-pkgs`). The default `GITHUB_TOKEN` cannot push cross-repo. The secret is already configured.
+- Both pipes use `skip_upload: "auto"` so prereleases (`-rc.N` tags) and snapshots never push — matching Chocolatey's RC-skipping.
+- `dist/` is gitignored; never commit it.
+- Package coordinates (fixed, copied verbatim): Scoop bucket `Galvill/scoop-jitenv`; winget `package_identifier: Galvill.jitenv`, `publisher: Galvill`; homepage `https://github.com/Galvill/jitenv`; license `MIT`; one-line summary `Just-in-time environment variable loader, scoped to per-command process trees`; copyright `© 2026 Gal Villaret`.
+- `ci.yml` runs `goreleaser release --snapshot --clean --skip=publish,sign` — it skips the publish stage, so the new pipes don't run there and `ci.yml` needs **no** change and no secret.
+
+## File Structure
+
+- **Modify** `.goreleaser.yaml` — add `scoops:` and `winget:` blocks plus explanatory comments (insert after the Chocolatey comment block, before `checksum:`); extend the `release.header` Windows-install snippet.
+- **Modify** `.github/workflows/release.yml` — add `RELEASE_PAT` to the GoReleaser step `env:`.
+- **Modify** `README.md` — add `### Scoop (Windows)` and `### winget (Windows)` sections.
+- **Modify** `web/quickstart.md` and `web/index.html` — add Scoop + winget install snippets beside Chocolatey.
+
+Verification for the config tasks is two real commands (no unit-test framework applies to YAML config):
+1. `goreleaser check` — schema validity.
+2. `RELEASE_PAT=dummy goreleaser release --snapshot --clean --skip=sign` — generates the manifests under `dist/` (snapshot auto-skips the push); assert the expected files/content exist.
+
+---
+
+### Task 1: Scoop pipe + RELEASE_PAT wiring
+
+**Files:**
+- Modify: `.goreleaser.yaml` (insert `scoops:` block after the Chocolatey comment block that ends `...packaging/chocolatey/ for the details.`, before `checksum:`)
+- Modify: `.github/workflows/release.yml` (the `Run GoReleaser` step `env:`)
+
+**Interfaces:**
+- Consumes: the existing `archives:` entry with `id: jitenv` (produces the Windows `.zip` carrying `jitenv.exe`, `jitenv-hook.exe`, `jitenv-tui.exe`).
+- Produces: `dist/scoop/bucket/jitenv.json` at release time, pushed to `Galvill/scoop-jitenv` on `bucket/jitenv.json`.
+
+- [ ] **Step 1: Add the `scoops:` block to `.goreleaser.yaml`**
+
+Insert immediately after the Chocolatey explanatory comment block (the paragraph ending `See that workflow and packaging/chocolatey/ for the details.`) and the blank line that follows it, directly before `checksum:`:
+
+```yaml
+# Scoop (#TODO-issue) and winget (below) ARE goreleaser pipes — unlike
+# Chocolatey. Their "publish" step is just committing a manifest file
+# (Scoop -> the Galvill/scoop-jitenv bucket) or opening a PR (winget ->
+# microsoft/winget-pkgs), pure git work that runs fine on this ubuntu
+# release runner. They consume the windows .zip + SHA256SUMS produced
+# above in this same run, so there's no async ordering problem like the
+# darwin cask. Cross-repo pushes need the RELEASE_PAT secret (the default
+# GITHUB_TOKEN can't push to other repos); release.yml passes it through.
+# skip_upload: "auto" skips prereleases/snapshots, matching Chocolatey.
+scoops:
+  - repository:
+      owner: Galvill
+      name: scoop-jitenv
+      branch: main
+      token: "{{ .Env.RELEASE_PAT }}"
+    directory: bucket
+    homepage: "https://github.com/Galvill/jitenv"
+    description: "Just-in-time environment variable loader, scoped to per-command process trees"
+    license: MIT
+    skip_upload: "auto"
+```
+
+- [ ] **Step 2: Add `RELEASE_PAT` to the release workflow**
+
+In `.github/workflows/release.yml`, the `Run GoReleaser` step currently ends with:
+
+```yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Change it to:
+
+```yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Cross-repo pushes for the Scoop bucket + winget fork; the
+          # default GITHUB_TOKEN can't push to other repositories.
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+```
+
+- [ ] **Step 3: Validate config schema**
+
+Run: `goreleaser check`
+Expected: `1 configuration file(s) validated` and no errors.
+
+- [ ] **Step 4: Generate the Scoop manifest via snapshot**
+
+Run: `RELEASE_PAT=dummy goreleaser release --snapshot --clean --skip=sign`
+Expected: log line `scoop manifests ... writing manifest=dist/scoop/bucket/jitenv.json`, and the build completes (`thanks for using GoReleaser!`). Nothing is pushed (snapshot auto-skips upload).
+
+- [ ] **Step 5: Assert the Scoop manifest content**
+
+Run: `cat dist/scoop/bucket/jitenv.json`
+Expected: JSON with `architecture.64bit` and `architecture.arm64`, each with a `url` under `releases/download/`, a 64-hex `hash`, and a `bin` array containing `jitenv.exe`, `jitenv-hook.exe`, `jitenv-tui.exe`; plus top-level `homepage`, `license: MIT`, and the description string.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .goreleaser.yaml .github/workflows/release.yml
+git commit -m "feat(release): publish a Scoop manifest via goreleaser
+
+Add a scoops: pipe that commits bucket/jitenv.json to
+Galvill/scoop-jitenv on each stable release, and pass RELEASE_PAT
+through release.yml for the cross-repo push.
+
+Claude-Session: https://claude.ai/code/session_01LZ4n128Nc4CU4oLBx59Vpr"
+```
+
+---
+
+### Task 2: winget pipe
+
+**Files:**
+- Modify: `.goreleaser.yaml` (add `winget:` block immediately after the `scoops:` block from Task 1)
+
+**Interfaces:**
+- Consumes: the same `archives:` entry `id: jitenv` Windows `.zip` and the `RELEASE_PAT` wiring added in Task 1.
+- Produces: `dist/winget/manifests/g/Galvill/jitenv/<version>/Galvill.jitenv{,.installer,.locale.en-US}.yaml`, pushed to a branch on `Galvill/winget-pkgs` with an auto-opened PR to `microsoft/winget-pkgs` `master`.
+
+- [ ] **Step 1: Add the `winget:` block to `.goreleaser.yaml`**
+
+Insert directly after the `scoops:` block (still before `checksum:`):
+
+```yaml
+winget:
+  - name: jitenv
+    publisher: Galvill
+    publisher_url: "https://github.com/Galvill"
+    author: Gal Villaret
+    short_description: "Just-in-time environment variable loader, scoped to per-command process trees"
+    description: |
+      jitenv loads environment variables on demand from pluggable sources
+      when configured executables are run, keeping secrets out of the parent
+      shell. Linux, macOS, and Windows.
+    license: MIT
+    license_url: "https://github.com/Galvill/jitenv/blob/main/LICENSE"
+    copyright: "© 2026 Gal Villaret"
+    homepage: "https://github.com/Galvill/jitenv"
+    release_notes_url: "https://github.com/Galvill/jitenv/releases/tag/{{ .Tag }}"
+    tags:
+      - secrets
+      - cli
+      - environment-variables
+      - shell-hook
+    package_identifier: Galvill.jitenv
+    repository:
+      owner: Galvill
+      name: winget-pkgs
+      branch: "jitenv-{{ .Version }}"
+      token: "{{ .Env.RELEASE_PAT }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+    skip_upload: "auto"
+```
+
+- [ ] **Step 2: Validate config schema**
+
+Run: `goreleaser check`
+Expected: `1 configuration file(s) validated` and no errors.
+
+- [ ] **Step 3: Generate the winget manifests via snapshot**
+
+Run: `RELEASE_PAT=dummy goreleaser release --snapshot --clean --skip=sign`
+Expected: `winget ... writing path=dist/winget/manifests/g/Galvill/jitenv/<version>/Galvill.jitenv.yaml` (plus `.installer.yaml` and `.locale.en-US.yaml`), build completes, nothing pushed.
+
+- [ ] **Step 4: Assert the winget manifest content**
+
+Run: `cat dist/winget/manifests/g/Galvill/jitenv/*/Galvill.jitenv.installer.yaml`
+Expected: `PackageIdentifier: Galvill.jitenv`, `InstallerType: zip`, two `Installers` entries (`Architecture: x64` and `Architecture: arm64`), each with `NestedInstallerType: portable` and `NestedInstallerFiles` listing `jitenv.exe`/`jitenv-hook.exe`/`jitenv-tui.exe` with `PortableCommandAlias` values, a `releases/download/` `InstallerUrl`, and a 64-hex `InstallerSha256`.
+
+Run: `cat dist/winget/manifests/g/Galvill/jitenv/*/Galvill.jitenv.locale.en-US.yaml`
+Expected: includes `Publisher: Galvill`, `PublisherUrl`, `Author: Gal Villaret`, `License: MIT`, `LicenseUrl`, `Copyright`, `Moniker: jitenv`, `Tags`, and the short description.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .goreleaser.yaml
+git commit -m "feat(release): open a winget-pkgs PR via goreleaser
+
+Add a winget: pipe that pushes Galvill.jitenv manifests to the
+Galvill/winget-pkgs fork and auto-opens a PR to microsoft/winget-pkgs
+on each stable release.
+
+Claude-Session: https://claude.ai/code/session_01LZ4n128Nc4CU4oLBx59Vpr"
+```
+
+---
+
+### Task 3: Documentation (README, release header, website)
+
+**Files:**
+- Modify: `README.md` (after the `### Chocolatey (Windows)` section, ends with "...PowerShell 7+ is required for the hook.")
+- Modify: `.goreleaser.yaml` (`release.header`, the Windows-install snippet)
+- Modify: `web/quickstart.md` (after the `### Windows — Chocolatey` block)
+- Modify: `web/index.html` (after the `<h3>Windows &mdash; Chocolatey</h3>` block)
+
+**Interfaces:**
+- Consumes: nothing in code — documents the channels shipped by Tasks 1 and 2.
+- Produces: user-facing install instructions for Scoop and winget.
+
+- [ ] **Step 1: Add README sections**
+
+In `README.md`, immediately after the Chocolatey section (which ends with the line `or right-click → Properties → Unblock, clears it. PowerShell 7+ is` / `required for the hook.`), insert:
+
+```markdown
+### Scoop (Windows)
+
+```powershell
+scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
+scoop install jitenv
+```
+
+Adds a dedicated [Scoop](https://scoop.sh) bucket and installs from it.
+Scoop shims `jitenv.exe`, `jitenv-hook.exe`, and `jitenv-tui.exe` onto
+`%PATH%`; `scoop update jitenv` picks up new releases. After install,
+activate the PowerShell hook **once**:
+
+```powershell
+jitenv hook install
+# open a new pwsh tab — the hook is live
+```
+
+### winget (Windows)
+
+```powershell
+winget install Galvill.jitenv
+```
+
+Published to the [winget-pkgs](https://github.com/microsoft/winget-pkgs)
+community repository as `Galvill.jitenv`. `winget upgrade Galvill.jitenv`
+picks up new releases. After install, activate the PowerShell hook
+**once**:
+
+```powershell
+jitenv hook install
+# open a new pwsh tab — the hook is live
+```
+
+As with Chocolatey, the first run of `jitenv.exe` may trip SmartScreen
+because the binary is not yet Authenticode-signed (tracked in
+[#39](https://github.com/Galvill/jitenv/issues/39)) — `Unblock-File`,
+or right-click → Properties → Unblock, clears it. PowerShell 7+ is
+required for the hook.
+```
+
+- [ ] **Step 2: Extend the GoReleaser release header**
+
+In `.goreleaser.yaml`, the `release.header` currently contains:
+
+```yaml
+    Windows users can install via Chocolatey:
+
+    ```powershell
+    choco install jitenv
+    ```
+```
+
+Replace that with:
+
+```yaml
+    Windows users can install via Chocolatey, Scoop, or winget:
+
+    ```powershell
+    choco install jitenv
+    # or
+    scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv; scoop install jitenv
+    # or
+    winget install Galvill.jitenv
+    ```
+```
+
+- [ ] **Step 3: Add website (quickstart.md) snippets**
+
+In `web/quickstart.md`, after the `### Windows — Chocolatey` block (which ends `PowerShell 7+ is required for the hook.`), insert:
+
+```markdown
+### Windows — Scoop
+
+```powershell
+scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
+scoop install jitenv
+```
+
+Adds a dedicated Scoop bucket and shims `jitenv.exe`, `jitenv-hook.exe`,
+and `jitenv-tui.exe` onto `%PATH%`. PowerShell 7+ is required for the hook.
+
+### Windows — winget
+
+```powershell
+winget install Galvill.jitenv
+```
+
+Installs `Galvill.jitenv` from the winget-pkgs community repository.
+PowerShell 7+ is required for the hook.
+```
+
+- [ ] **Step 4: Add website (index.html) snippets**
+
+In `web/index.html`, after the Chocolatey block (the `<p>...</p>` that ends `is required for the hook.</p>` following `<h3>Windows &mdash; Chocolatey</h3>`), insert:
+
+```html
+    <h3>Windows &mdash; Scoop</h3>
+    <pre><code>scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
+scoop install jitenv</code></pre>
+    <p>
+      Adds a dedicated Scoop bucket and shims <code>jitenv.exe</code>,
+      <code>jitenv-hook.exe</code>, and <code>jitenv-tui.exe</code> onto
+      <code>%PATH%</code>. PowerShell&nbsp;7+ is required for the hook.
+    </p>
+
+    <h3>Windows &mdash; winget</h3>
+    <pre><code>winget install Galvill.jitenv</code></pre>
+    <p>
+      Installs <code>Galvill.jitenv</code> from the winget-pkgs community
+      repository. PowerShell&nbsp;7+ is required for the hook.
+    </p>
+```
+
+- [ ] **Step 5: Validate config still parses**
+
+Run: `goreleaser check`
+Expected: `1 configuration file(s) validated`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md .goreleaser.yaml web/quickstart.md web/index.html
+git commit -m "docs: document Scoop + winget Windows install channels
+
+Claude-Session: https://claude.ai/code/session_01LZ4n128Nc4CU4oLBx59Vpr"
+```
+
+---
+
+## Post-merge manual verification (not automated)
+
+After this merges and the next **stable** (non-RC) release publishes:
+
+1. Confirm `Galvill/scoop-jitenv` received an updated `bucket/jitenv.json`.
+2. Confirm a PR was opened against `microsoft/winget-pkgs` for `Galvill.jitenv` (then shepherd it through Microsoft moderation).
+3. On a Windows host: `scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv && scoop install jitenv && jitenv --version`; and once the winget PR merges, `winget install Galvill.jitenv && jitenv --version`.
+
+These require a published release + the PAT + a Windows machine, so they stay manual.
+
+## Notes / risks
+
+- **winget moderation** is outside our control; a rejected/delayed upstream PR doesn't affect the Scoop bucket or the GitHub-release artifacts.
+- **Missing/expired `RELEASE_PAT`** will fail the publish step on a *stable* release (intended loud failure). Prereleases/snapshots are unaffected (`skip_upload: "auto"`).
+- **`#TODO-issue`** in the `.goreleaser.yaml` comment: replace with the real tracking issue number if one is filed, or drop the parenthetical.

--- a/docs/superpowers/specs/2026-06-24-scoop-winget-install-channels-design.md
+++ b/docs/superpowers/specs/2026-06-24-scoop-winget-install-channels-design.md
@@ -1,0 +1,151 @@
+# Scoop + winget install channels — design
+
+**Date:** 2026-06-24
+**Status:** Approved (design), pending implementation plan
+**Tracking:** adds Scoop and winget-pkgs as Windows install methods alongside the existing Chocolatey channel.
+
+## Goal
+
+Give Windows users two additional, idiomatic install paths beyond Chocolatey:
+
+```powershell
+# Scoop
+scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
+scoop install jitenv
+
+# winget
+winget install Galvill.jitenv
+```
+
+Both channels must update automatically on each stable release, with no
+manual per-release work beyond the existing release-cut flow.
+
+## Approach
+
+Use **GoReleaser's native `scoops:` and `winget:` pipes** inside the
+existing `.goreleaser.yaml`, run by the existing `release.yml` job on
+`ubuntu-latest`.
+
+Rationale — why these differ from Chocolatey:
+
+- Chocolatey is a **separate `windows-latest` workflow**
+  (`.github/workflows/chocolatey.yml`) only because the `choco` CLI used
+  to pack/push the `.nupkg` exists only on Windows.
+- Scoop and winget "publishing" is just **generating manifest files and
+  committing them / opening a PR** — pure git operations that run fine on
+  Linux. GoReleaser's pipes do exactly this.
+- Both pipes consume the **Windows `.zip` archives + `SHA256SUMS`** that
+  are produced earlier in the *same* GoReleaser run, so there is no
+  cross-run ordering problem (unlike the macOS cask, which ships
+  asynchronously after notarization).
+
+This keeps all logic that *can* run on the Linux release runner in one
+place, and avoids two more standalone workflows.
+
+## Prerequisites (DONE — completed manually by maintainer)
+
+1. **`Galvill/scoop-jitenv`** — new public repo holding the Scoop bucket
+   manifest (`bucket/jitenv.json`). GoReleaser commits the manifest here.
+2. **`Galvill/winget-pkgs`** — a fork of `microsoft/winget-pkgs`.
+   GoReleaser pushes the generated manifest to a branch on this fork, then
+   opens a PR to upstream `microsoft/winget-pkgs`.
+3. **`RELEASE_PAT` repo secret** — a PAT with `contents:write` +
+   `pull-requests:write` on both repos above. Required because the default
+   `GITHUB_TOKEN` cannot push to other repositories.
+
+## Components
+
+### 1. `.goreleaser.yaml` — `scoops:` block
+
+- `repository`: `owner: Galvill`, `name: scoop-jitenv`, token from
+  `{{ .Env.RELEASE_PAT }}`.
+- `directory: bucket` — manifest lands at `bucket/jitenv.json`.
+- `homepage: https://github.com/Galvill/jitenv`
+- `description`: the one-line summary used elsewhere ("Just-in-time
+  environment variable loader, scoped to per-command process trees").
+- `license: MIT`
+- `commit_author`: bot identity matching the project's other automated
+  commits.
+- `skip_upload: "auto"` — skips prereleases (the `-rc.N` tags), matching
+  Chocolatey's RC-skipping behavior for free.
+- Use the existing `jitenv` archive `id` so the pipe picks the Windows
+  `.zip` (carries `jitenv.exe`, `jitenv-hook.exe`, `jitenv-tui.exe`).
+  Scoop auto-shims the `.exe`s onto PATH so `jitenv config`
+  (re-execs `jitenv-tui`) works.
+
+### 2. `.goreleaser.yaml` — `winget:` block
+
+- `name: jitenv`
+- `publisher: Galvill`
+- `package_identifier: Galvill.jitenv`
+- `license: MIT`, `homepage`, `short_description` / `description` reusing
+  the existing summary text.
+- `repository`: the fork (`owner: Galvill`, `name: winget-pkgs`,
+  `branch: <generated>`), token from `{{ .Env.RELEASE_PAT }}`, with
+  `pull_request.enabled: true` and `pull_request.base` targeting
+  `owner: microsoft`, `name: winget-pkgs`, `branch: master`.
+- `skip_upload: "auto"` — skip prereleases.
+- winget only supports a single architecture per installer entry but
+  handles amd64 + arm64 fine via multiple installer entries, which
+  GoReleaser emits from the Windows archives automatically.
+- Note for the SmartScreen/unsigned-binary caveat (#39) carried in the
+  manifest description, mirroring the Chocolatey package.
+
+### 3. Header comments in `.goreleaser.yaml`
+
+Add comments next to the new blocks explaining *why* Scoop/winget live in
+the main pipeline while Chocolatey does not (cross-repo file/PR generation
+vs. the Windows-only `choco` CLI), mirroring the existing explanatory
+comments for the Homebrew cask and Chocolatey.
+
+### 4. `.github/workflows/release.yml`
+
+Add `RELEASE_PAT: ${{ secrets.RELEASE_PAT }}` to the GoReleaser step's
+`env:` (alongside `GITHUB_TOKEN`). No structural change to the job.
+
+### 5. Documentation
+
+- **README.md** — add `### Scoop (Windows)` and `### winget (Windows)`
+  sections beside the existing `### Chocolatey (Windows)` section, with
+  the install commands and the hook-activation reminder.
+- **GoReleaser `release.header`** — extend the Windows install snippet to
+  mention `scoop install jitenv` and `winget install Galvill.jitenv`
+  alongside `choco install jitenv`.
+- **Website / `web/` install docs** — add the two channels wherever
+  Chocolatey is documented. Confirm during planning whether
+  `website-update.yml`'s version-pin refresh needs to track these (Scoop
+  and winget versions are auto-managed by the pipes, so a pin is likely
+  unnecessary — verify).
+
+## Error handling / edge cases
+
+- **Missing `RELEASE_PAT`:** with `skip_upload: "auto"` the pipes still
+  generate manifests for inspection but the release won't hard-fail on a
+  prerelease; on a stable release a missing token *will* fail the push
+  step. Since the secret is configured (prereq 3), this is the intended
+  loud-failure path. Document the secret requirement near the blocks.
+- **Prereleases (`-rc.N`):** skipped via `skip_upload: "auto"`, matching
+  Chocolatey. RCs never reach the Scoop bucket or open a winget PR.
+- **winget moderation:** Microsoft's validation/moderation may reject or
+  delay a PR. This is outside our control; the PR is opened
+  automatically and tracked upstream. Failure of the upstream PR does not
+  affect the Scoop or GitHub-release artifacts.
+
+## Testing / verification
+
+- **Config validity:** `goreleaser check` (run in CI via `ci.yml` —
+  confirm during planning it covers the updated config).
+- **Dry run:** `goreleaser release --snapshot --clean --skip=publish`
+  locally/CI to confirm both `bucket/jitenv.json` and the winget manifest
+  set generate with correct version/URL/SHA256 substitutions.
+- **End-to-end:** real install (`scoop install`, `winget install`)
+  verified manually on Windows post-merge after the first stable release
+  that exercises the pipes. Documented as a manual smoke test — not
+  automated (requires a published release + the PAT + a Windows host).
+
+## Out of scope
+
+- Authenticode signing of the Windows binaries (tracked separately, #39).
+- Changing the Chocolatey channel.
+- Submitting the Scoop manifest to `ScoopInstaller/Extras` (we ship a
+  dedicated bucket instead).

--- a/web/index.html
+++ b/web/index.html
@@ -107,6 +107,22 @@ echo "$DATABASE_URL"       # empty in your shell &mdash; it never saw the value<
       is required for the hook.
     </p>
 
+    <h3>Windows &mdash; Scoop</h3>
+    <pre><code>scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
+scoop install jitenv</code></pre>
+    <p>
+      Adds a dedicated Scoop bucket and shims <code>jitenv.exe</code>,
+      <code>jitenv-hook.exe</code>, and <code>jitenv-tui.exe</code> onto
+      <code>%PATH%</code>. PowerShell&nbsp;7+ is required for the hook.
+    </p>
+
+    <h3>Windows &mdash; winget</h3>
+    <pre><code>winget install Galvill.jitenv</code></pre>
+    <p>
+      Installs <code>Galvill.jitenv</code> from the winget-pkgs community
+      repository. PowerShell&nbsp;7+ is required for the hook.
+    </p>
+
     <h3>Activate the shell hook (once)</h3>
     <pre><code>jitenv hook install
 exec $SHELL</code></pre>

--- a/web/quickstart.md
+++ b/web/quickstart.md
@@ -44,6 +44,25 @@ Fetches the official `windows_amd64` release zip, SHA256-verifies it,
 and shims both `jitenv.exe` and `jitenv-tui.exe` onto `%PATH%`.
 PowerShell 7+ is required for the hook.
 
+### Windows — Scoop
+
+```powershell
+scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
+scoop install jitenv
+```
+
+Adds a dedicated Scoop bucket and shims `jitenv.exe`, `jitenv-hook.exe`,
+and `jitenv-tui.exe` onto `%PATH%`. PowerShell 7+ is required for the hook.
+
+### Windows — winget
+
+```powershell
+winget install Galvill.jitenv
+```
+
+Installs `Galvill.jitenv` from the winget-pkgs community repository.
+PowerShell 7+ is required for the hook.
+
 ### From source
 
 ```sh


### PR DESCRIPTION
## Summary

Adds **Scoop** and **winget** as Windows install channels alongside the existing Chocolatey package, published automatically on each stable release via GoReleaser native pipes (no new workflows, no Windows runner).

```powershell
# Scoop
scoop bucket add jitenv https://github.com/Galvill/scoop-jitenv
scoop install jitenv
# winget
winget install Galvill.jitenv
```

## How it works

- **Scoop** — a `scoops:` pipe commits `bucket/jitenv.json` to `Galvill/scoop-jitenv`.
- **winget** — a `winget:` pipe pushes manifests to the `Galvill/winget-pkgs` fork and auto-opens a PR to `microsoft/winget-pkgs`.
- Both run inside the existing `release.yml` job on ubuntu and consume only the Windows `.zip`/`SHA256SUMS` produced in the same run — so no race with the async macOS/Homebrew flow.
- `skip_upload: "auto"` skips prereleases (`-rc.N`) and snapshots, matching Chocolatey's RC-skipping.
- Cross-repo pushes use a new `RELEASE_PAT` secret (the default `GITHUB_TOKEN` can't push cross-repo).

Chocolatey, `ci.yml`, and the `checksum:`/`signs:`/`release:` sections are untouched.

## Why these are GoReleaser pipes (and Chocolatey isn't)

Scoop/winget "publishing" is pure git work (commit a manifest / open a PR), which runs fine on the Linux release runner. Chocolatey stays a separate `windows-latest` workflow because the `choco` CLI only exists on Windows.

## Verification

- `goreleaser check` passes (v2.15.4).
- Snapshot run generates correct manifests: Scoop amd64+arm64 with all three exe shims + SHA256; winget zip + nested-portable manifests for x64+arm64.
- Full whole-branch review (Opus) re-ran the live toolchain and confirmed all release-time risks (token wiring, async-macOS isolation, RC skipping, block placement) — verdict: ready to merge.

## Prerequisites (already configured by maintainer)

- `Galvill/scoop-jitenv` bucket repo
- `Galvill/winget-pkgs` fork
- `RELEASE_PAT` secret (`contents:write` + `pull-requests:write` on both)

## Docs

README, GoReleaser release header, and the website (`web/quickstart.md`, `web/index.html`) all document the two new channels.

Design + plan: `docs/superpowers/specs/2026-06-24-scoop-winget-install-channels-design.md`, `docs/superpowers/plans/2026-06-24-scoop-winget-install-channels.md`.

## Note for reviewers

The Scoop/winget manifests shim **all three** binaries (`jitenv.exe`, `jitenv-hook.exe`, `jitenv-tui.exe`), whereas the Chocolatey package deliberately ships only `jitenv.exe` + `jitenv-tui.exe`. This is GoReleaser's default (it includes every binary in the archive). Flagging in case `jitenv-hook.exe` should be excluded from PATH for consistency.

https://claude.ai/code/session_01LZ4n128Nc4CU4oLBx59Vpr