### PR TITLE
unlock: bounded retry on incorrect passphrase

### DIFF
--- a/internal/cli/bag_import.go
+++ b/internal/cli/bag_import.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/dotenv"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 // newBagImportCmd implements `jitenv bag import <bag> [flags]` (#250) —
@@ -120,12 +121,11 @@ func runBagImport(cmd *cobra.Command, opts importOpts) error {
 	if err != nil {
 		return fmt.Errorf("load %s: %w (run `jitenv config init` first)", cfgPath, err)
 	}
-	pw, err := importPassphraseFn()
-	if err != nil {
-		return err
-	}
-	defer zeroBytes(pw)
-	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	// Retry on incorrect passphrase (#326). The importPassphraseFn
+	// indirection stays intact — tests inject a fixed passphrase via
+	// this hook, and a single-shot test fake will produce a single
+	// retry which still surfaces the correct ErrIncorrectPassphrase.
+	key, err := unlock.DeriveKeyWithRetry(cfg, importPassphraseFn, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/gitauth"
 	"github.com/gv/jitenv/internal/tui"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 // newCloneCmd is the user-facing `jitenv clone <url> [dir]` entry
@@ -87,12 +88,7 @@ func runClone(cmd *cobra.Command, args []string, tokenStdin bool, bagOverride st
 	if err != nil {
 		return fmt.Errorf("load %s: %w (run `jitenv config init` first)", cfgPath, err)
 	}
-	pw, err := crypto.PromptPassphrase("jitenv clone passphrase: ", false)
-	if err != nil {
-		return err
-	}
-	defer zeroBytes(pw)
-	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	key, err := unlock.PromptAndDeriveKey(cfg, "jitenv clone passphrase: ", 0)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/lockfile"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -71,12 +72,7 @@ func newConfigShowCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			pw, err := crypto.PromptPassphrase("jitenv config show passphrase: ", false)
-			if err != nil {
-				return err
-			}
-			defer zeroBytes(pw)
-			key, err := config.DeriveKeyFromMeta(c, pw)
+			key, err := unlock.PromptAndDeriveKey(c, "jitenv config show passphrase: ", 0)
 			if err != nil {
 				return err
 			}
@@ -147,19 +143,18 @@ available, e.g. via an expect-style wrapper).`,
 				}
 				return nil
 			}
-			pw, err := crypto.PromptPassphrase("jitenv config validate passphrase (warnings; Enter to skip): ", false)
+			key, err := unlock.PromptAndDeriveKey(c, "jitenv config validate passphrase (warnings; Enter to skip): ", 0)
 			if err != nil {
-				// Treat a prompt failure / cancellation as "skip
-				// warnings" — structural validation already passed.
-				return nil
-			}
-			defer zeroBytes(pw)
-			if len(pw) == 0 {
-				return nil
-			}
-			key, err := config.DeriveKeyFromMeta(c, pw)
-			if err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "note: could not decrypt to compute warnings: %v\n", err)
+				// PromptPassphrase returns "empty passphrase" when the user
+				// presses Enter, which is the documented opt-out for
+				// validate. ErrIncorrectPassphrase reaches us only after
+				// the retry budget is exhausted — at that point treat it
+				// like the pre-#326 "could not decrypt" note. Any other
+				// error (Ctrl+C, broken tty) also degrades to "skip
+				// warnings" since structural validation already passed.
+				if errors.Is(err, config.ErrIncorrectPassphrase) {
+					fmt.Fprintf(cmd.ErrOrStderr(), "note: could not decrypt to compute warnings: %v\n", err)
+				}
 				return nil
 			}
 			defer zeroBytes(key)

--- a/internal/cli/sources.go
+++ b/internal/cli/sources.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gv/jitenv/internal/config"
-	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/sources"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 func newSourcesCmd() *cobra.Command {
@@ -43,12 +43,7 @@ func newSourcesListCmd() *cobra.Command {
 			// IDs. Decrypt so we can list the real names. (source.type
 			// stays plaintext, so a config with no name_map — pre-#248 or
 			// never-migrated — still lists fine after a no-op decrypt.)
-			pw, err := crypto.PromptPassphrase("jitenv sources passphrase: ", false)
-			if err != nil {
-				return err
-			}
-			defer zeroBytes(pw)
-			key, err := config.DeriveKeyFromMeta(cfg, pw)
+			key, err := unlock.PromptAndDeriveKey(cfg, "jitenv sources passphrase: ", 0)
 			if err != nil {
 				return err
 			}
@@ -99,12 +94,7 @@ func newSourcesTestCmd() *cobra.Command {
 				return err
 			}
 
-			pw, err := crypto.PromptPassphrase("jitenv sources passphrase: ", false)
-			if err != nil {
-				return err
-			}
-			defer zeroBytes(pw)
-			key, err := config.DeriveKeyFromMeta(cfg, pw)
+			key, err := unlock.PromptAndDeriveKey(cfg, "jitenv sources passphrase: ", 0)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gv/jitenv/internal/config"
-	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/syncadapters"
 	"github.com/gv/jitenv/internal/syncconfig"
+	"github.com/gv/jitenv/internal/unlock"
 	"github.com/gv/jitenv/pkg/syncadapter"
 
 	// Blank-import the builtins so the registry is populated even in the
@@ -155,14 +155,11 @@ func runSyncInit(cmd *cobra.Command, adapterType, adapterName string, params []s
 		return fmt.Errorf("%s has no _meta header; run `jitenv config init` first", cfgPath)
 	}
 
-	pw, err := crypto.PromptPassphrase("jitenv sync init: passphrase: ", false)
-	if err != nil {
-		return err
-	}
-	defer zeroBytes(pw)
 	// Verify the passphrase against the data config before writing
-	// anything, and reuse the derived master key to wrap the DEK.
-	masterKey, err := config.DeriveKeyFromMeta(dataCfg, pw)
+	// anything, and reuse the derived master key to wrap the DEK. The
+	// bounded retry (#326) lets the user fix a typo without re-running
+	// `jitenv sync init` from scratch.
+	masterKey, err := unlock.PromptAndDeriveKey(dataCfg, "jitenv sync init: passphrase: ", 0)
 	if err != nil {
 		return err
 	}
@@ -264,20 +261,15 @@ func runSyncPush(cmd *cobra.Command, adapterName string, force bool) error {
 		return err
 	}
 
-	pw, err := crypto.PromptPassphrase("jitenv sync push: passphrase: ", false)
-	if err != nil {
-		return err
-	}
-	defer zeroBytes(pw)
-	masterKey, err := f.DeriveMasterKey(pw)
+	// Bounded retry (#326): f.DeriveMasterKey by itself can't verify the
+	// passphrase (no Meta.Verify on the sidecar), so the unwrap of the
+	// wrapped DEK IS the verifier. Pair them inside PromptWithRetry so
+	// a typo re-prompts instead of bailing the whole `sync push`.
+	masterKey, dek, err := promptAndUnlockSync(f, "jitenv sync push: passphrase: ")
 	if err != nil {
 		return err
 	}
 	defer zeroBytes(masterKey)
-	dek, err := f.UnwrapDEK(masterKey)
-	if err != nil {
-		return err
-	}
 	defer zeroBytes(dek)
 
 	adapter, err := buildAdapter(masterKey, ad)
@@ -332,20 +324,11 @@ func runSyncPull(cmd *cobra.Command, adapterName string, adopt bool) error {
 		return err
 	}
 
-	pw, err := crypto.PromptPassphrase("jitenv sync pull: passphrase: ", false)
-	if err != nil {
-		return err
-	}
-	defer zeroBytes(pw)
-	masterKey, err := f.DeriveMasterKey(pw)
+	masterKey, dek, err := promptAndUnlockSync(f, "jitenv sync pull: passphrase: ")
 	if err != nil {
 		return err
 	}
 	defer zeroBytes(masterKey)
-	dek, err := f.UnwrapDEK(masterKey)
-	if err != nil {
-		return err
-	}
 	defer zeroBytes(dek)
 
 	adapter, err := buildAdapter(masterKey, ad)
@@ -465,15 +448,17 @@ func runSyncStatus(cmd *cobra.Command) error {
 	}
 	localHash := syncconfig.HashConfig(cfgBytes)
 
-	pw, err := crypto.PromptPassphrase("jitenv sync status: passphrase: ", false)
+	// `sync status` needs the master key to decrypt adapter params
+	// inside buildAdapter, but never touches the blob — so the DEK is
+	// only used here as a passphrase verifier (so a typo retries
+	// immediately instead of producing N per-adapter "decrypt failed"
+	// lines later in the loop, #326). Zero the DEK as soon as we have
+	// the master key.
+	masterKey, dek, err := promptAndUnlockSync(f, "jitenv sync status: passphrase: ")
 	if err != nil {
 		return err
 	}
-	defer zeroBytes(pw)
-	masterKey, err := f.DeriveMasterKey(pw)
-	if err != nil {
-		return err
-	}
+	zeroBytes(dek)
 	defer zeroBytes(masterKey)
 
 	fmt.Fprintln(out, "merge model: whole-file last-writer-wins with a divergence fence")
@@ -591,6 +576,42 @@ func parseParams(kvs []string) (map[string]any, error) {
 		m[kv[:i]] = kv[i+1:]
 	}
 	return m, nil
+}
+
+// promptAndUnlockSync drives the sync passphrase prompt through the
+// bounded-retry helper (#326). The master key for a sync sidecar is not
+// directly verifiable (sync.toml has no Meta.Verify of its own), so the
+// unwrap of the wrapped DEK doubles as the wrong-passphrase check:
+// syncconfig.UnwrapDEK returns syncconfig.ErrIncorrectPassphrase on
+// AEAD failure, which the retry loop recognises via errors.Is.
+//
+// Returns (masterKey, dek). Both buffers are the caller's to zero. On
+// any error nothing is returned and the helper has already zeroed any
+// transient key material.
+func promptAndUnlockSync(f *syncconfig.File, prompt string) ([]byte, []byte, error) {
+	var dek []byte
+	masterKey, err := unlock.PromptWithRetry(prompt, 0, func(pw []byte) ([]byte, error) {
+		mk, derr := f.DeriveMasterKey(pw)
+		if derr != nil {
+			return nil, derr
+		}
+		d, uerr := f.UnwrapDEK(mk)
+		if uerr != nil {
+			// Zero the transient master key on the wrong-passphrase
+			// path so the loop's between-attempts heap is bounded
+			// (CLAUDE.md "Master key handling").
+			zeroBytes(mk)
+			return nil, uerr
+		}
+		dek = d
+		return mk, nil
+	}, func(err error) bool {
+		return errors.Is(err, syncconfig.ErrIncorrectPassphrase)
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return masterKey, dek, nil
 }
 
 // short truncates a hex hash for display; empty stays "-".

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gv/jitenv/internal/agent"
 	"github.com/gv/jitenv/internal/config"
-	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/shell"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 var unlockForeground bool
@@ -31,12 +31,7 @@ func newUnlockCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			pw, err := crypto.PromptPassphrase("jitenv unlock passphrase: ", false)
-			if err != nil {
-				return err
-			}
-			defer zeroBytes(pw)
-			key, err := config.DeriveKeyFromMeta(cfg, pw)
+			key, err := unlock.PromptAndDeriveKey(cfg, "jitenv unlock passphrase: ", 0)
 			if err != nil {
 				return err
 			}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -15,6 +15,20 @@ import (
 
 const verifySentinel = "jitenv-ok"
 
+// ErrIncorrectPassphrase is the sentinel returned by DeriveKeyFromMeta
+// when the supplied passphrase fails the Meta.Verify check (i.e. it
+// derived a key that does not decrypt the verify envelope). Exported so
+// callers can branch on this specific failure — notably the bounded
+// retry loop in internal/unlock — instead of bailing out on the first
+// typo (issue #326). The exact message is kept identical to the
+// pre-#326 wording so user-facing error copy does not change.
+//
+// Any OTHER DeriveKeyFromMeta error (missing _meta, corrupt salt, KDF
+// params below the documented floor) stays fatal: those are signs of a
+// broken or tampered config, not a fat-fingered passphrase, and
+// re-prompting would just waste user keystrokes.
+var ErrIncorrectPassphrase = errors.New("incorrect passphrase")
+
 // metaVerifyAAD is the associated-data string that binds the [_meta]
 // verify envelope to its slot. Mirrored on encrypt (InitNew) and
 // decrypt (DeriveKeyFromMeta) — changing either side independently
@@ -132,7 +146,7 @@ func DeriveKeyFromMeta(c *Config, passphrase []byte) ([]byte, error) {
 	key := crypto.DeriveKey(passphrase, salt, params)
 	if pt, err := crypto.DecryptField(key, c.Meta.Verify, metaVerifyAAD); err != nil || pt != verifySentinel {
 		zero(key)
-		return nil, errors.New("incorrect passphrase")
+		return nil, ErrIncorrectPassphrase
 	}
 	return key, nil
 }

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -85,8 +86,19 @@ func TestInitAndDeriveKey(t *testing.T) {
 	}
 	defer zero(key)
 
+	// #326: the wrong-passphrase return must be the exported sentinel so
+	// the bounded-retry helper in internal/unlock can recognise it via
+	// errors.Is. The user-facing message stays unchanged ("incorrect
+	// passphrase") so cobra's exit-1 output is identical to pre-#326.
 	if _, err := DeriveKeyFromMeta(c, []byte("wrong")); err == nil {
 		t.Fatalf("expected wrong passphrase to fail")
+	} else {
+		if !errors.Is(err, ErrIncorrectPassphrase) {
+			t.Errorf("expected errors.Is(err, ErrIncorrectPassphrase), got %v", err)
+		}
+		if err.Error() != "incorrect passphrase" {
+			t.Errorf("user-facing error copy regressed; want %q got %q", "incorrect passphrase", err.Error())
+		}
 	}
 
 	if err := InitNew(path, pw); err == nil {

--- a/internal/syncconfig/syncconfig.go
+++ b/internal/syncconfig/syncconfig.go
@@ -33,6 +33,17 @@ import (
 	"github.com/gv/jitenv/internal/crypto"
 )
 
+// ErrIncorrectPassphrase is the sentinel returned by UnwrapDEK when the
+// supplied master key fails to authenticate the wrapped DEK — almost
+// always because the user mistyped the passphrase. Exported so the
+// bounded-retry helper in internal/unlock can branch on it without
+// matching against the (intentionally vague) user-facing error string
+// (issue #326). A wrong sidecar paired with a right passphrase will
+// also surface here; retrying on the same condition is still useful
+// (the user re-types the right passphrase) and is capped by the attempt
+// counter.
+var ErrIncorrectPassphrase = errors.New("incorrect passphrase")
+
 // AAD strings binding each envelope to its slot (security #110 pattern).
 const (
 	dekWrapAAD = "sync.dek" // wraps the DEK under the master key
@@ -176,9 +187,29 @@ func (f *File) UnwrapDEK(masterKey []byte) ([]byte, error) {
 	}
 	dek, err := crypto.DecryptFieldBytes(masterKey, f.WrappedDEK, dekWrapAAD)
 	if err != nil {
-		return nil, errors.New("cannot unwrap sync key (wrong passphrase, or sidecar is for a different config)")
+		// Keep the user-facing message identical to the pre-#326 wording
+		// — the AEAD tag failure can be a sidecar/data-config mismatch as
+		// well as a typo, and the long phrasing captures both cases. Use
+		// a custom error type whose Is method matches ErrIncorrectPassphrase
+		// so the unlock retry loop can recognise the condition via
+		// errors.Is without polluting the printed message with a duplicate
+		// "incorrect passphrase" tail from %w wrapping.
+		return nil, &wrongPassphraseError{msg: "cannot unwrap sync key (wrong passphrase, or sidecar is for a different config)"}
 	}
 	return dek, nil
+}
+
+// wrongPassphraseError is an internal helper that lets UnwrapDEK return a
+// rich user-facing message while still satisfying errors.Is against
+// ErrIncorrectPassphrase. %w wrapping would append "incorrect passphrase"
+// to every printed error and regress the existing user-facing copy.
+type wrongPassphraseError struct {
+	msg string
+}
+
+func (e *wrongPassphraseError) Error() string { return e.msg }
+func (e *wrongPassphraseError) Is(target error) bool {
+	return target == ErrIncorrectPassphrase
 }
 
 // SealBlob encrypts the config.toml bytes under the DEK into one opaque

--- a/internal/syncconfig/syncconfig_test.go
+++ b/internal/syncconfig/syncconfig_test.go
@@ -2,7 +2,9 @@ package syncconfig
 
 import (
 	"encoding/base64"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gv/jitenv/internal/crypto"
@@ -87,8 +89,20 @@ func TestUnwrapWrongPassphraseFailsClosed(t *testing.T) {
 	}
 
 	wrongMK, _ := f.DeriveMasterKey([]byte("wrong"))
-	if _, err := f.UnwrapDEK(wrongMK); err == nil {
+	_, err := f.UnwrapDEK(wrongMK)
+	if err == nil {
 		t.Fatal("expected unwrap with wrong passphrase to fail")
+	}
+	// #326: UnwrapDEK's wrong-passphrase error must satisfy
+	// errors.Is(err, ErrIncorrectPassphrase) so the unlock retry loop can
+	// recognise it. The user-facing message should also be unchanged
+	// (the helpful "(wrong passphrase, or sidecar is for a different
+	// config)" copy must not regress to a bare "incorrect passphrase").
+	if !errors.Is(err, ErrIncorrectPassphrase) {
+		t.Errorf("expected errors.Is(err, ErrIncorrectPassphrase), got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot unwrap sync key") {
+		t.Errorf("expected user-facing message to be preserved, got %q", err.Error())
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gv/jitenv/internal/config"
 	"github.com/gv/jitenv/internal/crypto"
 	"github.com/gv/jitenv/internal/shell"
+	"github.com/gv/jitenv/internal/unlock"
 )
 
 // Run is the entrypoint invoked by `jitenv config`. It prompts for the
@@ -201,16 +202,11 @@ func loadOrInit(cfgPath string) (*config.Config, []byte, bool, error) {
 		fmt.Fprintf(os.Stderr, "Created %s\n", cfgPath)
 	}
 
-	pw, err := crypto.PromptPassphrase("jitenv config passphrase: ", false)
-	if err != nil {
-		return nil, nil, false, err
-	}
-	defer zero(pw)
 	c, err := config.Load(cfgPath)
 	if err != nil {
 		return nil, nil, false, err
 	}
-	key, err := config.DeriveKeyFromMeta(c, pw)
+	key, err := unlock.PromptAndDeriveKey(c, "jitenv config passphrase: ", 0)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/internal/unlock/prompt.go
+++ b/internal/unlock/prompt.go
@@ -1,0 +1,122 @@
+package unlock
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/gv/jitenv/internal/config"
+	"github.com/gv/jitenv/internal/crypto"
+)
+
+// DefaultPassphraseAttempts is the cap on retries when the user fat-fingers
+// their passphrase (issue #326). Three attempts mirrors the long-standing
+// "ssh keychain / sudo" convention: enough slack for a typo, low enough to
+// stop being useful to an attacker who has shoulder-surfed the early
+// characters of the real passphrase. Each attempt incurs a fresh Argon2id
+// derivation so brute-forcing the whole retry budget is still expensive.
+const DefaultPassphraseAttempts = 3
+
+// promptFn is the package-level prompt reader. Tests override this var
+// to feed a deterministic sequence of passphrases without a TTY; in
+// production it points at crypto.PromptPassphrase.
+var promptFn = func(prompt string, confirm bool) ([]byte, error) {
+	return crypto.PromptPassphrase(prompt, confirm)
+}
+
+// retryWriter is the destination for the inter-attempt "incorrect
+// passphrase, try again" notice. Defaults to os.Stderr; tests override
+// it to capture the prompt copy without touching the real terminal.
+var retryWriter io.Writer = os.Stderr
+
+// PromptAndDeriveKey wraps the standard "prompt passphrase → derive
+// master key" idiom with a bounded retry on config.ErrIncorrectPassphrase
+// (issue #326). It is the canonical entry point for every key-holding
+// CLI / TUI surface: `jitenv unlock`, `jitenv config show|validate`,
+// `jitenv sources list|test`, `jitenv clone`, the TUI startup, and the
+// inline-unlock prompt fired from the agent-down countdown.
+//
+// Any OTHER DeriveKeyFromMeta error — corrupt salt, missing _meta, KDF
+// params below the documented floor — stays fatal: those are not user
+// input errors and re-prompting would only waste keystrokes.
+//
+// The returned key must be zeroed by the caller (defer zeroBytes(key)).
+// PromptAndDeriveKey zeroes every passphrase buffer between attempts
+// and trusts config.DeriveKeyFromMeta to zero its own (already-failed)
+// key buffer on the verify-fail path — see internal/config/edit.go.
+//
+// attempts <= 0 selects DefaultPassphraseAttempts (3).
+func PromptAndDeriveKey(cfg *config.Config, prompt string, attempts int) ([]byte, error) {
+	return PromptWithRetry(prompt, attempts, func(pw []byte) ([]byte, error) {
+		return config.DeriveKeyFromMeta(cfg, pw)
+	}, func(err error) bool {
+		return errors.Is(err, config.ErrIncorrectPassphrase)
+	})
+}
+
+// DeriveKeyWithRetry is the prompt-injected variant of PromptAndDeriveKey
+// for callers that already own their own passphrase reader (today: the
+// bag-import command's importPassphraseFn indirection, which tests stub
+// out to inject a fixed passphrase). The retry loop calls readPw on each
+// attempt, so a single-shot test fake will produce a single retry — that
+// matches the spec note in #326 ("the prompt currently flows through
+// passphraseProvider indirection — leave that intact, only swap the
+// derive path").
+//
+// Contract for readPw: each call should return a fresh passphrase. The
+// helper zeroes it between attempts so transient cleartext on the heap
+// is bounded.
+func DeriveKeyWithRetry(cfg *config.Config, readPw func() ([]byte, error), attempts int) ([]byte, error) {
+	return deriveWithRetry(readPw, attempts, func(pw []byte) ([]byte, error) {
+		return config.DeriveKeyFromMeta(cfg, pw)
+	}, func(err error) bool {
+		return errors.Is(err, config.ErrIncorrectPassphrase)
+	})
+}
+
+// PromptWithRetry is the generic retry primitive used by every passphrase-
+// driven derive flow. Exposed (not just internal) so callers whose
+// "derive" step is something other than config.DeriveKeyFromMeta — the
+// sync push/pull/status path's DeriveMasterKey+UnwrapDEK pair — can drop
+// into the same retry shape by supplying their own derive callback and
+// is-wrong-passphrase predicate.
+//
+// Contract for derive: on any error, derive MUST have zeroed whatever
+// transient key material it allocated. The passphrase buffer is zeroed
+// by PromptWithRetry between attempts. On success, the returned key is
+// the caller's to own (and zero).
+func PromptWithRetry(prompt string, attempts int, derive func(pw []byte) ([]byte, error), isWrong func(error) bool) ([]byte, error) {
+	return deriveWithRetry(func() ([]byte, error) {
+		return promptFn(prompt, false)
+	}, attempts, derive, isWrong)
+}
+
+// deriveWithRetry is the shared loop. Split out so PromptWithRetry and
+// DeriveKeyWithRetry don't duplicate the zeroing / message-printing
+// logic.
+func deriveWithRetry(readPw func() ([]byte, error), attempts int, derive func(pw []byte) ([]byte, error), isWrong func(error) bool) ([]byte, error) {
+	if attempts <= 0 {
+		attempts = DefaultPassphraseAttempts
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		pw, err := readPw()
+		if err != nil {
+			return nil, err
+		}
+		key, derr := derive(pw)
+		zeroBytes(pw)
+		if derr == nil {
+			return key, nil
+		}
+		if !isWrong(derr) {
+			return nil, derr
+		}
+		lastErr = derr
+		if i < attempts-1 {
+			fmt.Fprintln(retryWriter, "incorrect passphrase, try again")
+		}
+	}
+	return nil, lastErr
+}

--- a/internal/unlock/prompt_test.go
+++ b/internal/unlock/prompt_test.go
@@ -1,0 +1,233 @@
+package unlock
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gv/jitenv/internal/config"
+)
+
+// fakePromptFn returns a stub matching the (prompt, confirm) signature
+// of crypto.PromptPassphrase. Each call pops the next passphrase off pw.
+// After the slice is exhausted, calls return promptErr (default: an
+// "exhausted" error so a buggy helper doesn't silently spin).
+func fakePromptFn(pw []string, promptErr error) func(string, bool) ([]byte, error) {
+	i := 0
+	return func(_ string, _ bool) ([]byte, error) {
+		if i >= len(pw) {
+			if promptErr != nil {
+				return nil, promptErr
+			}
+			return nil, errors.New("fakePromptFn: passphrase sequence exhausted")
+		}
+		out := []byte(pw[i])
+		i++
+		return out, nil
+	}
+}
+
+// withFakePrompt installs a fake prompt for the duration of the test
+// and restores the production prompt on cleanup. The retry-notice
+// writer is also redirected to buf so the test can assert what the
+// user would see between attempts.
+func withFakePrompt(t *testing.T, fake func(string, bool) ([]byte, error)) *bytes.Buffer {
+	t.Helper()
+	prevPrompt := promptFn
+	prevWriter := retryWriter
+	promptFn = fake
+	buf := &bytes.Buffer{}
+	retryWriter = buf
+	t.Cleanup(func() {
+		promptFn = prevPrompt
+		retryWriter = prevWriter
+	})
+	return buf
+}
+
+// initFixture creates a fresh encrypted config and returns the loaded
+// (still-encrypted) Config object plus the correct passphrase.
+func initFixture(t *testing.T) (*config.Config, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	const right = "correct horse battery staple"
+	if err := config.InitNew(path, []byte(right)); err != nil {
+		t.Fatalf("InitNew: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return cfg, right
+}
+
+// TestPromptAndDeriveKey_RetriesUntilCorrect is the headline #326
+// behaviour: two wrong passphrases followed by the right one should
+// succeed, and the helper should emit one retry notice per wrong
+// attempt (so the user knows to re-try).
+func TestPromptAndDeriveKey_RetriesUntilCorrect(t *testing.T) {
+	cfg, right := initFixture(t)
+	buf := withFakePrompt(t, fakePromptFn([]string{"wrong1", "wrong2", right}, nil))
+
+	key, err := PromptAndDeriveKey(cfg, "passphrase: ", 0)
+	if err != nil {
+		t.Fatalf("expected eventual success after retries, got %v", err)
+	}
+	defer zeroBytes(key)
+	if len(key) == 0 {
+		t.Fatalf("expected non-empty key on success")
+	}
+
+	notices := strings.Count(buf.String(), "incorrect passphrase, try again")
+	if notices != 2 {
+		t.Errorf("expected 2 inter-attempt notices, got %d (output: %q)", notices, buf.String())
+	}
+}
+
+// TestPromptAndDeriveKey_ExhaustsBudget asserts that after attempts
+// failures the helper surfaces ErrIncorrectPassphrase (so the caller's
+// cobra layer prints the same "incorrect passphrase" exit-1 message as
+// pre-#326). It also asserts no FINAL notice is printed after the last
+// attempt — there is no "try again" left to offer.
+func TestPromptAndDeriveKey_ExhaustsBudget(t *testing.T) {
+	cfg, _ := initFixture(t)
+	buf := withFakePrompt(t, fakePromptFn([]string{"wrong1", "wrong2", "wrong3"}, nil))
+
+	_, err := PromptAndDeriveKey(cfg, "passphrase: ", 3)
+	if err == nil {
+		t.Fatalf("expected error after exhausting attempts")
+	}
+	if !errors.Is(err, config.ErrIncorrectPassphrase) {
+		t.Fatalf("expected errors.Is(err, ErrIncorrectPassphrase), got %v", err)
+	}
+	notices := strings.Count(buf.String(), "incorrect passphrase, try again")
+	if notices != 2 {
+		t.Errorf("expected 2 inter-attempt notices (one per non-final wrong), got %d", notices)
+	}
+}
+
+// TestPromptAndDeriveKey_DoesNotRetryFatalErrors guards the contract
+// that non-wrong-passphrase errors are NOT retryable: a corrupt-_meta
+// /  weak-KDF / missing-salt failure must surface immediately so the
+// user fixes the config instead of typing their passphrase three
+// times into a broken file.
+func TestPromptAndDeriveKey_DoesNotRetryFatalErrors(t *testing.T) {
+	cfg, _ := initFixture(t)
+	// Mutate KDF params below the documented floor so DeriveKeyFromMeta
+	// returns a NON-ErrIncorrectPassphrase error.
+	cfg.Meta.ArgonTime = 1
+	called := 0
+	withFakePrompt(t, func(_ string, _ bool) ([]byte, error) {
+		called++
+		return []byte("anything"), nil
+	})
+
+	_, err := PromptAndDeriveKey(cfg, "passphrase: ", 3)
+	if err == nil {
+		t.Fatalf("expected weak-KDF error")
+	}
+	if errors.Is(err, config.ErrIncorrectPassphrase) {
+		t.Fatalf("weak-KDF error must NOT be reported as incorrect-passphrase: %v", err)
+	}
+	if !strings.Contains(err.Error(), "argon_time") {
+		t.Errorf("expected weak-KDF error to mention argon_time, got %v", err)
+	}
+	if called != 1 {
+		t.Errorf("expected exactly 1 prompt for a non-wrong-passphrase failure, got %d", called)
+	}
+}
+
+// TestPromptAndDeriveKey_PropagatesPromptError ensures Ctrl+C / TTY
+// I/O errors from the prompt itself bubble out unchanged: there is no
+// passphrase to retry with if the user cancelled.
+func TestPromptAndDeriveKey_PropagatesPromptError(t *testing.T) {
+	cfg, _ := initFixture(t)
+	sentinel := errors.New("user pressed ctrl+c")
+	withFakePrompt(t, fakePromptFn(nil, sentinel))
+
+	_, err := PromptAndDeriveKey(cfg, "passphrase: ", 3)
+	if err == nil {
+		t.Fatalf("expected prompt error to propagate")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+}
+
+// TestPromptAndDeriveKey_FirstAttemptSucceeds is the happy-path case:
+// no retries, no notices. Guards against an off-by-one in the loop that
+// would emit a notice on success.
+func TestPromptAndDeriveKey_FirstAttemptSucceeds(t *testing.T) {
+	cfg, right := initFixture(t)
+	buf := withFakePrompt(t, fakePromptFn([]string{right}, nil))
+
+	key, err := PromptAndDeriveKey(cfg, "passphrase: ", 3)
+	if err != nil {
+		t.Fatalf("first-try success expected, got %v", err)
+	}
+	defer zeroBytes(key)
+	if buf.Len() != 0 {
+		t.Errorf("expected no inter-attempt notice on first-try success, got %q", buf.String())
+	}
+}
+
+// TestPromptWithRetry_GenericPath exercises the generic primitive used
+// by the sync push/pull/status paths: a custom derive callback paired
+// with a custom is-wrong predicate. The retry helper must zero the
+// passphrase between attempts and stop on the first non-wrong error.
+func TestPromptWithRetry_GenericPath(t *testing.T) {
+	myWrong := errors.New("not yet")
+	withFakePrompt(t, fakePromptFn([]string{"a", "b", "c"}, nil))
+
+	calls := 0
+	out, err := PromptWithRetry("p: ", 3, func(pw []byte) ([]byte, error) {
+		calls++
+		if calls < 3 {
+			return nil, myWrong
+		}
+		return []byte("yay-" + string(pw)), nil
+	}, func(e error) bool { return errors.Is(e, myWrong) })
+
+	if err != nil {
+		t.Fatalf("expected success on third call, got %v", err)
+	}
+	if string(out) != "yay-c" {
+		t.Errorf("expected derive to receive the third passphrase, got %q", out)
+	}
+}
+
+// TestDeriveKeyWithRetry_RespectsInjectedReader is the path bag_import
+// uses: the caller owns the passphrase reader (importPassphraseFn). The
+// helper must call it on every attempt and surface the result through
+// config.DeriveKeyFromMeta.
+func TestDeriveKeyWithRetry_RespectsInjectedReader(t *testing.T) {
+	cfg, right := initFixture(t)
+	pws := []string{"oops", right}
+	i := 0
+	readPw := func() ([]byte, error) {
+		if i >= len(pws) {
+			return nil, fmt.Errorf("readPw exhausted")
+		}
+		out := []byte(pws[i])
+		i++
+		return out, nil
+	}
+	// Redirect the retry notice writer so the test doesn't smudge
+	// test-run stderr.
+	prev := retryWriter
+	retryWriter = &bytes.Buffer{}
+	t.Cleanup(func() { retryWriter = prev })
+
+	key, err := DeriveKeyWithRetry(cfg, readPw, 0)
+	if err != nil {
+		t.Fatalf("expected eventual success, got %v", err)
+	}
+	defer zeroBytes(key)
+	if i != 2 {
+		t.Errorf("expected reader called twice (one wrong + one right), got %d", i)
+	}
+}

--- a/internal/unlock/unlock.go
+++ b/internal/unlock/unlock.go
@@ -19,6 +19,12 @@ import (
 	"github.com/gv/jitenv/internal/crypto"
 )
 
+// The bounded-retry helpers (PromptAndDeriveKey, DeriveKeyWithRetry,
+// PromptWithRetry) live in prompt.go alongside the retry primitive
+// itself; they are exposed from this same package so every key-holding
+// entry point — including this Spawn flow — can drop into the same
+// shape (issue #326).
+
 // Result reports what happened after a Spawn attempt. Socket is the
 // agent socket / pipe the caller can dial once unlock succeeds.
 // Migrated is true when the one-shot opaque-ID migration (#248) rewrote
@@ -51,12 +57,7 @@ func Spawn(cfgPath string) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	pw, err := crypto.PromptPassphrase("jitenv unlock passphrase: ", false)
-	if err != nil {
-		return Result{}, err
-	}
-	defer zeroBytes(pw)
-	key, err := config.DeriveKeyFromMeta(cfg, pw)
+	key, err := PromptAndDeriveKey(cfg, "jitenv unlock passphrase: ", 0)
 	if err != nil {
 		return Result{}, err
 	}


### PR DESCRIPTION
## Summary

Closes #326.

Every passphrase entry point now re-prompts up to a small bounded number of times (default 3) on a typo instead of bailing back to the shell on the first wrong attempt.

- Export `config.ErrIncorrectPassphrase` (and `syncconfig.ErrIncorrectPassphrase` via a custom error type so `UnwrapDEK`'s helpful "wrong passphrase, or sidecar is for a different config" copy doesn't regress) so callers can recognise the wrong-passphrase case via `errors.Is`.
- New `internal/unlock/prompt.go` with three helpers built on a shared retry primitive:
  - `PromptAndDeriveKey(cfg, prompt, attempts)` — the canonical helper for `DeriveKeyFromMeta` flows (`jitenv unlock`, TUI, `config show/validate`, `sources list/test`, `clone`, `sync init`, the inline-unlock helper in `internal/unlock`).
  - `DeriveKeyWithRetry(cfg, readPw, attempts)` — preserves the existing `importPassphraseFn` test indirection for `bag import` while still bounded-retrying the derive.
  - `PromptWithRetry(prompt, attempts, derive, isWrong)` — the generic primitive `sync push/pull/status` use to pair `DeriveMasterKey` + `UnwrapDEK` as the wrong-passphrase verifier (the sidecar has no `Meta.Verify` of its own; the wrapped-DEK unwrap is what fails closed on a typo).
- Non-passphrase `DeriveKeyFromMeta` errors (corrupt salt, missing `_meta`, weak KDF params) stay fatal — those are not user input errors and re-prompting would waste keystrokes.
- Each attempt zeroes the passphrase buffer before the next prompt; the wrong-derive key zeroing already happens inside `DeriveKeyFromMeta` (`internal/config/edit.go:zero(key)`) so transient cleartext on the heap is bounded.

## Test plan

- [x] `go test ./...` (clean, including the new `internal/unlock` suite — retry-until-correct, exhaust-budget returns the sentinel, fatal-error short-circuit, prompt-error propagation).
- [x] `golangci-lint run ./...` (exit 0).
- [x] `go vet ./...` (clean).
- [x] Updated `internal/config/edit_test.go::TestInitAndDeriveKey` to assert `errors.Is(err, ErrIncorrectPassphrase)` and pin the user-facing message at exactly `"incorrect passphrase"` so it can never silently regress.
- [x] Updated `internal/syncconfig/syncconfig_test.go::TestUnwrapWrongPassphraseFailsClosed` to assert the wrapped sentinel + preserved user-facing copy.

E2E with `expect` was skipped per the issue body ("a unit test on `PromptAndDeriveKey` via the injected prompt is sufficient"); the retry helper is testable without a TTY via a swappable package-level `promptFn`.

https://claude.ai/code/session_0161fmoXPAMgPDaubPg2S3re